### PR TITLE
feat(pricing): ingest live Vast marketplace offers

### DIFF
--- a/cmd/infercrane/main.go
+++ b/cmd/infercrane/main.go
@@ -4111,6 +4111,20 @@ func serve(parent context.Context, cfg config.Config, s *store.Store) error {
 		}, time.Minute, func(err error) {
 			logger.Warn("provider-native RunPod price refresh failed", "error", err)
 		})
+		vastFeed := priceingest.VastFeed{ValidFor: 10 * time.Minute}
+		vastCtx, vastCancel := context.WithTimeout(ctx, 45*time.Second)
+		vastErr := vastFeed.Refresh(vastCtx, priceCatalog)
+		vastCancel()
+		if vastErr != nil {
+			logger.Warn("initial provider-native Vast offer refresh failed", "error", vastErr)
+		}
+		go priceingest.RunProviderFeed(ctx, func(refreshCtx context.Context) error {
+			refreshCtx, cancel := context.WithTimeout(refreshCtx, 45*time.Second)
+			defer cancel()
+			return vastFeed.Refresh(refreshCtx, priceCatalog)
+		}, 5*time.Minute, func(err error) {
+			logger.Warn("provider-native Vast offer refresh failed", "error", err)
+		})
 	}
 	_, aiperfErr := exec.LookPath(cfg.AIPerfBinary)
 	optimizationExecutionEnabled := false

