### PR TITLE
docs(release): align candidate artifact claims

### DIFF
--- a/docs/release-notes-v1.0.0-rc.1.md
+++ b/docs/release-notes-v1.0.0-rc.1.md
@@ -34,7 +34,7 @@ and Terraform provider ZIPs for macOS and Linux on amd64 and arm64.
   promotion, rejection, monitoring, and rollback;
 - CLI, control API, Python and TypeScript SDKs, Terraform provider, GitHub Action, terminal workspace,
   and a separately deployed browser console;
-- Apache-2.0 licensing, multi-architecture artifacts and images, checksums, SBOMs, provenance, and
+- Apache-2.0 licensing, multi-architecture artifacts, checksums, SBOMs, provenance, and
   GitHub attestations.
 
 ## Distribution status


### PR DESCRIPTION
Align the public beta release copy with the separately gated container image.

Verified with `make docs-check` and `git diff --check`.