### PR TITLE
fix(ci): build TypeScript SDK in stack shard

### DIFF
--- a/scripts/dev-check.sh
+++ b/scripts/dev-check.sh
@@ -85,6 +85,16 @@ full|ci-container)
   ;;
 esac
 
+# The sequential `full` mode builds the TypeScript SDK in automation-clients.
+# The isolated stack shard has no artifacts from that runner, while its SDK
+# smoke imports the compiled entrypoint. Build that prerequisite explicitly so
+# the shard remains hermetic instead of depending on a dirty workspace.
+case "$mode" in
+ci-stack)
+  step stack-client-prerequisites sh -c 'npm --prefix "$1/sdk/typescript" ci --no-audit --no-fund && npm --prefix "$1/sdk/typescript" run build' sh "$root"
+  ;;
+esac
+
 case "$mode" in
 full|ci-stack)
   step stack-smoke "$root/scripts/test-stack.sh"


### PR DESCRIPTION
The stack shard runs on an isolated runner, but its SDK smoke imports `sdk/typescript/dist/index.js`. The old sequential developer gate produced that artifact in the automation-client stage; the new parallel shard correctly has no cross-runner artifacts.

This adds an explicit TypeScript install/build prerequisite only to `ci-stack`. The sequential `full` mode remains unchanged.

Evidence:
- `sh -n scripts/dev-check.sh`
- `git diff --check`
- `./scripts/dev-check.sh ci-stack`
  - stack-client-prerequisites: passed (2s)
  - stack-smoke: passed (37s)
  - failure-recovery: passed (14s)
  - control-plane-ha: passed (9s)
  - backup-restore-safety: passed (1s)
  - backup-restore-docker: passed (11s)
  - production-config: passed (8s)