### PR TITLE
release: finalize public distribution path

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -18,11 +18,17 @@ concurrency:
 jobs:
   preflight:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      attestations: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
       - name: Refuse an unprotected or mismatched publication
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -54,11 +60,28 @@ jobs:
           gh release download "$RELEASE_TAG" --dir publication-assets
           ./scripts/verify-release-artifacts.sh publication-assets "$RELEASE_TAG"
           test -f publication-assets/infercrane.rb
-          test "$(find publication-assets -maxdepth 1 -name 'infercrane-*.whl' | wc -l)" -eq 1
-          test "$(find publication-assets -maxdepth 1 -name 'infercrane-sdk-*.tgz' | wc -l)" -eq 1
+          version=$(jq -er '.version' .release/version.json)
+          wheel="publication-assets/infercrane-${version}-py3-none-any.whl"
+          npm_package="publication-assets/infercrane-sdk-${version}.tgz"
+          ./scripts/verify-sdk-artifacts.sh publication-assets "$version" verify
+          for artifact in \
+            publication-assets/infercrane_*.tar.gz \
+            publication-assets/infercrane_*.tar.gz.sbom.json \
+            publication-assets/checksums.txt \
+            publication-assets/infercrane.rb \
+            "$wheel" \
+            "$npm_package" \
+            publication-assets/sdk-checksums.txt; do
+            gh attestation verify "$artifact" \
+              --repo "$GITHUB_REPOSITORY" \
+              --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yml" \
+              --source-digest "$(git rev-parse HEAD)" \
+              --source-ref "refs/tags/$RELEASE_TAG" \
+              --deny-self-hosted-runners >/dev/null
+          done
           mkdir -p publication-assets/python publication-assets/npm publication-assets/homebrew
-          cp publication-assets/infercrane-*.whl publication-assets/python/
-          cp publication-assets/infercrane-sdk-*.tgz publication-assets/npm/
+          cp "$wheel" publication-assets/python/
+          cp "$npm_package" publication-assets/npm/
           cp publication-assets/infercrane.rb publication-assets/homebrew/
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -142,6 +144,10 @@ jobs:
           npm --prefix sdk/typescript test
           cd sdk/typescript
           npm pack --pack-destination "$RUNNER_TEMP/sdk-dist"
