### PR TITLE
ci: cut developer qualification latency without skipping gates

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -86,8 +86,13 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  developer-environment:
+  developer-environment-shard:
+    name: developer-environment / ${{ matrix.shard }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [core, container, stack]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -104,14 +109,29 @@ jobs:
           terraform_version: "1.15.8"
           terraform_wrapper: false
       - run: npm ci
+        if: matrix.shard == 'core'
         working-directory: docs
-      - run: make dev-check-full
+      - run: ./scripts/dev-check.sh "ci-${{ matrix.shard }}"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
-          name: developer-check-${{ github.run_id }}
+          name: developer-check-${{ github.run_id }}-${{ matrix.shard }}
           path: .infercrane/dev-check
           if-no-files-found: error
+
+  developer-environment:
+    if: always()
+    needs: developer-environment-shard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every developer-environment shard
+        env:
+          SHARD_RESULT: ${{ needs.developer-environment-shard.result }}
+        run: |
+          if [ "$SHARD_RESULT" != success ]; then
+            echo "One or more developer-environment shards failed: $SHARD_RESULT" >&2
+            exit 1
+          fi
 
   vulnerabilities:
     runs-on: ubuntu-latest

--- a/scripts/dev-check.sh
+++ b/scripts/dev-check.sh
@@ -3,7 +3,10 @@ set -eu
 
 root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
 mode=${1:-quick}
-case "$mode" in quick|full) ;; *) echo "usage: $0 [quick|full]" >&2; exit 2;; esac
+case "$mode" in
+  quick|full|ci-core|ci-container|ci-stack) ;;
+  *) echo "usage: $0 [quick|full|ci-core|ci-container|ci-stack]" >&2; exit 2 ;;
+esac
 
 run_id=$(date -u +%Y%m%dT%H%M%SZ)-$$
 evidence="$root/.infercrane/dev-check/$run_id"
@@ -52,27 +55,52 @@ step() {
   fi
 }
 
-# The repository verifier deliberately skips PostgreSQL integration tests when
-# no test database is configured; the full developer check runs those tests
-# later in its isolated container stage. Never let a stale caller-owned URL
-# accidentally enable them against an unavailable or unrelated database.
-step repository env -u INFERCRANE_TEST_DATABASE_URL make -C "$root" verify
-step provider-contracts sh -c 'cd "$1" && go test -count=1 ./internal/integration ./internal/conformance ./internal/provision ./internal/gateway ./internal/reconcile ./internal/workflows' sh "$root"
-step acceptance-safety "$root/scripts/test-acceptance-safety.sh"
+# `full` retains the complete sequential local gate. CI uses the three
+# `ci-*` modes on isolated runners and joins them behind one required summary
+# job, reducing wall-clock latency without omitting any full-mode stage.
+case "$mode" in
+quick|full|ci-core)
+  # The repository verifier deliberately skips PostgreSQL integration tests
+  # when no test database is configured; the full developer check runs those
+  # tests later in its isolated container stage. Never let a stale
+  # caller-owned URL accidentally enable them against an unavailable or
+  # unrelated database.
+  step repository env -u INFERCRANE_TEST_DATABASE_URL make -C "$root" verify
+  step provider-contracts sh -c 'cd "$1" && go test -count=1 ./internal/integration ./internal/conformance ./internal/provision ./internal/gateway ./internal/reconcile ./internal/workflows' sh "$root"
+  step acceptance-safety "$root/scripts/test-acceptance-safety.sh"
+  ;;
+esac
 
-if [ "$mode" = full ]; then
+case "$mode" in
+full|ci-core)
   step kubernetes-manifests make -C "$root" test-kubernetes-manifests
   step kubernetes-kind make -C "$root" test-kubernetes-kind
   step automation-clients make -C "$root" test-automation-full
+  ;;
+esac
+
+case "$mode" in
+full|ci-container)
   step container-tests make -C "$root" test-container
+  ;;
+esac
+
+case "$mode" in
+full|ci-stack)
   step stack-smoke "$root/scripts/test-stack.sh"
   step failure-recovery "$root/scripts/test-failure-recovery.sh"
   step control-plane-ha "$root/scripts/test-ha-control-plane.sh"
   step backup-restore-safety "$root/scripts/test-backup-restore-safety.sh"
   step backup-restore-docker "$root/scripts/test-backup-restore-docker.sh"
   step production-config make -C "$root" test-production-config
+  ;;
+esac
+
+case "$mode" in
+full|ci-core)
   step docs make -C "$root" docs-check
-fi
+  ;;
+esac
 
 cat >"$evidence/summary.txt" <<EOF
 InferCrane developer check passed


### PR DESCRIPTION
## Outcome

Run the full developer-environment qualification as three isolated parallel shards and retain the existing required `developer-environment` context as a fail-closed aggregate.

## Coverage

- `core`: repository verification, provider contracts, acceptance safety, Kubernetes manifests/Kind, automation clients, docs.
- `container`: real PostgreSQL container integration suite.
- `stack`: stack smoke, fault recovery, HA, backup/restore, and production config.
- Local `make dev-check-full` is unchanged and still runs every stage sequentially.

## Why

The previous successful run spent 409s in container tests and 140s in stack smoke, sequentially. Sharding targets the measured critical path without path-based skipping or reduced coverage.

## Evidence

- `sh -n scripts/dev-check.sh` — pass.
- `.github/workflows/quality.yml` YAML parse — pass.
- Invalid mode fails with exit 2 — pass.
- `./scripts/dev-check.sh quick` — pass (repository 38s, provider contracts 2s, acceptance safety 3s).
- This PR run is the authoritative isolated execution of all three CI shards and the aggregate required context.
