### PR TITLE
fix: make local demo readiness deterministic

### DIFF
--- a/scripts/demo-connect.sh
+++ b/scripts/demo-connect.sh
@@ -56,13 +56,24 @@ echo
 echo '$ infercrane connect http://worker-a:8101/v1 --as coder-demo --type vllm --manage-traffic'
 run_cli connect http://worker-a:8101/v1 --as "$endpoint" --type vllm --manage-traffic
 
+echo
+echo "Waiting for the stable endpoint to become routable..."
 attempt=0
 until response_headers=$(curl -fsS -D - -o "$response_body" \
   -H "Authorization: Bearer $api_key" -H 'Content-Type: application/json' \
   -d "{\"model\":\"$endpoint\",\"messages\":[{\"role\":\"user\",\"content\":\"Explain durable inference in one sentence.\"}]}" \
   "$base_url/v1/chat/completions" 2>/dev/null); do
   attempt=$((attempt + 1))
-  test "$attempt" -lt 30 || { echo "Connected endpoint did not become routable" >&2; exit 1; }
+  if [ "$attempt" -ge 90 ]; then
+    echo "Connected endpoint did not become routable within 90s" >&2
+    if [ -s "$response_body" ]; then
+      echo "Last gateway response:" >&2
+      jq . "$response_body" >&2 2>/dev/null || cat "$response_body" >&2
+    fi
+    echo "Control-plane logs:" >&2
+    INFERCRANE_DEV_PORT=$port docker compose -p "$project" logs --tail 100 infercrane >&2
+    exit 1
+  fi
   sleep 1
 done
 request_id=$(printf '%s\n' "$response_headers" | awk '/^X-Request-Id:/ {gsub("\r", "", $2); print $2}')

--- a/scripts/test-acceptance-safety.sh
+++ b/scripts/test-acceptance-safety.sh
@@ -314,6 +314,8 @@ grep -Fq 'INFERCRANE_ACCEPTANCE_GUARD_REQUESTS:-100' "$root/scripts/release-acce
 grep -Fq 'LOCAL FIXTURE DEMO' "$root/scripts/demo-connect.sh"
 grep -Fq 'rollout evaluate qwen-prod --wait' "$root/scripts/demo-connect.sh"
 grep -Fq '.deployment.active_revision_id == $active' "$root/scripts/demo-connect.sh"
+grep -Fq 'Connected endpoint did not become routable within 90s' "$root/scripts/demo-connect.sh"
+grep -Fq 'docker compose -p "$project" logs --tail 100 infercrane' "$root/scripts/demo-connect.sh"
 if grep -Eq 'rollout (provision|validate)|--approve-paid-resources|release-acceptance\.sh' "$root/scripts/demo-product.sh" "$root/scripts/demo-connect.sh"; then
   echo "local product demo contains a paid or provisioning action" >&2
   exit 1


### PR DESCRIPTION
## Summary\n- align demo route-readiness wait with the bounded 90-second stack readiness policy\n- print the final gateway response and control-plane logs on timeout\n- preserve the demo's paid-resource safety contract\n\n## Verification\n- make demo\n- make test-acceptance-safety\n- make verify\n- zero residual demo containers, volumes, and networks