### PR TITLE
fix: scope publication preflight to protected environment

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   preflight:
     runs-on: ubuntu-latest
+    environment: stable-publication
     outputs:
       npm_version: ${{ steps.packages.outputs.npm_version }}
       python_version: ${{ steps.packages.outputs.python_version }}


### PR DESCRIPTION
The publication preflight reads `ORG_SECURITY_READ_TOKEN`, which is intentionally stored only on the protected `stable-publication` environment. Attach the preflight job to that environment so the organization 2FA check can fail closed without broadening secret scope.

Verification: Actionlint and publication contract check.

Signed-off-by: Yasin Toy <yasin.toy@yandex.com>