### PR TITLE
fix(pricing): accept Azure default HTTPS pagination port

### DIFF
--- a/internal/priceingest/azure.go
+++ b/internal/priceingest/azure.go
@@ -314,5 +314,23 @@ func sameAzureOrigin(endpoint, candidate *url.URL) bool {
 	if endpoint == nil || candidate == nil || candidate.Scheme != "https" && candidate.Scheme != "http" {
 		return false
 	}
-	return strings.EqualFold(endpoint.Scheme, candidate.Scheme) && strings.EqualFold(endpoint.Host, candidate.Host)
+	return strings.EqualFold(endpoint.Scheme, candidate.Scheme) &&
+		strings.EqualFold(endpoint.Hostname(), candidate.Hostname()) &&
+		effectivePort(endpoint) == effectivePort(candidate)
+}
+
+func effectivePort(value *url.URL) string {
+	if value == nil {
+		return ""
+	}
+	if port := value.Port(); port != "" {
+		return port
+	}
+	if strings.EqualFold(value.Scheme, "https") {
+		return "443"
+	}
+	if strings.EqualFold(value.Scheme, "http") {
+		return "80"
+	}
+	return ""
 }

--- a/internal/priceingest/azure_test.go
+++ b/internal/priceingest/azure_test.go
@@ -155,3 +155,16 @@ func TestAzureRetailQueryIsStableAndOfficial(t *testing.T) {
 		}
 	}
 }
+
+func TestAzurePaginationAcceptsExplicitDefaultPortOnly(t *testing.T) {
+	endpoint, _ := url.Parse("https://prices.azure.com/api/retail/prices")
+	defaultPort, _ := url.Parse("https://prices.azure.com:443/api/retail/prices?$skip=1000")
+	wrongPort, _ := url.Parse("https://prices.azure.com:444/api/retail/prices?$skip=1000")
+	foreignHost, _ := url.Parse("https://example.com:443/api/retail/prices?$skip=1000")
+	if !sameAzureOrigin(endpoint, defaultPort) {
+		t.Fatal("Azure's explicit HTTPS default port was rejected")
+	}
+	if sameAzureOrigin(endpoint, wrongPort) || sameAzureOrigin(endpoint, foreignHost) {
+		t.Fatal("untrusted Azure pagination origin was accepted")
+	}
+}


### PR DESCRIPTION
## Summary
- normalize Azure pagination origins by scheme, hostname, and effective port
- accept Microsoft's explicit `:443` continuation links
- continue rejecting foreign hosts and non-default ports

## Production evidence
Azure returned `https://prices.azure.com:443/...` in `NextPageLink`; the prior strict host-string comparison failed closed.

## Validation
- `go test ./internal/priceingest`
- `go test -race -count=1 ./internal/priceingest`
- `go test ./...`
- `go vet ./...`