--- a/internal/priceingest/vast.go
+++ b/internal/priceingest/vast.go
@@ -1,0 +1,205 @@
+package priceingest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/pricing"
+)
+
+const defaultVastOffersURL = "https://console.vast.ai/api/v0/bundles/"
+
+var defaultVastGPUs = []string{
+	"A10", "A100 PCIE", "A100 SXM4", "A40", "B200", "B300",
+	"H100 NVL", "H100 PCIE", "H100 SXM", "H200", "H200 NVL",
+	"L4", "L40", "L40S", "RTX 3090", "RTX 3090 Ti", "RTX 4090",
+	"RTX 4090D", "RTX 5090", "RTX 6000Ada", "RTX A6000",
+}
+
+// VastFeed reads current verified marketplace offers directly from Vast.ai.
+// The returned rows are price observations only. A launch probe still owns the
+// account, quota, and deployability decision.
+type VastFeed struct {
+	BaseURL    string
+	Client     *http.Client
+	ValidFor   time.Duration
+	Now        func() time.Time
+	GPUQueries []string
+	Workers    int
+}
+
+func (f VastFeed) Refresh(ctx context.Context, catalog *pricing.DynamicCatalog) error {
+	if catalog == nil {
+		return errors.New("GPU price catalog is nil")
+	}
+	gpus := append([]string(nil), f.GPUQueries...)
+	if len(gpus) == 0 {
+		gpus = append(gpus, defaultVastGPUs...)
+	}
+	workers := f.Workers
+	if workers <= 0 {
+		workers = 4
+	}
+	if workers > len(gpus) {
+		workers = len(gpus)
+	}
+
+	type result struct {
+		prices map[pricing.Request]pricing.Estimate
+		err    error
+	}
+	jobs := make(chan string)
+	results := make(chan result, len(gpus))
+	var group sync.WaitGroup
+	for range workers {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			for gpu := range jobs {
+				prices, err := f.fetchGPU(ctx, gpu)
+				results <- result{prices: prices, err: err}
+			}
+		}()
+	}
+	go func() {
+		defer close(jobs)
+		for _, gpu := range gpus {
+			select {
+			case jobs <- gpu:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	go func() {
+		group.Wait()
+		close(results)
+	}()
+
+	prices := make(map[pricing.Request]pricing.Estimate)
+	var failures []error
+	for item := range results {
+		if item.err != nil {
+			failures = append(failures, item.err)
+			continue
+		}
+		for request, estimate := range item.prices {
+			if current, ok := prices[request]; !ok || estimate.Hourly < current.Hourly {
+				prices[request] = estimate
+			}
+		}
+	}
+	// Publish atomically. A partial provider sweep must never delete a last-good
+	// row and present the surviving subset as a complete current market.
+	if len(failures) > 0 {
+		return fmt.Errorf("Vast offer refresh was incomplete: %w", errors.Join(failures...))
+	}
+	if len(prices) == 0 {
+		return errors.New("Vast returned no verified rentable GPU offers")
+	}
+	catalog.ReplaceProvider("vast", prices)
+	return nil
+}
+
+func (f VastFeed) fetchGPU(ctx context.Context, gpu string) (map[pricing.Request]pricing.Estimate, error) {
+	endpoint := strings.TrimSpace(f.BaseURL)
+	if endpoint == "" {
+		endpoint = defaultVastOffersURL
+	}
+	parsedEndpoint, err := url.Parse(endpoint)
+	if err != nil || parsedEndpoint.Scheme != "https" && parsedEndpoint.Scheme != "http" {
+		return nil, errors.New("Vast offer endpoint is invalid")
+	}
+	body, _ := json.Marshal(map[string]any{
+		"limit":    64,
+		"type":     "ondemand",
+		"verified": map[string]bool{"eq": true},
+		"rentable": map[string]bool{"eq": true},
+		"rented":   map[string]bool{"eq": false},
+		"gpu_name": map[string]string{"eq": gpu},
+		"order":    [][]string{{"dph_total", "asc"}},
+	})
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("prepare Vast %s offer request: %w", gpu, err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("User-Agent", "InferCrane-GPU-Market/1.0")
+	client := f.Client
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("fetch Vast %s offers: %w", gpu, err)
+	}
+	defer response.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(response.Body, 4<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read Vast %s offers: %w", gpu, err)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, fmt.Errorf("Vast %s offers returned HTTP %d", gpu, response.StatusCode)
+	}
+	var payload struct {
+		Offers []struct {
+			ID           int64   `json:"id"`
+			GPUName      string  `json:"gpu_name"`
+			GPUs         int     `json:"num_gpus"`
+			Hourly       float64 `json:"dph_total"`
+			Geolocation  string  `json:"geolocation"`
+			Rentable     bool    `json:"rentable"`
+			Rented       bool    `json:"rented"`
+			Verification string  `json:"verification"`
+		}
+	}
+	if err = json.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("decode Vast %s offers: %w", gpu, err)
+	}
+	now := time.Now().UTC()
+	if f.Now != nil {
+		now = f.Now().UTC()
+	}
+	validFor := f.ValidFor
+	if validFor <= 0 {
+		validFor = 10 * time.Minute
+	}
+	prices := make(map[pricing.Request]pricing.Estimate)
+	for _, offer := range payload.Offers {
+		if !strings.EqualFold(strings.TrimSpace(offer.GPUName), strings.TrimSpace(gpu)) || offer.GPUs < 1 || offer.Hourly <= 0 || !offer.Rentable || offer.Rented || !strings.EqualFold(offer.Verification, "verified") {
+			continue
+		}
+		region := vastRegion(offer.Geolocation)
+		key := pricing.Request{Cloud: "vast", Region: region, GPU: offer.GPUName, GPUCount: offer.GPUs, Replicas: 1}
+		estimate := pricing.Estimate{
+			Currency: "USD", Hourly: offer.Hourly,
+			Source:     defaultVastOffersURL + "#offer-" + strconv.FormatInt(offer.ID, 10),
+			ObservedAt: now, StaleAfter: validFor,
+		}
+		if current, ok := prices[key]; !ok || estimate.Hourly < current.Hourly {
+			prices[key] = estimate
+		}
+	}
+	return prices, nil
+}
+
+func vastRegion(geolocation string) string {
+	parts := strings.Split(geolocation, ",")
+	for index := len(parts) - 1; index >= 0; index-- {
+		if value := strings.TrimSpace(parts[index]); value != "" {
+			return strings.ToUpper(value)
+		}
+	}
+	return "global"
+}

--- a/internal/priceingest/vast_test.go
+++ b/internal/priceingest/vast_test.go
@@ -1,0 +1,80 @@
+package priceingest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/pricing"
+)
+
+func TestVastFeedPublishesCheapestVerifiedRentableOffersAtomically(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"verified":{"eq":true}`) || !strings.Contains(string(body), `"rentable":{"eq":true}`) || !strings.Contains(string(body), `"rented":{"eq":false}`) {
+			t.Fatalf("unsafe Vast market query: %s", body)
+		}
+		var request map[string]any
+		_ = json.Unmarshal(body, &request)
+		gpu := request["gpu_name"].(map[string]any)["eq"].(string)
+		_, _ = w.Write([]byte(`{"offers":[` +
+			`{"id":11,"gpu_name":"` + gpu + `","num_gpus":1,"dph_total":1.3,"geolocation":"Texas, US","rentable":true,"rented":false,"verification":"verified"},` +
+			`{"id":12,"gpu_name":"` + gpu + `","num_gpus":1,"dph_total":0.9,"geolocation":"Virginia, US","rentable":true,"rented":false,"verification":"verified"},` +
+			`{"id":13,"gpu_name":"` + gpu + `","num_gpus":1,"dph_total":0.4,"geolocation":"Frankfurt, DE","rentable":false,"rented":false,"verification":"verified"},` +
+			`{"id":14,"gpu_name":"` + gpu + `","num_gpus":2,"dph_total":1.7,"geolocation":"Frankfurt, DE","rentable":true,"rented":false,"verification":"verified"}]}`))
+	}))
+	defer server.Close()
+	now := time.Date(2026, 9, 1, 5, 0, 0, 0, time.UTC)
+	catalog := pricing.NewDynamicCatalog(nil)
+	feed := VastFeed{BaseURL: server.URL, Client: server.Client(), GPUQueries: []string{"H100 SXM", "L40S"}, Workers: 2, Now: func() time.Time { return now }}
+	if err := feed.Refresh(context.Background(), catalog); err != nil {
+		t.Fatal(err)
+	}
+	for _, gpu := range []string{"H100 SXM", "L40S"} {
+		single, err := catalog.Estimate(context.Background(), pricing.Request{Cloud: "vast", Region: "US", GPU: gpu, GPUCount: 1, Replicas: 1})
+		if err != nil || single.Hourly != 0.9 || !strings.HasSuffix(single.Source, "#offer-12") || single.ObservedAt != now {
+			t.Fatalf("unexpected cheapest %s offer: %#v err=%v", gpu, single, err)
+		}
+		multi, err := catalog.Estimate(context.Background(), pricing.Request{Cloud: "vast", Region: "DE", GPU: gpu, GPUCount: 2, Replicas: 1})
+		if err != nil || multi.Hourly != 1.7 {
+			t.Fatalf("unexpected multi-GPU %s offer: %#v err=%v", gpu, multi, err)
+		}
+	}
+}
+
+func TestVastFeedKeepsLastGoodSnapshotWhenSweepIsPartial(t *testing.T) {
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 2 {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`{"offers":[{"id":1,"gpu_name":"H100 SXM","num_gpus":1,"dph_total":2,"geolocation":"US","rentable":true,"rented":false,"verification":"verified"}]}`))
+	}))
+	defer server.Close()
+	key := pricing.Request{Cloud: "vast", Region: "US", GPU: "H100 SXM", GPUCount: 1, Replicas: 1}
+	catalog := pricing.NewDynamicCatalog(nil)
+	catalog.ReplaceProvider("vast", map[pricing.Request]pricing.Estimate{key: {Currency: "USD", Source: "last-good", Hourly: 3, ObservedAt: time.Now(), StaleAfter: time.Hour}})
+	feed := VastFeed{BaseURL: server.URL, Client: server.Client(), GPUQueries: []string{"H100 SXM", "L40S"}, Workers: 1}
+	if err := feed.Refresh(context.Background(), catalog); err == nil {
+		t.Fatal("expected partial provider sweep to fail")
+	}
+	offer, err := catalog.Estimate(context.Background(), key)
+	if err != nil || offer.Source != "last-good" {
+		t.Fatalf("partial sweep replaced the last-good snapshot: %#v err=%v", offer, err)
+	}
+}
+
+func TestVastRegionUsesCountrySuffix(t *testing.T) {
+	for input, expected := range map[string]string{"Frankfurt, DE": "DE", ", US": "US", "": "global"} {
+		if got := vastRegion(input); got != expected {
+			t.Fatalf("vastRegion(%q)=%q want %q", input, got, expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- ingest current verified, rentable Vast.ai marketplace offers from the provider API
- keep price evidence separate from capacity and deployability
- publish provider refreshes atomically and preserve last-good data on partial failure
- refresh Vast every five minutes with a ten-minute validity window

## Verification
- `go test ./...`
- direct read-only request to the official Vast offer endpoint returned current verified offers

## Evidence semantics
These are current market-offer price observations. They do not prove tenant quota or launch success; InferCrane still runs a separate launch-capacity probe before deployment.