+      - name: Verify and checksum the exact SDK packages
+        run: |
+          version=$(jq -er '.version' .release/version.json)
+          ./scripts/verify-sdk-artifacts.sh "$RUNNER_TEMP/sdk-dist" "$version" prepare
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sdk-packages-${{ github.ref_name }}
@@ -151,6 +157,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "$GITHUB_REF_NAME" "$RUNNER_TEMP/sdk-dist/"* --clobber
+      - name: Attest SDK packages and their checksum manifest
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-path: ${{ runner.temp }}/sdk-dist/*
 
   image:
     needs: [preflight, artifacts]

--- a/.release/e2e-verification-prompt.md
+++ b/.release/e2e-verification-prompt.md
@@ -137,8 +137,9 @@ files. Verify:
 - SPDX SBOM for every archive;
 - generated `infercrane.rb` formula;
 - candidate image digest, BuildKit provenance/SBOM, and GitHub artifact attestation;
-- Python wheel and npm tarball only if the candidate workflow is designed to produce them;
-- checksums, attestation subjects, embedded CLI version, and source commit all agree.
+- Python wheel, npm tarball, and `sdk-checksums.txt`;
+- archive, formula, and SDK checksums and attestations originate from the exact release workflow,
+  tag ref, and source commit, and every embedded version agrees.
 
 Extract the native archive into a clean prefix and run `version`, `--help`, and shell completion.
 Install the formula from the downloaded file. Inspect wheel and npm tarball contents for secrets,
@@ -155,7 +156,8 @@ Do not publish. Review `.github/workflows/release.yml`,
 - tag creation builds a draft and does not publish PyPI/npm/Homebrew;
 - stable publication is manual and protected;
 - it refuses private repository visibility, disabled organization 2FA, an unprotected environment,
-  non-stable/mismatched tag, non-draft release, or missing assets;
+  non-stable/mismatched tag, non-draft release, missing assets, checksum failure, or mismatched
+  artifact provenance;
 - PyPI and npm use job-scoped OIDC; npm provenance is possible because repository and package are
   public; Homebrew uses a tap-only credential;
 - GitHub release publication happens only after PyPI, npm, and Homebrew jobs succeed;

--- a/.release/publication-runbook.md
+++ b/.release/publication-runbook.md
@@ -55,8 +55,8 @@ file. Keep the current integration marked unpublished until that independent rel
    tuple evidence; never reinterpret fixture results as GPU/provider qualification.
 3. Create and push only the configured candidate tag. Let `.github/workflows/release.yml` build the
    draft prerelease, archives, checksums, SPDX SBOMs, Homebrew formula, unpublishable SDK test
-   artifacts, exact-tag GHCR
-   image, vulnerability results, and GitHub attestations.
+   artifacts with a separate checksum manifest and attestations, exact-tag GHCR image,
+   vulnerability results, and GitHub attestations.
 4. Download the draft assets into a clean machine. Run `scripts/verify-release-artifacts.sh` with the
    candidate tag, confirm its Apache-2.0 `LICENSE`, InferCrane `NOTICE`, generated linked-dependency
    license bundle, and upstream attribution notices, install the native archive, run the documented
@@ -74,16 +74,17 @@ file. Keep the current integration marked unpublished until that independent rel
 2. Push only `v1.0.0`. Do not rebuild from a different commit and do not move either tag.
 3. Wait for the stable tag workflow. Confirm all jobs pass and the GitHub release remains a draft.
 4. Download and independently verify the stable archives, licenses/notices, checksums, SBOMs,
-   formula, wheel, npm tarball, image digest, vulnerability scan, and attestations. Confirm all
-   embedded/package versions are exactly `1.0.0` and all release assets originate from the stable
-   tag commit.
+   formula, wheel, npm tarball, SDK checksum manifest, image digest, vulnerability scan, and
+   attestations. Confirm all embedded/package versions are exactly `1.0.0` and all release assets
+   originate from the stable tag commit.
 
 ## Publish
 
 1. In GitHub Actions, run `publish stable release` with input `v1.0.0`.
 2. Approve the protected `stable-publication` environment only after reviewing the preflight output.
    The workflow refuses a private repository, disabled organization 2FA, an unprotected environment,
-   an RC/mismatched tag, a non-draft release, or incomplete artifacts.
+   an RC/mismatched tag, a non-draft release, incomplete artifacts, checksum failures, or artifact
+   attestations that do not originate from the exact release workflow, tag ref, and commit.
 3. The workflow publishes the exact wheel to PyPI with OIDC, the exact npm tarball with OIDC, updates
    the Homebrew tap, and publishes the already-verified GitHub draft last. If any registry step
    fails, the GitHub release stays draft. Do not replace an artifact at the same version; diagnose and

--- a/README.md
+++ b/README.md
@@ -22,10 +22,26 @@
 </p>
 
 <p align="center">
-  <a href="#try-the-complete-product-loop-locally">Run the five-minute local proof</a>
+  <a href="#install">Run the five-minute local proof</a>
   · <a href="https://docs.infercrane.com/quickstart">Read the quickstart</a>
   · <a href="docs/images/product/github-product-demo.mp4">Watch the two-minute product tour</a>
 </p>
+
+## Install
+
+Coming with the `v1.0.0` release: `brew install infercrane/tap/infercrane`, release archives, and
+published Python and TypeScript SDKs. Until then, run the local proof with Git and Docker Compose v2.
+It uses GPU-free workers and creates no cloud resources:
+
+```bash
+git clone https://github.com/infercrane/infercrane.git
+cd infercrane
+make demo
+```
+
+The proof connects an OpenAI-compatible worker, sends and inspects a request, creates an isolated
+candidate, records a deterministic Release Guard rejection, verifies that production traffic did
+not move, and removes its disposable stack.
 
 <p align="center">
   <a href="docs/images/product/github-product-demo.mp4">
@@ -44,6 +60,22 @@ replica count, and active revision underneath it.
 - **Keep one endpoint:** route revisions and providers behind a stable OpenAI-compatible contract.
 - **Prove every change:** persist request, benchmark, quality, cost, and rollout evidence before
   promotion—and preserve the active revision when evidence is missing.
+
+## Why not just…
+
+- **Raw vLLM and Kubernetes:** the serving engine and manifests do not by themselves provide an
+  evidence-gated release lifecycle. InferCrane adds deterministic promotion, rejection, rollback,
+  and a persisted record of what changed.
+- **LiteLLM:** it is an excellent routing layer. InferCrane additionally owns deployment lifecycle,
+  evidence-gated promotion, and rollback; it can also connect to an existing LiteLLM endpoint
+  without taking infrastructure ownership.
+- **A managed inference platform:** it is often the right choice when a team wants the provider to
+  operate its infrastructure. InferCrane is for teams that want the control plane, capacity, and
+  billing boundary to remain in infrastructure they own.
+- **Scripts and CI:** scripts can deploy a revision. InferCrane standardizes the durable
+  reject/promote/rollback decision and the evidence attached to it.
+
+See the [detailed comparison](docs/compare.mdx), including the boundaries InferCrane does not own.
 
 The local proof needs no GPU or cloud account. Real-provider support remains exact-tuple qualified;
 InferCrane reports missing model/runtime/hardware evidence as unknown instead of turning it into a
@@ -82,21 +114,6 @@ AWS · GCP · Kubernetes · RunPod · existing infrastructure
 | Understand production failures | Trace queue wait, attempts, runtime, revision, latency, saturation, and durable operations without storing prompt content. |
 | Optimize performance and cost | Propose serving configurations, measure comparable candidates on real hardware, and persist only qualified evidence. |
 | Survive infrastructure delays | Submit idempotent durable operations that continue after the CLI or control plane process disconnects. |
-
-## Try the complete product loop locally
-
-You need Git and Docker with Compose v2. The local proof uses GPU-free workers and creates no cloud
-resources:
-
-```bash
-git clone https://github.com/infercrane/infercrane.git
-cd infercrane
-make demo
-```
-
-The proof connects an OpenAI-compatible worker, sends and inspects a request, creates an isolated
-candidate, records a deterministic Release Guard rejection, verifies that production traffic did
-not move, and removes its disposable stack.
 
 <p align="center">
   <img alt="Connect an existing inference endpoint with InferCrane" src="docs/images/showcase/connect-existing.gif" width="820">

--- a/docs/integrations/terraform.mdx
+++ b/docs/integrations/terraform.mdx
@@ -23,8 +23,15 @@ Recommendations remain an explicit evaluation rather than a Terraform apply.
 
 <Warning>
 The provider is not yet published in the Terraform Registry. Local qualification builds it from
-`integrations/terraform`; registry installation begins only after release publication.
+`integrations/terraform`. Registry publication is deferred until the provider has an independent
+repository, signed release artifacts, and its own qualification path.
 </Warning>
+
+Build the provider from the same InferCrane tag as the control plane and use Terraform's
+`dev_overrides` installation mechanism as documented in
+[`integrations/terraform/README.md`](https://github.com/infercrane/infercrane/blob/main/integrations/terraform/README.md).
+The `infercrane/infercrane` source address below identifies the provider protocol address; it is not
+a claim that Registry installation works today.
 
 ```hcl
 terraform {

--- a/integrations/terraform/README.md
+++ b/integrations/terraform/README.md
@@ -5,16 +5,33 @@ replicas, rollout workers, or long-running cloud operations. InferCrane remains 
 owner for serving lifecycle changes.
 
 The provider is included in the source repository and is qualified in CI. Terraform Registry
-publication is pending the first stable release. Until then, build it from the matching source tag or
-use the InferCrane CLI and control API.
+publication is deferred until the provider has an independent repository and release path. Build it
+from the matching InferCrane source tag or use the InferCrane CLI and control API.
 
 ## Build from source
 
 ```bash
 git clone --branch v1.0.0 https://github.com/infercrane/infercrane.git
 cd infercrane/integrations/terraform
-go build -o terraform-provider-infercrane
+mkdir -p "$HOME/.local/share/infercrane/providers"
+go build -o "$HOME/.local/share/infercrane/providers/terraform-provider-infercrane"
 ```
+
+Until Registry publication, add a development override to `~/.terraformrc` using the absolute path
+to that directory:
+
+```hcl
+provider_installation {
+  dev_overrides {
+    "registry.terraform.io/infercrane/infercrane" = "/Users/you/.local/share/infercrane/providers"
+  }
+  direct {}
+}
+```
+
+The override is a local installation mechanism, not Registry qualification. With the override in
+place, run `terraform plan` or `terraform apply` directly; `terraform init` still attempts Registry
+version discovery for the unpublished source address.
 
 The provider requires:
 

--- a/packaging/homebrew/infercrane.rb
+++ b/packaging/homebrew/infercrane.rb
@@ -1,5 +1,5 @@
 class Infercrane < Formula
-  desc "Production inference without the platform engineering"
+  desc "Operate self-hosted models behind one OpenAI-compatible endpoint"
   homepage "https://github.com/infercrane/infercrane"
   # Generated release formulae substitute these template values from checksums.txt.
   version "RELEASE_VERSION"

--- a/scripts/check-publication-contract.sh
+++ b/scripts/check-publication-contract.sh
@@ -25,6 +25,12 @@ grep -Fq 'node-version: "24.20.0"' "$publish_workflow"
 grep -Fq 'npm install --global npm@11.6.4' "$publish_workflow"
 grep -Fq 'HOMEBREW_TAP_TOKEN' "$publish_workflow"
 grep -Fq 'gh release edit "$RELEASE_TAG" --draft=false --latest' "$publish_workflow"
+grep -Fq './scripts/verify-sdk-artifacts.sh publication-assets "$version" verify' "$publish_workflow"
+grep -Fq 'gh attestation verify "$artifact"' "$publish_workflow"
+grep -Fq -- '--signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yml"' "$publish_workflow"
+grep -Fq -- '--source-digest "$(git rev-parse HEAD)"' "$publish_workflow"
+grep -Fq -- '--source-ref "refs/tags/$RELEASE_TAG"' "$publish_workflow"
+grep -Fq -- '--deny-self-hosted-runners' "$publish_workflow"
 
 # The tag workflow may build and attach artifacts, but it must leave the GitHub
 # release as a draft and provide verifiable provenance for archives and images.
@@ -34,8 +40,11 @@ if grep -A2 -F 'sdk-packages:' "$release_workflow" | grep -Fq 'if:'; then
   echo "release candidates must build SDK artifacts for qualification" >&2
   exit 1
 fi
-test "$(grep -Ec 'uses: actions/attest@[0-9a-f]{40}' "$release_workflow")" -eq 2
+test "$(grep -Ec 'uses: actions/attest@[0-9a-f]{40}' "$release_workflow")" -eq 3
 grep -Fq 'subject-name: ghcr.io/infercrane/infercrane' "$release_workflow"
+grep -Fq './scripts/verify-sdk-artifacts.sh "$RUNNER_TEMP/sdk-dist" "$version" prepare' "$release_workflow"
+test -x "$root/scripts/verify-sdk-artifacts.sh"
+grep -Fq 'sdk-checksums.txt' "$root/scripts/verify-sdk-artifacts.sh"
 if grep -REq 'uses: [^ ]+@(v[0-9]+|release/v[0-9]+)([[:space:]]|$)' "$root/.github/workflows"; then
   echo "GitHub Actions must be pinned to full commit SHAs" >&2
   exit 1

--- a/scripts/test-automation-clients.sh
+++ b/scripts/test-automation-clients.sh
@@ -56,9 +56,10 @@ with zipfile.ZipFile(sys.argv[1]) as archive:
 PY
 npm --prefix "$root/sdk/typescript" ci --no-audit --no-fund
 npm --prefix "$root/sdk/typescript" test
-(cd "$root/sdk/typescript" && npm pack --dry-run --json) >"$package_dir/npm-pack.json"
+(cd "$root/sdk/typescript" && npm pack --pack-destination "$package_dir" --json) >"$package_dir/npm-pack.json"
 jq -e '.[0].files | map(.path) | index("LICENSE") != null and index("NOTICE") != null' \
   "$package_dir/npm-pack.json" >/dev/null
+"$root/scripts/verify-sdk-artifacts.sh" "$package_dir" "$release_version" prepare
 node --test "$root"/actions/infercrane/test/*.test.js
 
 (

--- a/scripts/verify-sdk-artifacts.sh
+++ b/scripts/verify-sdk-artifacts.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -eu
+
+dist=${1:?usage: verify-sdk-artifacts.sh DIST VERSION [prepare|verify]}
+version=${2:?usage: verify-sdk-artifacts.sh DIST VERSION [prepare|verify]}
+mode=${3:-verify}
+
+case "$mode" in
+  prepare|verify) ;;
+  *) echo "mode must be prepare or verify" >&2; exit 2 ;;
+esac
+
+printf '%s\n' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$' || {
+  echo "invalid SDK version: $version" >&2
+  exit 2
+}
+
+wheel="infercrane-${version}-py3-none-any.whl"
+npm_package="infercrane-sdk-${version}.tgz"
+
+test "$(find "$dist" -maxdepth 1 -type f -name 'infercrane-*.whl' | wc -l | tr -d ' ')" = 1
+test "$(find "$dist" -maxdepth 1 -type f -name 'infercrane-sdk-*.tgz' | wc -l | tr -d ' ')" = 1
+test -f "$dist/$wheel"
+test -f "$dist/$npm_package"
+
+python3 - "$dist/$wheel" "$version" <<'PY'
+import sys
+import zipfile
+
+wheel, version = sys.argv[1:]
+with zipfile.ZipFile(wheel) as archive:
+    names = archive.namelist()
+    metadata = archive.read(next(name for name in names if name.endswith(".dist-info/METADATA"))).decode()
+    assert "Name: infercrane\n" in metadata
+    assert f"Version: {version}\n" in metadata
+    assert any(name.endswith(".dist-info/licenses/LICENSE") for name in names)
+    assert any(name.endswith(".dist-info/licenses/NOTICE") for name in names)
+PY
+
+tar -xOf "$dist/$npm_package" package/package.json | \
+  jq -e --arg version "$version" '.name == "@infercrane/sdk" and .version == $version' >/dev/null
+tar -tzf "$dist/$npm_package" | grep -Eq '^package/LICENSE$'
+tar -tzf "$dist/$npm_package" | grep -Eq '^package/NOTICE$'
+
+checksum() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$@"
+  else
+    shasum -a 256 "$@"
+  fi
+}
+
+verify_checksums() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c sdk-checksums.txt
+  else
+    shasum -a 256 -c sdk-checksums.txt
+  fi
+}
+
+if [ "$mode" = prepare ]; then
+  (
+    cd "$dist"
+    checksum "$wheel" "$npm_package" > sdk-checksums.txt
+  )
+fi
+
+test -f "$dist/sdk-checksums.txt"
+(cd "$dist" && verify_checksums)
+
+echo "SDK artifacts verified for $version: exact wheel and npm package, Apache-2.0 notices, and SHA-256 checksums."

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -5,9 +5,15 @@ package has no runtime dependencies and supports Python 3.10 or newer.
 
 ## Install
 
+For a published `v1.0.0` release:
+
 ```bash
-python -m pip install infercrane
+python -m pip install 'infercrane==1.0.0'
 ```
+
+Until that version appears on PyPI, install the SDK from the same checked-out tag as the control
+plane with `python -m pip install ./sdk/python`. Do not treat an unpublished package name as a
+release guarantee.
 
 ## Configure
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -4,9 +4,15 @@ Typed Node.js client for the InferCrane control API and OpenAI-compatible infere
 
 ## Install
 
+For a published `v1.0.0` release:
+
 ```bash
-npm install @infercrane/sdk
+npm install '@infercrane/sdk@1.0.0'
 ```
+
+Until that version appears on npm, build the SDK from the same checked-out tag as the control plane
+with `npm ci --prefix sdk/typescript && npm run build --prefix sdk/typescript`. Do not treat an
+unpublished package name as a release guarantee.
 
 Node.js 20 or newer is required.
 


### PR DESCRIPTION
## Summary

- add the release-gated Install section and respectful “Why not just…” comparison to the root README
- keep Python and TypeScript package install instructions honest before registry publication
- document the usable local Terraform provider override and keep Registry support explicitly deferred
- checksum and attest the exact SDK packages produced by the tag workflow
- fail stable publication unless SDK identity/licenses/checksums and all release-asset attestations match the exact release workflow, tag ref, commit, and GitHub-hosted runner boundary

## Evidence boundary

No provider, model, performance, or qualification claim is upgraded. The proposed universal managed-platform pricing claim was replaced with an ownership and billing-boundary distinction.

## Verification

- `make verify`
- `npm run check --prefix docs`
- `npm run check:a11y --prefix docs`
- SDK exact-artifact and tamper fail-closed checks
- clean Python wheel install/import smoke
- clean npm tarball install/import smoke
- generated Homebrew formula local-tap download/checksum/install/version/completion/test/uninstall E2E
