### PR TITLE
ops: persist SkyPilot production runtime

### DIFF
--- a/deploy/fly/control-plane.toml
+++ b/deploy/fly/control-plane.toml
@@ -17,7 +17,10 @@ kill_timeout = 35
   INFERCRANE_HOST = "0.0.0.0"
   INFERCRANE_PORT = "8080"
   INFERCRANE_HOSTED_AUTH_AUTO_PROVISION = "true"
-  INFERCRANE_SKYPILOT_API = "disabled"
+  # SkyPilot starts a local API process. Keep the provider list credential-gated
+  # and give the machine enough memory for the control plane plus that process.
+  INFERCRANE_SKYPILOT_API = "auto"
+  SKYPILOT_DISABLE_USAGE_COLLECTION = "1"
   INFERCRANE_GPU_PRICE_SYNC_SECONDS = "3600"
   INFERCRANE_DATABASE_MAX_OPEN = "12"
   INFERCRANE_DATABASE_MAX_IDLE = "4"
@@ -44,8 +47,7 @@ kill_timeout = 35
 
 [[vm]]
   size = "shared-cpu-1x"
-  # Provider CLIs must not start resident helper servers in the hosted control
-  # plane. This budget is verified by staging after disabled adapters are kept
-  # outside the executable backend registry.
-  memory = "1gb"
+  # SkyPilot recommends at least 2 GiB for its local API server. The production
+  # readiness check is not considered healthy until both processes have started.
+  memory = "2gb"
   processes = ["app"]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -456,7 +456,12 @@ func load(requireAPIKey bool) (Config, error) {
 	// Preserve the existing RunPod default while moving the execution boundary
 	// to provider-neutral manifests. Other clouds must be declared explicitly.
 	if len(config.SkyPilotProviders) == 0 && config.RunPodAPIKey != "" {
-		config.SkyPilotProviders = []SkyPilotProvider{{Cloud: "runpod", Label: "RunPod", Runtimes: []string{"vllm"}, CredentialEnv: []string{"RUNPOD_API_KEY"}}}
+		config.SkyPilotProviders = []SkyPilotProvider{{
+			Cloud:         "runpod",
+			Label:         "RunPod",
+			Runtimes:      []string{"vllm", "sglang", "custom-oci"},
+			CredentialEnv: []string{"RUNPOD_API_KEY"},
+		}}
 	}
 	if config.Port < 1 || config.Port > 65535 {
 		return Config{}, fmt.Errorf("INFERCRANE_PORT must be between 1 and 65535")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -135,6 +135,10 @@ func TestSkyPilotExecutionBoundary(t *testing.T) {
 	if err != nil || !cfg.SkyPilotEnabled() {
 		t.Fatalf("auto SkyPilot did not follow RunPod credentials: enabled=%v err=%v", cfg.SkyPilotEnabled(), err)
 	}
+	providers := cfg.ConfiguredSkyPilotProviders()
+	if len(providers) != 1 || providers[0].Cloud != "runpod" || strings.Join(providers[0].Runtimes, ",") != "vllm,sglang,custom-oci" {
+		t.Fatalf("unexpected RunPod SkyPilot defaults: %#v", providers)
+	}
 
 	t.Setenv("INFERCRANE_SKYPILOT_API", "invalid")
 	if _, err = Load(); err == nil || !strings.Contains(err.Error(), "INFERCRANE_SKYPILOT_API") {

--- a/scripts/test-fly-config.sh
+++ b/scripts/test-fly-config.sh
@@ -25,7 +25,8 @@ env = data["env"]
 assert env["INFERCRANE_ENV"] == "production"
 assert env["INFERCRANE_HOST"] == "0.0.0.0"
 assert env["INFERCRANE_PORT"] == "8080"
-assert env["INFERCRANE_SKYPILOT_API"] == "disabled"
+assert env["INFERCRANE_SKYPILOT_API"] == "auto"
+assert env["SKYPILOT_DISABLE_USAGE_COLLECTION"] == "1"
 assert env["INFERCRANE_GPU_PRICE_SYNC_SECONDS"] == "3600"
 assert "INFERCRANE_INSTANCE_ID" not in env, "replica identity must default to the unique machine hostname"
 
@@ -40,7 +41,7 @@ assert service["checks"][0]["method"] == "GET"
 
 machine = data["vm"][0]
 assert machine["size"] == "shared-cpu-1x"
-assert machine["memory"] == "1gb"
+assert machine["memory"] == "2gb"
 
 serialized = path.read_text().lower()
 for forbidden in ("database_url", "api_key", "secret_key", "webhook_secret", "private key"):


### PR DESCRIPTION
## Summary
- keep production SkyPilot in credential-gated auto mode
- provision the 2 GiB memory floor required by the local SkyPilot API server
- disable SkyPilot usage collection
- expose all portable RunPod runtimes through the default manifest

## Validation
- `go test ./internal/config`
- `flyctl config validate -a infercrane-control -c deploy/fly/control-plane.toml`
- production health remained stable after scaling to the same 2 GiB configuration