### PR TITLE
fix(pricing): respect Vast marketplace rate limit

### DIFF
--- a/internal/priceingest/vast.go
+++ b/internal/priceingest/vast.go
@@ -19,11 +19,12 @@ import (
 
 const defaultVastOffersURL = "https://console.vast.ai/api/v0/bundles/"
 
-var defaultVastGPUs = []string{
-	"A10", "A100 PCIE", "A100 SXM4", "A40", "B200", "B300",
-	"H100 NVL", "H100 PCIE", "H100 SXM", "H200", "H200 NVL",
-	"L4", "L40", "L40S", "RTX 3090", "RTX 3090 Ti", "RTX 4090",
-	"RTX 4090D", "RTX 5090", "RTX 6000Ada", "RTX A6000",
+var defaultVastGPUQueryGroups = [][]string{
+	{"H100 NVL", "H100 PCIE", "H100 SXM", "H200", "H200 NVL", "B200", "B300"},
+	{"A10", "A100 PCIE", "A100 SXM4", "A40"},
+	{"L4", "L40", "L40S"},
+	{"RTX 3090", "RTX 3090 Ti", "RTX 4090", "RTX 4090D", "RTX 5090"},
+	{"RTX 6000Ada", "RTX A6000"},
 }
 
 // VastFeed reads current verified marketplace offers directly from Vast.ai.
@@ -35,47 +36,60 @@ type VastFeed struct {
 	ValidFor   time.Duration
 	Now        func() time.Time
 	GPUQueries []string
-	Workers    int
+	// GPUQueryGroups lets one Vast request cover a similarly priced family.
+	// Vast currently permits five requests per window and caps each response at
+	// 64 offers, so the production defaults deliberately use exactly five
+	// price-band groups instead of one request per accelerator.
+	GPUQueryGroups [][]string
+	Workers        int
 }
 
 func (f VastFeed) Refresh(ctx context.Context, catalog *pricing.DynamicCatalog) error {
 	if catalog == nil {
 		return errors.New("GPU price catalog is nil")
 	}
-	gpus := append([]string(nil), f.GPUQueries...)
-	if len(gpus) == 0 {
-		gpus = append(gpus, defaultVastGPUs...)
+	groups := cloneGPUQueryGroups(f.GPUQueryGroups)
+	if len(groups) == 0 && len(f.GPUQueries) > 0 {
+		for _, gpu := range f.GPUQueries {
+			groups = append(groups, []string{gpu})
+		}
+	}
+	if len(groups) == 0 {
+		groups = cloneGPUQueryGroups(defaultVastGPUQueryGroups)
 	}
 	workers := f.Workers
 	if workers <= 0 {
-		workers = 4
+		// Vast's public marketplace API is intentionally queried serially. The
+		// production catalog uses its full five-request window, so concurrency
+		// would turn a healthy refresh into a burst that is easy to throttle.
+		workers = 1
 	}
-	if workers > len(gpus) {
-		workers = len(gpus)
+	if workers > len(groups) {
+		workers = len(groups)
 	}
 
 	type result struct {
 		prices map[pricing.Request]pricing.Estimate
 		err    error
 	}
-	jobs := make(chan string)
-	results := make(chan result, len(gpus))
+	jobs := make(chan []string)
+	results := make(chan result, len(groups))
 	var group sync.WaitGroup
 	for range workers {
 		group.Add(1)
 		go func() {
 			defer group.Done()
-			for gpu := range jobs {
-				prices, err := f.fetchGPU(ctx, gpu)
+			for gpus := range jobs {
+				prices, err := f.fetchGPUs(ctx, gpus)
 				results <- result{prices: prices, err: err}
 			}
 		}()
 	}
 	go func() {
 		defer close(jobs)
-		for _, gpu := range gpus {
+		for _, gpus := range groups {
 			select {
-			case jobs <- gpu:
+			case jobs <- gpus:
 			case <-ctx.Done():
 				return
 			}
@@ -111,7 +125,10 @@ func (f VastFeed) Refresh(ctx context.Context, catalog *pricing.DynamicCatalog) 
 	return nil
 }
 
-func (f VastFeed) fetchGPU(ctx context.Context, gpu string) (map[pricing.Request]pricing.Estimate, error) {
+func (f VastFeed) fetchGPUs(ctx context.Context, gpus []string) (map[pricing.Request]pricing.Estimate, error) {
+	if len(gpus) == 0 {
+		return nil, errors.New("Vast GPU query group is empty")
+	}
 	endpoint := strings.TrimSpace(f.BaseURL)
 	if endpoint == "" {
 		endpoint = defaultVastOffersURL
@@ -120,18 +137,22 @@ func (f VastFeed) fetchGPU(ctx context.Context, gpu string) (map[pricing.Request
 	if err != nil || parsedEndpoint.Scheme != "https" && parsedEndpoint.Scheme != "http" {
 		return nil, errors.New("Vast offer endpoint is invalid")
 	}
+	gpuFilter := map[string]any{"in": gpus}
+	if len(gpus) == 1 {
+		gpuFilter = map[string]any{"eq": gpus[0]}
+	}
 	body, _ := json.Marshal(map[string]any{
 		"limit":    64,
 		"type":     "ondemand",
 		"verified": map[string]bool{"eq": true},
 		"rentable": map[string]bool{"eq": true},
 		"rented":   map[string]bool{"eq": false},
-		"gpu_name": map[string]string{"eq": gpu},
+		"gpu_name": gpuFilter,
 		"order":    [][]string{{"dph_total", "asc"}},
 	})
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("prepare Vast %s offer request: %w", gpu, err)
+		return nil, fmt.Errorf("prepare Vast %s offer request: %w", strings.Join(gpus, ", "), err)
 	}
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Accept", "application/json")
@@ -142,15 +163,15 @@ func (f VastFeed) fetchGPU(ctx context.Context, gpu string) (map[pricing.Request
 	}
 	response, err := client.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("fetch Vast %s offers: %w", gpu, err)
+		return nil, fmt.Errorf("fetch Vast %s offers: %w", strings.Join(gpus, ", "), err)
 	}
 	defer response.Body.Close()
 	data, err := io.ReadAll(io.LimitReader(response.Body, 4<<20))
 	if err != nil {
-		return nil, fmt.Errorf("read Vast %s offers: %w", gpu, err)
+		return nil, fmt.Errorf("read Vast %s offers: %w", strings.Join(gpus, ", "), err)
 	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return nil, fmt.Errorf("Vast %s offers returned HTTP %d", gpu, response.StatusCode)
+		return nil, fmt.Errorf("Vast %s offers returned HTTP %d", strings.Join(gpus, ", "), response.StatusCode)
 	}
 	var payload struct {
 		Offers []struct {
@@ -165,7 +186,7 @@ func (f VastFeed) fetchGPU(ctx context.Context, gpu string) (map[pricing.Request
 		}
 	}
 	if err = json.Unmarshal(data, &payload); err != nil {
-		return nil, fmt.Errorf("decode Vast %s offers: %w", gpu, err)
+		return nil, fmt.Errorf("decode Vast %s offers: %w", strings.Join(gpus, ", "), err)
 	}
 	now := time.Now().UTC()
 	if f.Now != nil {
@@ -176,8 +197,12 @@ func (f VastFeed) fetchGPU(ctx context.Context, gpu string) (map[pricing.Request
 		validFor = 10 * time.Minute
 	}
 	prices := make(map[pricing.Request]pricing.Estimate)
+	allowed := make(map[string]struct{}, len(gpus))
+	for _, gpu := range gpus {
+		allowed[strings.ToLower(strings.TrimSpace(gpu))] = struct{}{}
+	}
 	for _, offer := range payload.Offers {
-		if !strings.EqualFold(strings.TrimSpace(offer.GPUName), strings.TrimSpace(gpu)) || offer.GPUs < 1 || offer.Hourly <= 0 || !offer.Rentable || offer.Rented || !strings.EqualFold(offer.Verification, "verified") {
+		if _, ok := allowed[strings.ToLower(strings.TrimSpace(offer.GPUName))]; !ok || offer.GPUs < 1 || offer.Hourly <= 0 || !offer.Rentable || offer.Rented || !strings.EqualFold(offer.Verification, "verified") {
 			continue
 		}
 		region := vastRegion(offer.Geolocation)
@@ -192,6 +217,16 @@ func (f VastFeed) fetchGPU(ctx context.Context, gpu string) (map[pricing.Request
 		}
 	}
 	return prices, nil
+}
+
+func cloneGPUQueryGroups(groups [][]string) [][]string {
+	cloned := make([][]string, 0, len(groups))
+	for _, group := range groups {
+		if len(group) > 0 {
+			cloned = append(cloned, append([]string(nil), group...))
+		}
+	}
+	return cloned
 }
 
 func vastRegion(geolocation string) string {

--- a/internal/priceingest/vast_test.go
+++ b/internal/priceingest/vast_test.go
@@ -71,6 +71,40 @@ func TestVastFeedKeepsLastGoodSnapshotWhenSweepIsPartial(t *testing.T) {
 	}
 }
 
+func TestDefaultVastFeedUsesFiveGroupedMarketplaceQueries(t *testing.T) {
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var request struct {
+			GPUName struct {
+				In []string `json:"in"`
+			} `json:"gpu_name"`
+		}
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Fatal(err)
+		}
+		if len(request.GPUName.In) < 2 {
+			t.Fatalf("default query was not grouped: %s", body)
+		}
+		calls.Add(1)
+		gpu := request.GPUName.In[0]
+		_, _ = w.Write([]byte(`{"offers":[{"id":1,"gpu_name":"` + gpu + `","num_gpus":1,"dph_total":1,"geolocation":"US","rentable":true,"rented":false,"verification":"verified"}]}`))
+	}))
+	defer server.Close()
+
+	catalog := pricing.NewDynamicCatalog(nil)
+	feed := VastFeed{BaseURL: server.URL, Client: server.Client()}
+	if err := feed.Refresh(context.Background(), catalog); err != nil {
+		t.Fatal(err)
+	}
+	if got := calls.Load(); got != 5 {
+		t.Fatalf("default Vast refresh made %d requests; public limit is five", got)
+	}
+	if got := len(catalog.Snapshot()); got != 5 {
+		t.Fatalf("grouped refresh published %d offers, want 5", got)
+	}
+}
+
 func TestVastRegionUsesCountrySuffix(t *testing.T) {
 	for input, expected := range map[string]string{"Frankfurt, DE": "DE", ", US": "US", "": "global"} {
 		if got := vastRegion(input); got != expected {


### PR DESCRIPTION
## What changed
- group the production Vast accelerator catalog into five price-band queries
- query those groups serially to stay within the public marketplace limit
- preserve singleton queries for focused tests and integrations
- verify the default refresh makes exactly five requests and publishes atomically

## Why
The first direct marketplace refresh succeeded, but the prior one-query-per-GPU sweep exceeded Vast's five-request public limit. That caused later refreshes to return HTTP 429 and otherwise-current rows to age out.

## Verification
- `go test ./internal/priceingest`
- `go test ./...`
- `git diff --check`