### PR TITLE
fix(pricing): stage exact Vast GPU quotes

### DIFF
--- a/cmd/infercrane/main.go
+++ b/cmd/infercrane/main.go
@@ -4099,7 +4099,12 @@ func serve(parent context.Context, cfg config.Config, s *store.Store) error {
 	if cfg.GPUPriceSyncInterval > 0 {
 		// Dynamic marketplace prices must come from the provider itself. Static
 		// third-party catalogs are intentionally excluded from this live catalog.
-		runPodFeed := priceingest.RunPodFeed{APIKey: cfg.RunPodAPIKey, ValidFor: 2 * time.Minute}
+		priceSyncInterval := cfg.GPUPriceSyncInterval
+		runPodValidFor := 2 * priceSyncInterval
+		if runPodValidFor < 2*time.Minute {
+			runPodValidFor = 2 * time.Minute
+		}
+		runPodFeed := priceingest.RunPodFeed{APIKey: cfg.RunPodAPIKey, ValidFor: runPodValidFor}
 		runPodCtx, runPodCancel := context.WithTimeout(ctx, 20*time.Second)
 		runPodErr := runPodFeed.Refresh(runPodCtx, priceCatalog)
 		runPodCancel()
@@ -4108,21 +4113,24 @@ func serve(parent context.Context, cfg config.Config, s *store.Store) error {
 		}
 		go priceingest.RunProviderFeed(ctx, func(refreshCtx context.Context) error {
 			return runPodFeed.Refresh(refreshCtx, priceCatalog)
-		}, time.Minute, func(err error) {
+		}, priceSyncInterval, func(err error) {
 			logger.Warn("provider-native RunPod price refresh failed", "error", err)
 		})
-		vastFeed := priceingest.VastFeed{ValidFor: 10 * time.Minute}
-		vastCtx, vastCancel := context.WithTimeout(ctx, 45*time.Second)
+		// Four exact Vast GPU shards are refreshed per rate-limit window. A full
+		// reviewed catalog rotation is nine windows, so validity covers two full
+		// rotations plus retry headroom without pretending an expired row is live.
+		vastFeed := priceingest.VastFeed{APIKey: os.Getenv("VAST_API_KEY"), ValidFor: 20 * priceSyncInterval}
+		vastCtx, vastCancel := context.WithTimeout(ctx, 75*time.Second)
 		vastErr := vastFeed.Refresh(vastCtx, priceCatalog)
 		vastCancel()
 		if vastErr != nil {
 			logger.Warn("initial provider-native Vast offer refresh failed", "error", vastErr)
 		}
 		go priceingest.RunProviderFeed(ctx, func(refreshCtx context.Context) error {
-			refreshCtx, cancel := context.WithTimeout(refreshCtx, 45*time.Second)
+			refreshCtx, cancel := context.WithTimeout(refreshCtx, 75*time.Second)
 			defer cancel()
 			return vastFeed.Refresh(refreshCtx, priceCatalog)
-		}, 5*time.Minute, func(err error) {
+		}, priceSyncInterval, func(err error) {
 			logger.Warn("provider-native Vast offer refresh failed", "error", err)
 		})
 	}

--- a/deploy/fly/control-plane.toml
+++ b/deploy/fly/control-plane.toml
@@ -21,7 +21,9 @@ kill_timeout = 35
   # and give the machine enough memory for the control plane plus that process.
   INFERCRANE_SKYPILOT_API = "auto"
   SKYPILOT_DISABLE_USAGE_COLLECTION = "1"
-  INFERCRANE_GPU_PRICE_SYNC_SECONDS = "3600"
+  # Provider-native price feeds rotate exact marketplace shards while staying
+  # below provider request budgets. This is observation, not capacity polling.
+  INFERCRANE_GPU_PRICE_SYNC_SECONDS = "75"
   INFERCRANE_DATABASE_MAX_OPEN = "12"
   INFERCRANE_DATABASE_MAX_IDLE = "4"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -501,8 +501,8 @@ func load(requireAPIKey bool) (Config, error) {
 	if config.HealthInterval <= 0 || config.UpstreamTimeout <= 0 || config.ShutdownTimeout <= 0 || config.RequestRetention <= 0 {
 		return Config{}, fmt.Errorf("timeouts must be positive")
 	}
-	if config.GPUPriceSyncInterval != 0 && (config.GPUPriceSyncInterval < 5*time.Minute || config.GPUPriceSyncInterval > 24*time.Hour) {
-		return Config{}, fmt.Errorf("INFERCRANE_GPU_PRICE_SYNC_SECONDS must be 0 or between 300 and 86400")
+	if config.GPUPriceSyncInterval != 0 && (config.GPUPriceSyncInterval < time.Minute || config.GPUPriceSyncInterval > 24*time.Hour) {
+		return Config{}, fmt.Errorf("INFERCRANE_GPU_PRICE_SYNC_SECONDS must be 0 or between 60 and 86400")
 	}
 	if config.RunPodContainerDiskGiB < 50 || config.RunPodContainerDiskGiB > 2048 {
 		return Config{}, fmt.Errorf("INFERCRANE_RUNPOD_CONTAINER_DISK_GIB must be between 50 and 2048")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -85,7 +85,12 @@ func TestGPUPriceSyncIntervalIsBounded(t *testing.T) {
 	if err != nil || cfg.GPUPriceSyncInterval != time.Hour {
 		t.Fatalf("cfg=%#v err=%v", cfg, err)
 	}
-	t.Setenv("INFERCRANE_GPU_PRICE_SYNC_SECONDS", "60")
+	t.Setenv("INFERCRANE_GPU_PRICE_SYNC_SECONDS", "75")
+	cfg, err = Load()
+	if err != nil || cfg.GPUPriceSyncInterval != 75*time.Second {
+		t.Fatalf("cfg=%#v err=%v", cfg, err)
+	}
+	t.Setenv("INFERCRANE_GPU_PRICE_SYNC_SECONDS", "59")
 	if _, err = Load(); err == nil || !strings.Contains(err.Error(), "GPU_PRICE_SYNC") {
 		t.Fatalf("unsafe price refresh interval accepted: %v", err)
 	}

--- a/internal/priceingest/vast.go
+++ b/internal/priceingest/vast.go
@@ -17,118 +17,98 @@ import (
 	"github.com/infercrane/infercrane/internal/pricing"
 )
 
-const defaultVastOffersURL = "https://console.vast.ai/api/v0/bundles/"
+const (
+	defaultVastOffersURL      = "https://console.vast.ai/api/v0/bundles/"
+	defaultVastShardsPerSweep = 4
+)
 
-var defaultVastGPUQueryGroups = [][]string{
-	{"H100 NVL", "H100 PCIE", "H100 SXM", "H200", "H200 NVL", "B200", "B300"},
-	{"A10", "A100 PCIE", "A100 SXM4", "A40"},
-	{"L4", "L40", "L40S"},
-	{"RTX 3090", "RTX 3090 Ti", "RTX 4090", "RTX 4090D", "RTX 5090"},
-	{"RTX 6000Ada", "RTX A6000"},
+// These are exact names from Vast's canonical gpu_names/unique endpoint. The
+// order front-loads the accelerators most relevant to production inference.
+// Each refresh covers a bounded slice and continues at the prior cursor.
+var defaultVastGPUs = []string{
+	"B200", "H200", "H100 SXM", "L40S",
+	"A100 SXM4", "L4", "RTX 4090", "A100 PCIE",
+	"H200 NVL", "H100 PCIE", "H100 NVL", "B300",
+	"L40", "A40", "A10", "A16", "A800 PCIE", "GB10",
+	"RTX 5090", "RTX 5080", "RTX 4090D", "RTX 4080", "RTX 6000Ada",
+	"RTX 5880Ada", "RTX 5000Ada", "RTX 4500Ada", "RTX 4000Ada",
+	"RTX PRO 6000 S", "RTX PRO 6000 WS", "RTX PRO 6000 Max-Q",
+	"RTX A6000", "RTX A5000", "RTX A4500", "RTX A4000", "Tesla T4", "Tesla V100",
 }
 
-// VastFeed reads current verified marketplace offers directly from Vast.ai.
-// The returned rows are price observations only. A launch probe still owns the
-// account, quota, and deployability decision.
+// VastFeed reads verified, rentable marketplace offers directly from Vast.ai.
+// Vast's public endpoint allows five calls per window and caps a response at 64
+// rows. A mixed-family query can therefore silently omit expensive GPUs and
+// multi-GPU tuples. InferCrane instead refreshes exact one-GPU shards, four per
+// sweep, leaving one request of rate-limit headroom. Each successful shard is
+// independently complete and is published atomically.
+//
+// These rows are price observations only. A launch probe still owns account,
+// quota, stock, and deployability decisions.
 type VastFeed struct {
-	BaseURL    string
-	Client     *http.Client
-	ValidFor   time.Duration
-	Now        func() time.Time
-	GPUQueries []string
-	// GPUQueryGroups lets one Vast request cover a similarly priced family.
-	// Vast currently permits five requests per window and caps each response at
-	// 64 offers, so the production defaults deliberately use exactly five
-	// price-band groups instead of one request per accelerator.
-	GPUQueryGroups [][]string
-	Workers        int
+	APIKey           string
+	BaseURL          string
+	Client           *http.Client
+	ValidFor         time.Duration
+	Now              func() time.Time
+	GPUQueries       []string
+	ShardsPerRefresh int
+
+	mu     sync.Mutex
+	cursor int
 }
 
-func (f VastFeed) Refresh(ctx context.Context, catalog *pricing.DynamicCatalog) error {
+func (f *VastFeed) Refresh(ctx context.Context, catalog *pricing.DynamicCatalog) error {
 	if catalog == nil {
 		return errors.New("GPU price catalog is nil")
 	}
-	groups := cloneGPUQueryGroups(f.GPUQueryGroups)
-	if len(groups) == 0 && len(f.GPUQueries) > 0 {
-		for _, gpu := range f.GPUQueries {
-			groups = append(groups, []string{gpu})
-		}
+	if f == nil {
+		return errors.New("Vast price feed is nil")
 	}
-	if len(groups) == 0 {
-		groups = cloneGPUQueryGroups(defaultVastGPUQueryGroups)
+	gpus := append([]string(nil), f.GPUQueries...)
+	if len(gpus) == 0 {
+		gpus = append(gpus, defaultVastGPUs...)
 	}
-	workers := f.Workers
-	if workers <= 0 {
-		// Vast's public marketplace API is intentionally queried serially. The
-		// production catalog uses its full five-request window, so concurrency
-		// would turn a healthy refresh into a burst that is easy to throttle.
-		workers = 1
+	shards := f.ShardsPerRefresh
+	if shards <= 0 {
+		shards = defaultVastShardsPerSweep
 	}
-	if workers > len(groups) {
-		workers = len(groups)
+	if shards > defaultVastShardsPerSweep {
+		shards = defaultVastShardsPerSweep
+	}
+	if shards > len(gpus) {
+		shards = len(gpus)
 	}
 
-	type result struct {
-		prices map[pricing.Request]pricing.Estimate
-		err    error
+	// A feed instance owns one cursor and one request budget. Serializing refresh
+	// calls prevents a startup refresh and timer refresh from sharing the same
+	// five-call window.
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.cursor >= len(gpus) {
+		f.cursor = 0
 	}
-	jobs := make(chan []string)
-	results := make(chan result, len(groups))
-	var group sync.WaitGroup
-	for range workers {
-		group.Add(1)
-		go func() {
-			defer group.Done()
-			for gpus := range jobs {
-				prices, err := f.fetchGPUs(ctx, gpus)
-				results <- result{prices: prices, err: err}
-			}
-		}()
-	}
-	go func() {
-		defer close(jobs)
-		for _, gpus := range groups {
-			select {
-			case jobs <- gpus:
-			case <-ctx.Done():
-				return
-			}
+	completed := 0
+	for completed < shards {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-	}()
-	go func() {
-		group.Wait()
-		close(results)
-	}()
-
-	prices := make(map[pricing.Request]pricing.Estimate)
-	var failures []error
-	for item := range results {
-		if item.err != nil {
-			failures = append(failures, item.err)
-			continue
+		gpu := strings.TrimSpace(gpus[f.cursor])
+		if gpu == "" {
+			return errors.New("Vast GPU query is empty")
 		}
-		for request, estimate := range item.prices {
-			if current, ok := prices[request]; !ok || estimate.Hourly < current.Hourly {
-				prices[request] = estimate
-			}
+		prices, err := f.fetchGPU(ctx, gpu)
+		if err != nil {
+			return err
 		}
+		catalog.ReplaceProviderGPU("vast", gpu, prices)
+		f.cursor = (f.cursor + 1) % len(gpus)
+		completed++
 	}
-	// Publish atomically. A partial provider sweep must never delete a last-good
-	// row and present the surviving subset as a complete current market.
-	if len(failures) > 0 {
-		return fmt.Errorf("Vast offer refresh was incomplete: %w", errors.Join(failures...))
-	}
-	if len(prices) == 0 {
-		return errors.New("Vast returned no verified rentable GPU offers")
-	}
-	catalog.ReplaceProvider("vast", prices)
 	return nil
 }
 
-func (f VastFeed) fetchGPUs(ctx context.Context, gpus []string) (map[pricing.Request]pricing.Estimate, error) {
-	if len(gpus) == 0 {
-		return nil, errors.New("Vast GPU query group is empty")
-	}
+func (f *VastFeed) fetchGPU(ctx context.Context, gpu string) (map[pricing.Request]pricing.Estimate, error) {
 	endpoint := strings.TrimSpace(f.BaseURL)
 	if endpoint == "" {
 		endpoint = defaultVastOffersURL
@@ -137,41 +117,24 @@ func (f VastFeed) fetchGPUs(ctx context.Context, gpus []string) (map[pricing.Req
 	if err != nil || parsedEndpoint.Scheme != "https" && parsedEndpoint.Scheme != "http" {
 		return nil, errors.New("Vast offer endpoint is invalid")
 	}
-	gpuFilter := map[string]any{"in": gpus}
-	if len(gpus) == 1 {
-		gpuFilter = map[string]any{"eq": gpus[0]}
+	if strings.TrimSpace(f.APIKey) != "" && (parsedEndpoint.Scheme != "https" || !strings.EqualFold(parsedEndpoint.Hostname(), "console.vast.ai")) {
+		return nil, errors.New("refusing to send Vast credentials to an untrusted endpoint")
 	}
 	body, _ := json.Marshal(map[string]any{
-		"limit":    64,
-		"type":     "ondemand",
-		"verified": map[string]bool{"eq": true},
-		"rentable": map[string]bool{"eq": true},
-		"rented":   map[string]bool{"eq": false},
-		"gpu_name": gpuFilter,
-		"order":    [][]string{{"dph_total", "asc"}},
+		"limit":             1,
+		"type":              "on-demand",
+		"verified":          map[string]bool{"eq": true},
+		"external":          map[string]bool{"eq": false},
+		"rentable":          map[string]bool{"eq": true},
+		"rented":            map[string]bool{"eq": false},
+		"gpu_name":          map[string]string{"eq": gpu},
+		"num_gpus":          map[string]int{"eq": 1},
+		"allocated_storage": 5,
+		"order":             [][]string{{"dph_total", "asc"}},
 	})
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	data, err := f.request(ctx, endpoint, body, gpu)
 	if err != nil {
-		return nil, fmt.Errorf("prepare Vast %s offer request: %w", strings.Join(gpus, ", "), err)
-	}
-	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Accept", "application/json")
-	request.Header.Set("User-Agent", "InferCrane-GPU-Market/1.0")
-	client := f.Client
-	if client == nil {
-		client = &http.Client{Timeout: 15 * time.Second}
-	}
-	response, err := client.Do(request)
-	if err != nil {
-		return nil, fmt.Errorf("fetch Vast %s offers: %w", strings.Join(gpus, ", "), err)
-	}
-	defer response.Body.Close()
-	data, err := io.ReadAll(io.LimitReader(response.Body, 4<<20))
-	if err != nil {
-		return nil, fmt.Errorf("read Vast %s offers: %w", strings.Join(gpus, ", "), err)
-	}
-	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return nil, fmt.Errorf("Vast %s offers returned HTTP %d", strings.Join(gpus, ", "), response.StatusCode)
+		return nil, err
 	}
 	var payload struct {
 		Offers []struct {
@@ -179,14 +142,13 @@ func (f VastFeed) fetchGPUs(ctx context.Context, gpus []string) (map[pricing.Req
 			GPUName      string  `json:"gpu_name"`
 			GPUs         int     `json:"num_gpus"`
 			Hourly       float64 `json:"dph_total"`
-			Geolocation  string  `json:"geolocation"`
 			Rentable     bool    `json:"rentable"`
 			Rented       bool    `json:"rented"`
 			Verification string  `json:"verification"`
 		}
 	}
 	if err = json.Unmarshal(data, &payload); err != nil {
-		return nil, fmt.Errorf("decode Vast %s offers: %w", strings.Join(gpus, ", "), err)
+		return nil, fmt.Errorf("decode Vast %s offers: %w", gpu, err)
 	}
 	now := time.Now().UTC()
 	if f.Now != nil {
@@ -194,47 +156,109 @@ func (f VastFeed) fetchGPUs(ctx context.Context, gpus []string) (map[pricing.Req
 	}
 	validFor := f.ValidFor
 	if validFor <= 0 {
-		validFor = 10 * time.Minute
+		validFor = 30 * time.Minute
 	}
 	prices := make(map[pricing.Request]pricing.Estimate)
-	allowed := make(map[string]struct{}, len(gpus))
-	for _, gpu := range gpus {
-		allowed[strings.ToLower(strings.TrimSpace(gpu))] = struct{}{}
-	}
 	for _, offer := range payload.Offers {
-		if _, ok := allowed[strings.ToLower(strings.TrimSpace(offer.GPUName))]; !ok || offer.GPUs < 1 || offer.Hourly <= 0 || !offer.Rentable || offer.Rented || !strings.EqualFold(offer.Verification, "verified") {
+		if !strings.EqualFold(strings.TrimSpace(offer.GPUName), gpu) || offer.GPUs != 1 || offer.Hourly <= 0 || !offer.Rentable || offer.Rented || !strings.EqualFold(offer.Verification, "verified") {
 			continue
 		}
-		region := vastRegion(offer.Geolocation)
-		key := pricing.Request{Cloud: "vast", Region: region, GPU: offer.GPUName, GPUCount: offer.GPUs, Replicas: 1}
-		estimate := pricing.Estimate{
+		key := pricing.Request{Cloud: "vast", Region: "global", GPU: gpu, GPUCount: 1, Replicas: 1}
+		prices[key] = pricing.Estimate{
 			Currency: "USD", Hourly: offer.Hourly,
 			Source:     defaultVastOffersURL + "#offer-" + strconv.FormatInt(offer.ID, 10),
 			ObservedAt: now, StaleAfter: validFor,
 		}
-		if current, ok := prices[key]; !ok || estimate.Hourly < current.Hourly {
-			prices[key] = estimate
-		}
+		break
 	}
 	return prices, nil
 }
 
-func cloneGPUQueryGroups(groups [][]string) [][]string {
-	cloned := make([][]string, 0, len(groups))
-	for _, group := range groups {
-		if len(group) > 0 {
-			cloned = append(cloned, append([]string(nil), group...))
-		}
+func (f *VastFeed) request(ctx context.Context, endpoint string, body []byte, gpu string) ([]byte, error) {
+	client := f.Client
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
 	}
-	return cloned
+	for attempt := 0; attempt < 3; attempt++ {
+		request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("prepare Vast %s offer request: %w", gpu, err)
+		}
+		request.Header.Set("Content-Type", "application/json")
+		request.Header.Set("Accept", "application/json")
+		request.Header.Set("User-Agent", "InferCrane-GPU-Market/1.0")
+		if strings.TrimSpace(f.APIKey) != "" {
+			request.Header.Set("Authorization", "Bearer "+f.APIKey)
+		}
+		response, err := client.Do(request)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			if attempt < 2 && waitContext(ctx, time.Duration(attempt+1)*250*time.Millisecond) {
+				continue
+			}
+			return nil, fmt.Errorf("fetch Vast %s offers: %w", gpu, err)
+		}
+		data, readErr := io.ReadAll(io.LimitReader(response.Body, 4<<20))
+		response.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("read Vast %s offers: %w", gpu, readErr)
+		}
+		if response.StatusCode >= 200 && response.StatusCode < 300 {
+			return data, nil
+		}
+		if attempt < 2 && retryableVastStatus(response.StatusCode) {
+			delay, ok := vastRetryDelay(response, attempt)
+			if ok && waitContext(ctx, delay) {
+				continue
+			}
+		}
+		return nil, fmt.Errorf("Vast %s offers returned HTTP %d", gpu, response.StatusCode)
+	}
+	return nil, fmt.Errorf("Vast %s offers exhausted retries", gpu)
 }
 
-func vastRegion(geolocation string) string {
-	parts := strings.Split(geolocation, ",")
-	for index := len(parts) - 1; index >= 0; index-- {
-		if value := strings.TrimSpace(parts[index]); value != "" {
-			return strings.ToUpper(value)
+func retryableVastStatus(status int) bool {
+	return status == http.StatusTooManyRequests || status == http.StatusBadGateway || status == http.StatusServiceUnavailable || status == http.StatusGatewayTimeout
+}
+
+func vastRetryDelay(response *http.Response, attempt int) (time.Duration, bool) {
+	if response.StatusCode != http.StatusTooManyRequests {
+		return time.Duration(attempt+1) * 250 * time.Millisecond, true
+	}
+	if value := strings.TrimSpace(response.Header.Get("Retry-After")); value != "" {
+		if seconds, err := strconv.Atoi(value); err == nil && seconds >= 0 {
+			return time.Duration(seconds)*time.Second + 100*time.Millisecond, true
+		}
+		if when, err := http.ParseTime(value); err == nil {
+			return time.Until(when) + 100*time.Millisecond, true
 		}
 	}
-	return "global"
+	if value := strings.TrimSpace(response.Header.Get("X-RateLimit-Reset")); value != "" {
+		if reset, err := strconv.ParseFloat(value, 64); err == nil {
+			delay := time.Until(time.Unix(int64(reset), 0)) + 100*time.Millisecond
+			if delay < 100*time.Millisecond {
+				delay = 100 * time.Millisecond
+			}
+			return delay, true
+		}
+	}
+	// A blind retry spends more of the same window. Let the scheduled runner
+	// retry instead when Vast does not state when the quota resets.
+	return 0, false
+}
+
+func waitContext(ctx context.Context, delay time.Duration) bool {
+	if delay <= 0 {
+		return true
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }

--- a/internal/priceingest/vast.go
+++ b/internal/priceingest/vast.go
@@ -88,27 +88,38 @@ func (f *VastFeed) Refresh(ctx context.Context, catalog *pricing.DynamicCatalog)
 	if f.cursor >= len(gpus) {
 		f.cursor = 0
 	}
-	completed := 0
-	for completed < shards {
+	attemptBudget := defaultVastShardsPerSweep
+	visited := 0
+	var failures []error
+	for visited < shards && attemptBudget > 0 {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		gpu := strings.TrimSpace(gpus[f.cursor])
 		if gpu == "" {
-			return errors.New("Vast GPU query is empty")
+			failures = append(failures, errors.New("Vast GPU query is empty"))
+			f.cursor = (f.cursor + 1) % len(gpus)
+			visited++
+			continue
 		}
-		prices, err := f.fetchGPU(ctx, gpu)
+		prices, err := f.fetchGPU(ctx, gpu, &attemptBudget)
 		if err != nil {
-			return err
+			failures = append(failures, err)
+		} else {
+			catalog.ReplaceProviderGPU("vast", gpu, prices)
 		}
-		catalog.ReplaceProviderGPU("vast", gpu, prices)
+		// A poisoned or unavailable shard must not block every GPU after it. Its
+		// last-good row remains untouched and it is retried on the next rotation.
 		f.cursor = (f.cursor + 1) % len(gpus)
-		completed++
+		visited++
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("Vast staged refresh had failed shards: %w", errors.Join(failures...))
 	}
 	return nil
 }
 
-func (f *VastFeed) fetchGPU(ctx context.Context, gpu string) (map[pricing.Request]pricing.Estimate, error) {
+func (f *VastFeed) fetchGPU(ctx context.Context, gpu string, attemptBudget *int) (map[pricing.Request]pricing.Estimate, error) {
 	endpoint := strings.TrimSpace(f.BaseURL)
 	if endpoint == "" {
 		endpoint = defaultVastOffersURL
@@ -132,7 +143,7 @@ func (f *VastFeed) fetchGPU(ctx context.Context, gpu string) (map[pricing.Reques
 		"allocated_storage": 5,
 		"order":             [][]string{{"dph_total", "asc"}},
 	})
-	data, err := f.request(ctx, endpoint, body, gpu)
+	data, err := f.request(ctx, endpoint, body, gpu, attemptBudget)
 	if err != nil {
 		return nil, err
 	}
@@ -174,12 +185,16 @@ func (f *VastFeed) fetchGPU(ctx context.Context, gpu string) (map[pricing.Reques
 	return prices, nil
 }
 
-func (f *VastFeed) request(ctx context.Context, endpoint string, body []byte, gpu string) ([]byte, error) {
+func (f *VastFeed) request(ctx context.Context, endpoint string, body []byte, gpu string, attemptBudget *int) ([]byte, error) {
 	client := f.Client
 	if client == nil {
 		client = &http.Client{Timeout: 15 * time.Second}
 	}
 	for attempt := 0; attempt < 3; attempt++ {
+		if attemptBudget == nil || *attemptBudget <= 0 {
+			return nil, fmt.Errorf("Vast %s offer request budget exhausted", gpu)
+		}
+		*attemptBudget--
 		request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 		if err != nil {
 			return nil, fmt.Errorf("prepare Vast %s offer request: %w", gpu, err)

--- a/internal/priceingest/vast_test.go
+++ b/internal/priceingest/vast_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -14,81 +15,78 @@ import (
 	"github.com/infercrane/infercrane/internal/pricing"
 )
 
-func TestVastFeedPublishesCheapestVerifiedRentableOffersAtomically(t *testing.T) {
+func TestVastFeedPublishesExactOneGPUGlobalFloor(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		if !strings.Contains(string(body), `"verified":{"eq":true}`) || !strings.Contains(string(body), `"rentable":{"eq":true}`) || !strings.Contains(string(body), `"rented":{"eq":false}`) {
-			t.Fatalf("unsafe Vast market query: %s", body)
-		}
 		var request map[string]any
-		_ = json.Unmarshal(body, &request)
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Error(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
 		gpu := request["gpu_name"].(map[string]any)["eq"].(string)
+		if request["limit"].(float64) != 1 || request["allocated_storage"].(float64) != 5 || request["external"].(map[string]any)["eq"] != false || request["num_gpus"].(map[string]any)["eq"].(float64) != 1 {
+			t.Errorf("unsafe or ambiguous Vast query: %s", body)
+		}
 		_, _ = w.Write([]byte(`{"offers":[` +
-			`{"id":11,"gpu_name":"` + gpu + `","num_gpus":1,"dph_total":1.3,"geolocation":"Texas, US","rentable":true,"rented":false,"verification":"verified"},` +
-			`{"id":12,"gpu_name":"` + gpu + `","num_gpus":1,"dph_total":0.9,"geolocation":"Virginia, US","rentable":true,"rented":false,"verification":"verified"},` +
-			`{"id":13,"gpu_name":"` + gpu + `","num_gpus":1,"dph_total":0.4,"geolocation":"Frankfurt, DE","rentable":false,"rented":false,"verification":"verified"},` +
-			`{"id":14,"gpu_name":"` + gpu + `","num_gpus":2,"dph_total":1.7,"geolocation":"Frankfurt, DE","rentable":true,"rented":false,"verification":"verified"}]}`))
+			`{"id":12,"gpu_name":"` + gpu + `","num_gpus":1,"dph_total":0.9,"rentable":true,"rented":false,"verification":"verified"},` +
+			`{"id":13,"gpu_name":"` + gpu + `","num_gpus":2,"dph_total":0.4,"rentable":true,"rented":false,"verification":"verified"}]}`))
 	}))
 	defer server.Close()
 	now := time.Date(2026, 9, 1, 5, 0, 0, 0, time.UTC)
 	catalog := pricing.NewDynamicCatalog(nil)
-	feed := VastFeed{BaseURL: server.URL, Client: server.Client(), GPUQueries: []string{"H100 SXM", "L40S"}, Workers: 2, Now: func() time.Time { return now }}
+	feed := VastFeed{BaseURL: server.URL, Client: server.Client(), GPUQueries: []string{"H100 SXM", "L40S"}, Now: func() time.Time { return now }}
 	if err := feed.Refresh(context.Background(), catalog); err != nil {
 		t.Fatal(err)
 	}
 	for _, gpu := range []string{"H100 SXM", "L40S"} {
-		single, err := catalog.Estimate(context.Background(), pricing.Request{Cloud: "vast", Region: "US", GPU: gpu, GPUCount: 1, Replicas: 1})
-		if err != nil || single.Hourly != 0.9 || !strings.HasSuffix(single.Source, "#offer-12") || single.ObservedAt != now {
-			t.Fatalf("unexpected cheapest %s offer: %#v err=%v", gpu, single, err)
-		}
-		multi, err := catalog.Estimate(context.Background(), pricing.Request{Cloud: "vast", Region: "DE", GPU: gpu, GPUCount: 2, Replicas: 1})
-		if err != nil || multi.Hourly != 1.7 {
-			t.Fatalf("unexpected multi-GPU %s offer: %#v err=%v", gpu, multi, err)
+		key := pricing.Request{Cloud: "vast", Region: "global", GPU: gpu, GPUCount: 1, Replicas: 1}
+		offer, err := catalog.Estimate(context.Background(), key)
+		if err != nil || offer.Hourly != 0.9 || !strings.HasSuffix(offer.Source, "#offer-12") || offer.ObservedAt != now {
+			t.Fatalf("unexpected %s floor: %#v err=%v", gpu, offer, err)
 		}
 	}
 }
 
-func TestVastFeedKeepsLastGoodSnapshotWhenSweepIsPartial(t *testing.T) {
-	var calls atomic.Int64
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if calls.Add(1) == 2 {
-			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+func TestVastFeedUpdatesCompletedShardsAndRetainsFailedShard(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var request map[string]any
+		_ = json.Unmarshal(body, &request)
+		gpu := request["gpu_name"].(map[string]any)["eq"].(string)
+		if gpu == "L40S" {
+			http.Error(w, "unavailable", http.StatusBadRequest)
 			return
 		}
-		_, _ = w.Write([]byte(`{"offers":[{"id":1,"gpu_name":"H100 SXM","num_gpus":1,"dph_total":2,"geolocation":"US","rentable":true,"rented":false,"verification":"verified"}]}`))
+		_, _ = w.Write([]byte(`{"offers":[{"id":1,"gpu_name":"` + gpu + `","num_gpus":1,"dph_total":2,"rentable":true,"rented":false,"verification":"verified"}]}`))
 	}))
 	defer server.Close()
-	key := pricing.Request{Cloud: "vast", Region: "US", GPU: "H100 SXM", GPUCount: 1, Replicas: 1}
+	h100 := pricing.Request{Cloud: "vast", Region: "global", GPU: "H100 SXM", GPUCount: 1, Replicas: 1}
+	l40s := pricing.Request{Cloud: "vast", Region: "global", GPU: "L40S", GPUCount: 1, Replicas: 1}
 	catalog := pricing.NewDynamicCatalog(nil)
-	catalog.ReplaceProvider("vast", map[pricing.Request]pricing.Estimate{key: {Currency: "USD", Source: "last-good", Hourly: 3, ObservedAt: time.Now(), StaleAfter: time.Hour}})
-	feed := VastFeed{BaseURL: server.URL, Client: server.Client(), GPUQueries: []string{"H100 SXM", "L40S"}, Workers: 1}
+	catalog.ReplaceProvider("vast", map[pricing.Request]pricing.Estimate{
+		h100: {Currency: "USD", Source: "old-h100", Hourly: 3, ObservedAt: time.Now(), StaleAfter: time.Hour},
+		l40s: {Currency: "USD", Source: "old-l40s", Hourly: 1, ObservedAt: time.Now(), StaleAfter: time.Hour},
+	})
+	feed := VastFeed{BaseURL: server.URL, Client: server.Client(), GPUQueries: []string{"H100 SXM", "L40S"}}
 	if err := feed.Refresh(context.Background(), catalog); err == nil {
-		t.Fatal("expected partial provider sweep to fail")
+		t.Fatal("expected failed L40S shard")
 	}
-	offer, err := catalog.Estimate(context.Background(), key)
-	if err != nil || offer.Source != "last-good" {
-		t.Fatalf("partial sweep replaced the last-good snapshot: %#v err=%v", offer, err)
+	snapshot := catalog.Snapshot()
+	if snapshot[h100].Hourly != 2 || snapshot[l40s].Source != "old-l40s" {
+		t.Fatalf("unexpected staged snapshot: %#v", snapshot)
 	}
 }
 
-func TestDefaultVastFeedUsesFiveGroupedMarketplaceQueries(t *testing.T) {
+func TestDefaultVastFeedLeavesRateLimitHeadroom(t *testing.T) {
 	var calls atomic.Int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		var request struct {
-			GPUName struct {
-				In []string `json:"in"`
-			} `json:"gpu_name"`
-		}
-		if err := json.Unmarshal(body, &request); err != nil {
-			t.Fatal(err)
-		}
-		if len(request.GPUName.In) < 2 {
-			t.Fatalf("default query was not grouped: %s", body)
-		}
+		var request map[string]any
+		_ = json.Unmarshal(body, &request)
+		gpu := request["gpu_name"].(map[string]any)["eq"].(string)
 		calls.Add(1)
-		gpu := request.GPUName.In[0]
-		_, _ = w.Write([]byte(`{"offers":[{"id":1,"gpu_name":"` + gpu + `","num_gpus":1,"dph_total":1,"geolocation":"US","rentable":true,"rented":false,"verification":"verified"}]}`))
+		_, _ = w.Write([]byte(`{"offers":[{"id":1,"gpu_name":"` + gpu + `","num_gpus":1,"dph_total":1,"rentable":true,"rented":false,"verification":"verified"}]}`))
 	}))
 	defer server.Close()
 
@@ -97,18 +95,38 @@ func TestDefaultVastFeedUsesFiveGroupedMarketplaceQueries(t *testing.T) {
 	if err := feed.Refresh(context.Background(), catalog); err != nil {
 		t.Fatal(err)
 	}
-	if got := calls.Load(); got != 5 {
-		t.Fatalf("default Vast refresh made %d requests; public limit is five", got)
+	if got := calls.Load(); got != 4 {
+		t.Fatalf("default Vast sweep made %d calls; want four plus one request of headroom", got)
 	}
-	if got := len(catalog.Snapshot()); got != 5 {
-		t.Fatalf("grouped refresh published %d offers, want 5", got)
+	if got := len(catalog.Snapshot()); got != 4 {
+		t.Fatalf("staged sweep published %d exact GPU floors, want 4", got)
 	}
 }
 
-func TestVastRegionUsesCountrySuffix(t *testing.T) {
-	for input, expected := range map[string]string{"Frankfurt, DE": "DE", ", US": "US", "": "global"} {
-		if got := vastRegion(input); got != expected {
-			t.Fatalf("vastRegion(%q)=%q want %q", input, got, expected)
+func TestVastFeedRetries429AtStatedReset(t *testing.T) {
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Unix(), 10))
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
 		}
+		_, _ = w.Write([]byte(`{"offers":[{"id":1,"gpu_name":"L40S","num_gpus":1,"dph_total":1,"rentable":true,"rented":false,"verification":"verified"}]}`))
+	}))
+	defer server.Close()
+	catalog := pricing.NewDynamicCatalog(nil)
+	feed := VastFeed{BaseURL: server.URL, Client: server.Client(), GPUQueries: []string{"L40S"}}
+	if err := feed.Refresh(context.Background(), catalog); err != nil {
+		t.Fatal(err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("429 retry calls=%d want 2", calls.Load())
+	}
+}
+
+func TestVastFeedDoesNotSendCredentialsToCustomEndpoint(t *testing.T) {
+	feed := VastFeed{APIKey: "secret", BaseURL: "http://example.test", GPUQueries: []string{"L40S"}}
+	if err := feed.Refresh(context.Background(), pricing.NewDynamicCatalog(nil)); err == nil || !strings.Contains(err.Error(), "untrusted") {
+		t.Fatalf("credential exfiltration boundary failed: %v", err)
 	}
 }

--- a/internal/priceingest/vast_test.go
+++ b/internal/priceingest/vast_test.go
@@ -124,6 +124,64 @@ func TestVastFeedRetries429AtStatedReset(t *testing.T) {
 	}
 }
 
+func TestVastFeedRetriesWithinSharedAttemptBudget(t *testing.T) {
+	var calls atomic.Int64
+	seen := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var request map[string]any
+		_ = json.Unmarshal(body, &request)
+		gpu := request["gpu_name"].(map[string]any)["eq"].(string)
+		seen[gpu]++
+		call := calls.Add(1)
+		if call <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`{"offers":[{"id":1,"gpu_name":"` + gpu + `","num_gpus":1,"dph_total":1,"rentable":true,"rented":false,"verification":"verified"}]}`))
+	}))
+	defer server.Close()
+	catalog := pricing.NewDynamicCatalog(nil)
+	feed := VastFeed{BaseURL: server.URL, Client: server.Client(), GPUQueries: []string{"B200", "H200", "H100 SXM", "L40S"}}
+	if err := feed.Refresh(context.Background(), catalog); err != nil {
+		t.Fatal(err)
+	}
+	if got := calls.Load(); got != 4 {
+		t.Fatalf("retrying sweep made %d calls, want hard budget of 4", got)
+	}
+	if seen["B200"] != 3 || seen["H200"] != 1 || seen["H100 SXM"] != 0 {
+		t.Fatalf("retry budget did not shorten the sweep: %#v", seen)
+	}
+}
+
+func TestVastFeedAdvancesPastPoisonedShard(t *testing.T) {
+	seen := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var request map[string]any
+		_ = json.Unmarshal(body, &request)
+		gpu := request["gpu_name"].(map[string]any)["eq"].(string)
+		seen[gpu]++
+		if gpu == "poison" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, _ = w.Write([]byte(`{"offers":[{"id":1,"gpu_name":"` + gpu + `","num_gpus":1,"dph_total":1,"rentable":true,"rented":false,"verification":"verified"}]}`))
+	}))
+	defer server.Close()
+	catalog := pricing.NewDynamicCatalog(nil)
+	feed := VastFeed{BaseURL: server.URL, Client: server.Client(), GPUQueries: []string{"first", "poison", "after"}, ShardsPerRefresh: 2}
+	if err := feed.Refresh(context.Background(), catalog); err == nil {
+		t.Fatal("expected poisoned shard to be reported")
+	}
+	if err := feed.Refresh(context.Background(), catalog); err != nil {
+		t.Fatal(err)
+	}
+	if seen["after"] == 0 {
+		t.Fatalf("shard after persistent failure was never reached: %#v", seen)
+	}
+}
+
 func TestVastFeedDoesNotSendCredentialsToCustomEndpoint(t *testing.T) {
 	feed := VastFeed{APIKey: "secret", BaseURL: "http://example.test", GPUQueries: []string{"L40S"}}
 	if err := feed.Refresh(context.Background(), pricing.NewDynamicCatalog(nil)); err == nil || !strings.Contains(err.Error(), "untrusted") {

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -91,6 +91,28 @@ func (c *DynamicCatalog) ReplaceProvider(provider string, prices map[Request]Est
 	}
 }
 
+// ReplaceProviderGPU atomically replaces one provider/GPU shard. Marketplace
+// APIs with strict request budgets can refresh exact accelerator SKUs over
+// several rate-limit windows without presenting a capped mixed response as a
+// complete provider snapshot.
+func (c *DynamicCatalog) ReplaceProviderGPU(provider, gpu string, prices map[Request]Estimate) {
+	if c == nil || provider == "" || gpu == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for request := range c.feed {
+		if request.Cloud == provider && request.GPU == gpu {
+			delete(c.feed, request)
+		}
+	}
+	for request, estimate := range prices {
+		if request.Cloud == provider && request.GPU == gpu {
+			c.feed[request] = estimate
+		}
+	}
+}
+
 func (c *DynamicCatalog) Snapshot() map[Request]Estimate {
 	if c == nil {
 		return nil

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -20,3 +20,26 @@ func TestCatalogAndStaleness(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestDynamicCatalogReplacesOneProviderGPUShard(t *testing.T) {
+	catalog := NewDynamicCatalog(nil)
+	h100 := Request{Cloud: "vast", Region: "global", GPU: "H100 SXM", GPUCount: 1, Replicas: 1}
+	l40s := Request{Cloud: "vast", Region: "global", GPU: "L40S", GPUCount: 1, Replicas: 1}
+	catalog.ReplaceProvider("vast", map[Request]Estimate{
+		h100: {Hourly: 2, Source: "old-h100"},
+		l40s: {Hourly: 1, Source: "old-l40s"},
+	})
+	catalog.ReplaceProviderGPU("vast", "H100 SXM", map[Request]Estimate{
+		h100: {Hourly: 1.5, Source: "new-h100"},
+	})
+
+	snapshot := catalog.Snapshot()
+	if snapshot[h100].Source != "new-h100" || snapshot[l40s].Source != "old-l40s" {
+		t.Fatalf("unexpected shard replacement: %#v", snapshot)
+	}
+	catalog.ReplaceProviderGPU("vast", "H100 SXM", nil)
+	snapshot = catalog.Snapshot()
+	if _, ok := snapshot[h100]; ok || snapshot[l40s].Source != "old-l40s" {
+		t.Fatalf("empty shard did not remove only H100: %#v", snapshot)
+	}
+}

--- a/internal/provideridentity/gpu.go
+++ b/internal/provideridentity/gpu.go
@@ -8,7 +8,32 @@ import "strings"
 // GPUTypeID returns the exact provider resource identifier for a reviewed
 // alias. Unknown values remain unchanged instead of being guessed.
 func GPUTypeID(provider, gpu string) string {
-	if !strings.EqualFold(strings.TrimSpace(provider), "runpod") {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "vast" {
+		switch strings.ToUpper(strings.TrimSpace(gpu)) {
+		case "H100", "H100 SXM":
+			return "H100 SXM"
+		case "H100 PCIE":
+			return "H100 PCIE"
+		case "H100 NVL":
+			return "H100 NVL"
+		case "H200", "H200 SXM":
+			return "H200"
+		case "H200 NVL":
+			return "H200 NVL"
+		case "A100", "A100 80GB", "A100 SXM4":
+			return "A100 SXM4"
+		case "A100 PCIE", "A100 80GB PCIE":
+			return "A100 PCIE"
+		case "T4", "TESLA T4":
+			return "Tesla T4"
+		case "V100", "TESLA V100":
+			return "Tesla V100"
+		default:
+			return gpu
+		}
+	}
+	if provider != "runpod" {
 		return gpu
 	}
 	switch strings.ToUpper(strings.TrimSpace(gpu)) {
@@ -47,7 +72,7 @@ func GPUTypeID(provider, gpu string) string {
 // secure-cloud gpuTypes quote is global; launch capacity is checked separately
 // for the requested data center.
 func PriceRegion(provider, region string) string {
-	if strings.EqualFold(strings.TrimSpace(provider), "runpod") {
+	if strings.EqualFold(strings.TrimSpace(provider), "runpod") || strings.EqualFold(strings.TrimSpace(provider), "vast") {
 		return "global"
 	}
 	return region

--- a/internal/provideridentity/gpu_test.go
+++ b/internal/provideridentity/gpu_test.go
@@ -26,3 +26,20 @@ func TestProviderIdentityDoesNotGuessOtherClouds(t *testing.T) {
 		t.Fatalf("RunPod price scope=%q", got)
 	}
 }
+
+func TestVastAliasesResolveToExactMarketplaceName(t *testing.T) {
+	for input, expected := range map[string]string{
+		"H100":      "H100 SXM",
+		"H100 PCIe": "H100 PCIE",
+		"A100 80GB": "A100 SXM4",
+		"T4":        "Tesla T4",
+		"L40S":      "L40S",
+	} {
+		if got := GPUTypeID("vast", input); got != expected {
+			t.Fatalf("GPUTypeID(vast, %q)=%q, want %q", input, got, expected)
+		}
+	}
+	if got := PriceRegion("vast", "US"); got != "global" {
+		t.Fatalf("Vast price scope=%q", got)
+	}
+}

--- a/scripts/test-fly-config.sh
+++ b/scripts/test-fly-config.sh
@@ -27,7 +27,7 @@ assert env["INFERCRANE_HOST"] == "0.0.0.0"
 assert env["INFERCRANE_PORT"] == "8080"
 assert env["INFERCRANE_SKYPILOT_API"] == "auto"
 assert env["SKYPILOT_DISABLE_USAGE_COLLECTION"] == "1"
-assert env["INFERCRANE_GPU_PRICE_SYNC_SECONDS"] == "3600"
+assert env["INFERCRANE_GPU_PRICE_SYNC_SECONDS"] == "75"
 assert "INFERCRANE_INSTANCE_ID" not in env, "replica identity must default to the unique machine hostname"
 
 service = data["http_service"]


### PR DESCRIPTION
## Outcome
Replace capped mixed-family Vast queries with exact, rate-budgeted market shards.

## Design
- query one exact canonical GPU and `num_gpus=1` per request
- request only the globally cheapest verified, non-external, rentable offer
- fix price semantics at 5 GiB allocated storage
- refresh four shards per provider window, leaving one call of headroom
- persist the cursor and atomically replace only the completed GPU shard
- preserve failed shards as last-good observations
- honor `Retry-After` / `X-RateLimit-Reset` for 429 and retry transient gateway failures
- rotate 36 inference-relevant canonical Vast SKUs every 75 seconds
- add Vast alias and global price-scope mappings
- make the configured sync interval authoritative

## Why
Vast caps search responses at 64 rows. Grouping several GPU families under a global price sort can return HTTP 200 while silently omitting an expensive family or a GPU-count tuple. Exact shards make each published floor complete for its declared scope.

## Verification
- direct Vast query returned one current exact L40S/1-GPU offer and rate-limit headers
- `go test ./...`
- focused tests cover exact filters, per-shard retention, call-budget headroom, 429 reset retry, credential boundary, alias mapping, cadence bounds, and shard replacement
- `git diff --check`