### PR TITLE
Add queryable GPU price catalog

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -4517,6 +4517,105 @@
     "/api/v1/catalog/gpu-prices": {
       "get": {
         "operationId": "listGPUPrices",
+        "parameters": [
+          {
+            "description": "Case-insensitive search across provider, GPU, and region.",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Exact provider filter.",
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Exact GPU model filter.",
+            "in": "query",
+            "name": "gpu",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Exact region filter.",
+            "in": "query",
+            "name": "region",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter observations by evidence freshness; this is not a stock claim.",
+            "in": "query",
+            "name": "current",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Sort field.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "hourly_usd",
+              "enum": [
+                "hourly_usd",
+                "provider",
+                "gpu",
+                "observed_at"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "default": "asc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum observations returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 5000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Zero-based result offset.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -9716,6 +9815,105 @@
     "/api/v1/public/catalog/gpu-prices": {
       "get": {
         "operationId": "listPublicGPUPrices",
+        "parameters": [
+          {
+            "description": "Case-insensitive search across provider, GPU, and region.",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Exact provider filter.",
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Exact GPU model filter.",
+            "in": "query",
+            "name": "gpu",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Exact region filter.",
+            "in": "query",
+            "name": "region",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter observations by evidence freshness; this is not a stock claim.",
+            "in": "query",
+            "name": "current",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Sort field.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "hourly_usd",
+              "enum": [
+                "hourly_usd",
+                "provider",
+                "gpu",
+                "observed_at"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "default": "asc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum observations returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Zero-based result offset.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4517,6 +4517,105 @@
     "/api/v1/catalog/gpu-prices": {
       "get": {
         "operationId": "listGPUPrices",
+        "parameters": [
+          {
+            "description": "Case-insensitive search across provider, GPU, and region.",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Exact provider filter.",
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Exact GPU model filter.",
+            "in": "query",
+            "name": "gpu",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Exact region filter.",
+            "in": "query",
+            "name": "region",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter observations by evidence freshness; this is not a stock claim.",
+            "in": "query",
+            "name": "current",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Sort field.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "hourly_usd",
+              "enum": [
+                "hourly_usd",
+                "provider",
+                "gpu",
+                "observed_at"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "default": "asc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum observations returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 5000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Zero-based result offset.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -9716,6 +9815,105 @@
     "/api/v1/public/catalog/gpu-prices": {
       "get": {
         "operationId": "listPublicGPUPrices",
+        "parameters": [
+          {
+            "description": "Case-insensitive search across provider, GPU, and region.",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Exact provider filter.",
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Exact GPU model filter.",
+            "in": "query",
+            "name": "gpu",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Exact region filter.",
+            "in": "query",
+            "name": "region",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter observations by evidence freshness; this is not a stock claim.",
+            "in": "query",
+            "name": "current",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Sort field.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "hourly_usd",
+              "enum": [
+                "hourly_usd",
+                "provider",
+                "gpu",
+                "observed_at"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "default": "asc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum observations returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Zero-based result offset.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {

--- a/internal/apicontract/contract.go
+++ b/internal/apicontract/contract.go
@@ -198,6 +198,9 @@ func Document() (map[string]any, error) {
 			operation["security"] = []any{}
 		}
 		parameters := pathParameters(route.Path)
+		if route.Path == "/catalog/gpu-prices" || route.Path == "/public/catalog/gpu-prices" {
+			parameters = append(parameters, gpuPriceQueryParameters(route.Path == "/public/catalog/gpu-prices")...)
+		}
 		if route.Path == "/billing/webhooks/stripe" {
 			parameters = append(parameters, map[string]any{"name": "Stripe-Signature", "in": "header", "required": true, "description": "Stripe webhook HMAC signature; the request is unauthenticated by bearer token and grants balance only after verification.", "schema": map[string]any{"type": "string"}})
 		}
@@ -277,6 +280,24 @@ func pathParameters(path string) []map[string]any {
 		}
 	}
 	return parameters
+}
+
+func gpuPriceQueryParameters(public bool) []map[string]any {
+	maxLimit := 5000
+	if public {
+		maxLimit = 100
+	}
+	return []map[string]any{
+		{"name": "q", "in": "query", "required": false, "description": "Case-insensitive search across provider, GPU, and region.", "schema": map[string]any{"type": "string"}},
+		{"name": "provider", "in": "query", "required": false, "description": "Exact provider filter.", "schema": map[string]any{"type": "string"}},
+		{"name": "gpu", "in": "query", "required": false, "description": "Exact GPU model filter.", "schema": map[string]any{"type": "string"}},
+		{"name": "region", "in": "query", "required": false, "description": "Exact region filter.", "schema": map[string]any{"type": "string"}},
+		{"name": "current", "in": "query", "required": false, "description": "Filter observations by evidence freshness; this is not a stock claim.", "schema": map[string]any{"type": "boolean"}},
+		{"name": "sort", "in": "query", "required": false, "description": "Sort field.", "schema": map[string]any{"type": "string", "enum": []string{"hourly_usd", "provider", "gpu", "observed_at"}, "default": "hourly_usd"}},
+		{"name": "order", "in": "query", "required": false, "description": "Sort direction.", "schema": map[string]any{"type": "string", "enum": []string{"asc", "desc"}, "default": "asc"}},
+		{"name": "limit", "in": "query", "required": false, "description": "Maximum observations returned.", "schema": map[string]any{"type": "integer", "minimum": 1, "maximum": maxLimit}},
+		{"name": "offset", "in": "query", "required": false, "description": "Zero-based result offset.", "schema": map[string]any{"type": "integer", "minimum": 0, "default": 0}},
+	}
 }
 
 func ref(name string) map[string]any { return map[string]any{"$ref": "#/components/schemas/" + name} }

--- a/internal/apicontract/contract_test.go
+++ b/internal/apicontract/contract_test.go
@@ -97,4 +97,17 @@ func TestPublicGPUPricesAreDocumentedWithoutBearerAuthentication(t *testing.T) {
 	if !ok || len(security) != 0 {
 		t.Fatalf("public GPU prices must not require bearer authentication: %#v", operation["security"])
 	}
+	parameters, ok := operation["parameters"].([]map[string]any)
+	if !ok {
+		t.Fatalf("public GPU price query parameters missing: %#v", operation["parameters"])
+	}
+	found := map[string]bool{}
+	for _, parameter := range parameters {
+		found[parameter["name"].(string)] = true
+	}
+	for _, name := range []string{"q", "provider", "gpu", "current", "sort", "limit", "offset"} {
+		if !found[name] {
+			t.Fatalf("public GPU price query parameter %q missing", name)
+		}
+	}
 }

--- a/internal/controlapi/api.go
+++ b/internal/controlapi/api.go
@@ -4178,7 +4178,27 @@ func (a API) computeProviders(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"data": providers})
 }
 
-func (a API) gpuPrices(w http.ResponseWriter, _ *http.Request) {
+type gpuPriceRow struct {
+	Provider     string    `json:"provider"`
+	Region       string    `json:"region"`
+	GPU          string    `json:"gpu"`
+	GPUCount     int       `json:"gpu_count"`
+	Replicas     int       `json:"replicas"`
+	Currency     string    `json:"currency"`
+	HourlyUSD    float64   `json:"hourly_usd"`
+	Source       string    `json:"source"`
+	ObservedAt   time.Time `json:"observed_at"`
+	ValidUntil   time.Time `json:"valid_until"`
+	Current      bool      `json:"current"`
+	Availability string    `json:"availability"`
+}
+
+type gpuPriceFacet struct {
+	Value string `json:"value"`
+	Count int    `json:"count"`
+}
+
+func (a API) gpuPrices(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
 	prices := append([]GPUPriceObservation(nil), a.GPUPrices...)
 	if a.GPUPriceCatalog != nil {
@@ -4192,23 +4212,171 @@ func (a API) gpuPrices(w http.ResponseWriter, _ *http.Request) {
 			})
 		}
 	}
-	rows := make([]map[string]any, 0, len(prices))
+	rows := make([]gpuPriceRow, 0, len(prices))
 	for _, price := range prices {
-		rows = append(rows, map[string]any{
-			"provider": price.Provider, "region": price.Region, "gpu": price.GPU,
-			"gpu_count": price.GPUCount, "replicas": price.Replicas,
-			"currency": price.Currency, "hourly_usd": price.HourlyUSD,
-			"source": price.Source, "observed_at": price.ObservedAt,
-			"valid_until": price.ValidUntil, "current": price.ValidUntil.After(now),
-			"availability": "unknown",
+		rows = append(rows, gpuPriceRow{
+			Provider: price.Provider, Region: price.Region, GPU: price.GPU,
+			GPUCount: price.GPUCount, Replicas: price.Replicas,
+			Currency: price.Currency, HourlyUSD: price.HourlyUSD,
+			Source: price.Source, ObservedAt: price.ObservedAt,
+			ValidUntil: price.ValidUntil, Current: price.ValidUntil.After(now),
+			Availability: "unknown",
 		})
 	}
+
+	query := r.URL.Query()
+	search := strings.ToLower(strings.TrimSpace(query.Get("q")))
+	provider := strings.ToLower(strings.TrimSpace(query.Get("provider")))
+	gpu := strings.ToLower(strings.TrimSpace(query.Get("gpu")))
+	region := strings.ToLower(strings.TrimSpace(query.Get("region")))
+	currentFilter := strings.ToLower(strings.TrimSpace(query.Get("current")))
+	if currentFilter != "" && currentFilter != "true" && currentFilter != "false" {
+		writeError(w, http.StatusBadRequest, "invalid_query", "current must be true or false")
+		return
+	}
+
+	facetRows := make([]gpuPriceRow, 0, len(rows))
+	filtered := make([]gpuPriceRow, 0, len(rows))
+	for _, row := range rows {
+		if search != "" && !strings.Contains(strings.ToLower(row.Provider+" "+row.GPU+" "+row.Region), search) {
+			continue
+		}
+		if currentFilter == "true" && !row.Current {
+			continue
+		}
+		if currentFilter == "false" && row.Current {
+			continue
+		}
+		facetRows = append(facetRows, row)
+		if provider != "" && strings.ToLower(row.Provider) != provider {
+			continue
+		}
+		if gpu != "" && strings.ToLower(row.GPU) != gpu {
+			continue
+		}
+		if region != "" && strings.ToLower(row.Region) != region {
+			continue
+		}
+		filtered = append(filtered, row)
+	}
+	rows = filtered
+
+	sortField := strings.ToLower(strings.TrimSpace(query.Get("sort")))
+	if sortField == "" {
+		sortField = "hourly_usd"
+	}
+	if sortField != "hourly_usd" && sortField != "provider" && sortField != "gpu" && sortField != "observed_at" {
+		writeError(w, http.StatusBadRequest, "invalid_query", "sort must be hourly_usd, provider, gpu, or observed_at")
+		return
+	}
+	order := strings.ToLower(strings.TrimSpace(query.Get("order")))
+	if order == "" {
+		order = "asc"
+	}
+	if order != "asc" && order != "desc" {
+		writeError(w, http.StatusBadRequest, "invalid_query", "order must be asc or desc")
+		return
+	}
 	sort.SliceStable(rows, func(i, j int) bool {
-		return rows[i]["hourly_usd"].(float64) < rows[j]["hourly_usd"].(float64)
+		comparison := 0
+		switch sortField {
+		case "provider":
+			comparison = strings.Compare(strings.ToLower(rows[i].Provider), strings.ToLower(rows[j].Provider))
+		case "gpu":
+			comparison = strings.Compare(strings.ToLower(rows[i].GPU), strings.ToLower(rows[j].GPU))
+		case "observed_at":
+			comparison = rows[i].ObservedAt.Compare(rows[j].ObservedAt)
+		default:
+			if rows[i].HourlyUSD < rows[j].HourlyUSD {
+				comparison = -1
+			} else if rows[i].HourlyUSD > rows[j].HourlyUSD {
+				comparison = 1
+			}
+		}
+		if comparison == 0 {
+			comparison = strings.Compare(
+				strings.ToLower(rows[i].Provider+"\x00"+rows[i].Region+"\x00"+rows[i].GPU),
+				strings.ToLower(rows[j].Provider+"\x00"+rows[j].Region+"\x00"+rows[j].GPU),
+			)
+		}
+		if order == "desc" {
+			return comparison > 0
+		}
+		return comparison < 0
 	})
+
+	isPublic := strings.Contains(r.URL.Path, "/public/")
+	defaultLimit, maxLimit := len(rows), 5000
+	if isPublic {
+		defaultLimit, maxLimit = 40, 100
+	}
+	limit := defaultLimit
+	if raw := strings.TrimSpace(query.Get("limit")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 1 || parsed > maxLimit {
+			writeError(w, http.StatusBadRequest, "invalid_query", "limit must be between 1 and "+strconv.Itoa(maxLimit))
+			return
+		}
+		limit = parsed
+	}
+	offset := 0
+	if raw := strings.TrimSpace(query.Get("offset")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 0 {
+			writeError(w, http.StatusBadRequest, "invalid_query", "offset must be zero or greater")
+			return
+		}
+		offset = parsed
+	}
+	total := len(rows)
+	if offset > total {
+		offset = total
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+
+	providerCounts, gpuCounts := map[string]int{}, map[string]int{}
+	for _, row := range facetRows {
+		providerCounts[row.Provider]++
+		gpuCounts[row.GPU]++
+	}
+	matchedProviders, matchedGPUs := map[string]bool{}, map[string]bool{}
+	currentCount := 0
+	latestObservedAt := time.Time{}
+	for _, row := range rows {
+		matchedProviders[row.Provider] = true
+		matchedGPUs[row.GPU] = true
+		if row.Current {
+			currentCount++
+		}
+		if row.ObservedAt.After(latestObservedAt) {
+			latestObservedAt = row.ObservedAt
+		}
+	}
+	providers, gpus := make([]gpuPriceFacet, 0, len(providerCounts)), make([]gpuPriceFacet, 0, len(gpuCounts))
+	for value, count := range providerCounts {
+		providers = append(providers, gpuPriceFacet{Value: value, Count: count})
+	}
+	for value, count := range gpuCounts {
+		gpus = append(gpus, gpuPriceFacet{Value: value, Count: count})
+	}
+	sort.Slice(providers, func(i, j int) bool { return providers[i].Value < providers[j].Value })
+	sort.Slice(gpus, func(i, j int) bool { return gpus[i].Value < gpus[j].Value })
+
+	if isPublic {
+		w.Header().Set("Cache-Control", "public, max-age=60, stale-while-revalidate=300")
+	}
+	if !latestObservedAt.IsZero() {
+		w.Header().Set("Last-Modified", latestObservedAt.UTC().Format(http.TimeFormat))
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"data":       rows,
+		"data":       rows[offset:end],
 		"disclosure": "Prices are sourced observations. Current stock, account quota, and deployability are verified separately.",
+		"pagination": map[string]any{"limit": limit, "offset": offset, "total": total, "has_more": end < total},
+		"summary":    map[string]any{"providers": len(matchedProviders), "gpus": len(matchedGPUs), "current": currentCount, "latest_observed_at": latestObservedAt},
+		"facets":     map[string]any{"providers": providers, "gpus": gpus},
 	})
 }
 

--- a/internal/controlapi/api_test.go
+++ b/internal/controlapi/api_test.go
@@ -622,6 +622,40 @@ func TestComputeCatalogSeparatesPriceFromExecutionReadiness(t *testing.T) {
 	}
 }
 
+func TestPublicGPUPricesFilterAndPaginateWithoutDumpingCatalog(t *testing.T) {
+	now := time.Now().UTC()
+	handler := (API{
+		Store:  &fakeStore{},
+		APIKey: "secret",
+		GPUPrices: []GPUPriceObservation{
+			{Provider: "runpod", Region: "eu", GPU: "L40S", GPUCount: 1, Replicas: 1, Currency: "USD", HourlyUSD: 0.42, Source: "test", ObservedAt: now, ValidUntil: now.Add(time.Hour)},
+			{Provider: "lambda", Region: "us", GPU: "H100", GPUCount: 1, Replicas: 1, Currency: "USD", HourlyUSD: 2.49, Source: "test", ObservedAt: now, ValidUntil: now.Add(time.Hour)},
+			{Provider: "runpod", Region: "us", GPU: "H100", GPUCount: 1, Replicas: 1, Currency: "USD", HourlyUSD: 1.99, Source: "test", ObservedAt: now.Add(-2 * time.Hour), ValidUntil: now.Add(-time.Hour)},
+		},
+	}).Handler()
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/public/catalog/gpu-prices?q=h100&current=true&limit=1&offset=0&sort=hourly_usd", nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	body := response.Body.String()
+	if response.Code != http.StatusOK || !strings.Contains(body, `"provider":"lambda"`) || strings.Contains(body, `"provider":"runpod"`) {
+		t.Fatalf("filtered catalog status=%d body=%s", response.Code, body)
+	}
+	if !strings.Contains(body, `"total":1`) || !strings.Contains(body, `"providers":1`) || !strings.Contains(body, `"has_more":false`) {
+		t.Fatalf("filtered catalog metadata missing: %s", body)
+	}
+	if response.Header().Get("Cache-Control") == "" || response.Header().Get("Last-Modified") == "" {
+		t.Fatalf("public cache evidence missing: %#v", response.Header())
+	}
+
+	request = httptest.NewRequest(http.MethodGet, "/api/v1/public/catalog/gpu-prices?limit=101", nil)
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body.String(), `"code":"invalid_query"`) {
+		t.Fatalf("invalid public limit status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
 func TestCloudDeploymentFailsClosedWithoutReadyCompute(t *testing.T) {
 	handler := (API{Store: &fakeStore{}, APIKey: "secret", ComputeProviders: []ComputeProvider{{ID: "runpod", Label: "RunPod", State: "connection-required"}}}).Handler()
 	request := httptest.NewRequest(http.MethodPost, "/api/v1/deployments", strings.NewReader(`{"name":"qwen","model":"Qwen/Qwen3-8B","cloud":"runpod","gpu":"L40S","min_replicas":1,"max_replicas":1}`))


### PR DESCRIPTION
## Summary
- add server-side GPU price search, facets, sorting, and pagination
- cap public catalog responses and preserve authenticated export behavior
- expose freshness metadata and public cache headers
- document the query contract in OpenAPI

## Verification
- go test ./...
- make generate-api-check
- git diff --check