### PR TITLE
fix(pricing): keep provider APIs authoritative

### DIFF
--- a/cmd/infercrane/main.go
+++ b/cmd/infercrane/main.go
@@ -4155,6 +4155,28 @@ func serve(parent context.Context, cfg config.Config, s *store.Store) error {
 		}, hyperscalerSyncInterval, func(err error) {
 			logger.Warn("provider-native Azure Retail Prices refresh failed", "error", err)
 		})
+		// Google requires a restricted API key even for its public Billing
+		// Catalog. The full Compute Engine catalog is paginated, so refresh it in
+		// the background and publish only after every bounded page succeeds.
+		// Catalog prices are GPU billing components, never stock evidence.
+		if gcpBillingAPIKey := strings.TrimSpace(os.Getenv("GOOGLE_CLOUD_BILLING_API_KEY")); gcpBillingAPIKey != "" {
+			gcpFeed := priceingest.GCPFeed{APIKey: gcpBillingAPIKey, ValidFor: hyperscalerValidFor}
+			go func() {
+				gcpCtx, gcpCancel := context.WithTimeout(ctx, 2*time.Minute)
+				gcpErr := gcpFeed.Refresh(gcpCtx, priceCatalog)
+				gcpCancel()
+				if gcpErr != nil {
+					logger.Warn("initial provider-native Google Cloud Billing Catalog refresh failed", "error", gcpErr)
+				}
+				priceingest.RunProviderFeed(ctx, func(refreshCtx context.Context) error {
+					refreshCtx, cancel := context.WithTimeout(refreshCtx, 2*time.Minute)
+					defer cancel()
+					return gcpFeed.Refresh(refreshCtx, priceCatalog)
+				}, hyperscalerSyncInterval, func(err error) {
+					logger.Warn("provider-native Google Cloud Billing Catalog refresh failed", "error", err)
+				})
+			}()
+		}
 		// AWS's official regional EC2 catalog is hundreds of MB. Stream it in the
 		// background so a cold catalog download can never delay API readiness.
 		awsFeed := priceingest.AWSFeed{Regions: []string{"us-east-1"}, ValidFor: hyperscalerValidFor}

--- a/compose.production.runpod.yaml
+++ b/compose.production.runpod.yaml
@@ -1,7 +1,7 @@
 services:
   infercrane:
     environment:
-      INFERCRANE_SKYPILOT_API: enabled
+      INFERCRANE_SKYPILOT_API: disabled
       INFERCRANE_RUNPOD_SERVERLESS_TEMPLATE_ID: ${INFERCRANE_RUNPOD_SERVERLESS_TEMPLATE_ID:-}
       INFERCRANE_RUNPOD_CONTAINER_DISK_GIB: ${INFERCRANE_RUNPOD_CONTAINER_DISK_GIB:-100}
       INFERCRANE_RUNPOD_ARTIFACT_CACHE_POLICY: ${INFERCRANE_RUNPOD_ARTIFACT_CACHE_POLICY:-prefer}
@@ -10,9 +10,7 @@ services:
       RUNPOD_API_KEY_FILE: /run/secrets/runpod-api-key
     volumes:
       - ${RUNPOD_KEY_FILE:?set RUNPOD_KEY_FILE}:/run/secrets/runpod-api-key:ro
-      - skypilot-state:/home/app/.sky
       - runpod-state:/home/app/.runpod
 
 volumes:
   runpod-state:
-  skypilot-state:

--- a/deploy/fly/control-plane.toml
+++ b/deploy/fly/control-plane.toml
@@ -17,9 +17,10 @@ kill_timeout = 35
   INFERCRANE_HOST = "0.0.0.0"
   INFERCRANE_PORT = "8080"
   INFERCRANE_HOSTED_AUTH_AUTO_PROVISION = "true"
-  # SkyPilot starts a local API process. Keep the provider list credential-gated
-  # and give the machine enough memory for the control plane plus that process.
-  INFERCRANE_SKYPILOT_API = "auto"
+  # Native provider adapters are the production default. SkyPilot remains an
+  # explicit manifest-driven long-tail execution option; it is not a pricing
+  # source and is not started merely because a RunPod credential exists.
+  INFERCRANE_SKYPILOT_API = "disabled"
   SKYPILOT_DISABLE_USAGE_COLLECTION = "1"
   # Provider-native price feeds rotate exact marketplace shards while staying
   # below provider request budgets. This is observation, not capacity polling.
@@ -49,7 +50,6 @@ kill_timeout = 35
 
 [[vm]]
   size = "shared-cpu-1x"
-  # SkyPilot recommends at least 2 GiB for its local API server. The production
-  # readiness check is not considered healthy until both processes have started.
+  # Leave headroom for reconciliation, pricing ingestion, and API traffic.
   memory = "2gb"
   processes = ["app"]

--- a/docs/architecture/data-flows.md
+++ b/docs/architecture/data-flows.md
@@ -39,8 +39,10 @@
 ## Provisioning
 
 The durable workflow resolves a registered provider backend by cloud, runtime, and persisted adapter
-identity. RunPod elastic delegates to SkyPilot. AWS EC2 delegates API compatibility and STS to AWS
-CLI v2 while InferCrane retains idempotency, adoption, private-network, tag, and deletion policy.
+identity. RunPod elastic uses the native Pods adapter by default. Explicit SkyPilot manifests may
+add long-tail execution targets, but do not supply InferCrane's price authority. AWS EC2 delegates
+API compatibility and STS to AWS CLI v2 while InferCrane retains idempotency, adoption,
+private-network, tag, and deletion policy.
 Both return a target that follows the same runtime and reconciliation path as an existing worker.
 
 ## Governed external fallback

--- a/docs/integrations/runpod.md
+++ b/docs/integrations/runpod.md
@@ -49,7 +49,8 @@ plan or local simulation is not real-provider qualification.
     ```
 
     The base production profile is provider-neutral. The additional overlay mounts the key
-    read-only and enables the RunPod/SkyPilot adapter explicitly.
+    read-only and enables native RunPod Pods and optional provider-native Serverless. SkyPilot is
+    not enabled implicitly by a RunPod credential.
 
     Large custom OCI workloads may need more than the default 100 GiB container disk. Set, for
     example, `INFERCRANE_RUNPOD_CONTAINER_DISK_GIB=500` in the same private environment file. Disk

--- a/docs/production.md
+++ b/docs/production.md
@@ -136,9 +136,9 @@ docker compose --env-file /private/path/infercrane.env \
 ```
 
 The overlay mounts the RunPod key read-only and persists only the provider client's local state.
-The entrypoint configures the RunPod client without printing the key and supervises SkyPilot only
-when this overlay explicitly enables it. `INFERCRANE_SKYPILOT_API=disabled` is available for
-diagnostics, but disables RunPod elastic provisioning from that control-plane instance.
+The entrypoint configures the RunPod client without printing the key. Native RunPod Pods remain
+available while `INFERCRANE_SKYPILOT_API=disabled`; SkyPilot starts only for an explicit provider
+manifest in an operator-owned overlay.
 
 AWS and Kubernetes follow the same explicit composition pattern:
 
@@ -164,7 +164,7 @@ context/namespace/RBAC boundary. Never combine overlays merely because their cli
 the image; enable only providers this control-plane instance is intended to operate.
 
 The real RunPod qualification stack is isolated from the development Compose stack. It persists
-PostgreSQL, RunPod configuration, and SkyPilot state across control-plane restarts:
+PostgreSQL and RunPod client configuration across control-plane restarts:
 
 ```sh
 export RUNPOD_KEY_FILE=/absolute/path/to/runpod-key
@@ -175,13 +175,14 @@ docker compose -p infercrane-runpod -f compose.runpod-acceptance.yaml up --build
 
 This command starts the control plane but does not provision a GPU or create a Serverless endpoint.
 Provider mutation begins only after a deployment is submitted. The key file is mounted read-only;
-the entrypoint configures SkyPilot/RunPod and passes the key only to its runtime child processes so
-Serverless API calls work without declaring the secret value in Compose environment metadata.
+the entrypoint configures the RunPod client and passes the key only to its runtime child processes
+so Serverless API calls work without declaring the secret value in Compose environment metadata.
 
-The production image includes the local `git`, OpenSSH, and `rsync` executables required by
-SkyPilot's task packaging and remote synchronization paths. When the RunPod overlay is enabled,
-the entrypoint supervises SkyPilot's foreground API server and exits if that required subprocess
-stops. Without that overlay, InferCrane is executed directly and has no SkyPilot subprocess.
+The production image still includes the executables required by the optional SkyPilot execution
+path. The normal RunPod overlay executes InferCrane directly with no SkyPilot subprocess. An
+operator that enables SkyPilot must provide `INFERCRANE_SKYPILOT_PROVIDERS_JSON`; the entrypoint
+then supervises its foreground API server and exits if that required subprocess stops.
+
 - `INFERCRANE_INSTANCE_ID`: stable and unique per control-plane replica.
 - `INFERCRANE_DATABASE_MAX_OPEN` and `INFERCRANE_DATABASE_MAX_IDLE`: size these with the total
   replica count below PostgreSQL's connection budget or place PgBouncer in transaction mode.

--- a/docs/provider-setup.md
+++ b/docs/provider-setup.md
@@ -145,7 +145,10 @@ the actual launch or a provider-specific read-only probe supplies evidence.
 
 ## RunPod
 
-Set a scoped `RUNPOD_API_KEY` on the control plane and configure SkyPilot's RunPod credentials for elastic workers. Run `infercrane doctor --cloud` before provisioning.
+Set a scoped `RUNPOD_API_KEY` on the control plane. Native RunPod Pods are the default elastic
+worker path and do not depend on a third-party catalog. Declare a SkyPilot provider manifest only
+when intentionally using its long-tail execution path. Run `infercrane doctor --cloud` before
+provisioning.
 
 For Serverless, create a RunPod vLLM template with `MODEL_NAME`, immutable `MODEL_REVISION`, and `RAW_OPENAI_OUTPUT=1`, then set `INFERCRANE_RUNPOD_SERVERLESS_TEMPLATE_ID`. `infercrane doctor --serverless` reads and validates the template without creating an endpoint.
 
@@ -168,6 +171,12 @@ and deterministic adoption identity. Configuration is all-or-nothing. See
 [GCP Compute BYOC](/integrations/gcp-compute). MIG, GKE, and Vertex remain separate registered,
 deferred profiles rather than implicit aliases. Run `infercrane doctor --gcp` before provisioning;
 it performs only identity and Compute API reads.
+
+Google's public Cloud Billing Catalog requires a consumer API key. To add current GCP GPU billing
+components to the price market, create a key restricted to `cloudbilling.googleapis.com` and set it
+as `GOOGLE_CLOUD_BILLING_API_KEY` on the control plane. This key is used only for the official
+Compute Engine SKU catalog. The resulting rows are GPU-device rates, not complete VM quotes or
+capacity evidence; CPU, memory, disk, network, quota, and launchability remain separate facts.
 
 ## CoreWeave
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -453,16 +453,10 @@ func load(requireAPIKey bool) (Config, error) {
 		ShutdownTimeout: time.Duration(shutdownSeconds) * time.Second, RequestRetention: time.Duration(retentionHours) * time.Hour,
 		GPUPriceSyncInterval: time.Duration(gpuPriceSyncSeconds) * time.Second,
 	}
-	// Preserve the existing RunPod default while moving the execution boundary
-	// to provider-neutral manifests. Other clouds must be declared explicitly.
-	if len(config.SkyPilotProviders) == 0 && config.RunPodAPIKey != "" {
-		config.SkyPilotProviders = []SkyPilotProvider{{
-			Cloud:         "runpod",
-			Label:         "RunPod",
-			Runtimes:      []string{"vllm", "sglang", "custom-oci"},
-			CredentialEnv: []string{"RUNPOD_API_KEY"},
-		}}
-	}
+	// SkyPilot is an explicit long-tail execution boundary. A RunPod API key by
+	// itself selects the native RunPod adapter and must not silently opt the
+	// control plane into SkyPilot's independently refreshed provider catalogs.
+	// Operators enable SkyPilot only by declaring provider manifests.
 	if config.Port < 1 || config.Port > 65535 {
 		return Config{}, fmt.Errorf("INFERCRANE_PORT must be between 1 and 65535")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -137,12 +137,17 @@ func TestSkyPilotExecutionBoundary(t *testing.T) {
 
 	t.Setenv("INFERCRANE_SKYPILOT_API", "auto")
 	cfg, err = Load()
-	if err != nil || !cfg.SkyPilotEnabled() {
-		t.Fatalf("auto SkyPilot did not follow RunPod credentials: enabled=%v err=%v", cfg.SkyPilotEnabled(), err)
+	if err != nil {
+		t.Fatal(err)
 	}
-	providers := cfg.ConfiguredSkyPilotProviders()
-	if len(providers) != 1 || providers[0].Cloud != "runpod" || strings.Join(providers[0].Runtimes, ",") != "vllm,sglang,custom-oci" {
-		t.Fatalf("unexpected RunPod SkyPilot defaults: %#v", providers)
+	if cfg.SkyPilotEnabled() || len(cfg.ConfiguredSkyPilotProviders()) != 0 {
+		t.Fatalf("RunPod credentials silently enabled SkyPilot: cfg=%#v", cfg)
+	}
+
+	t.Setenv("INFERCRANE_SKYPILOT_PROVIDERS_JSON", `[{"cloud":"runpod","runtimes":["vllm","sglang","custom-oci"],"credential_env":["RUNPOD_API_KEY"]}]`)
+	cfg, err = Load()
+	if err != nil || !cfg.SkyPilotEnabled() {
+		t.Fatalf("explicit RunPod SkyPilot manifest was not enabled: enabled=%v err=%v", cfg.SkyPilotEnabled(), err)
 	}
 
 	t.Setenv("INFERCRANE_SKYPILOT_API", "invalid")

--- a/internal/priceingest/gcp.go
+++ b/internal/priceingest/gcp.go
@@ -1,0 +1,358 @@
+package priceingest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/pricing"
+)
+
+const (
+	defaultGCPCatalogURL      = "https://cloudbilling.googleapis.com/v1/services/6F81-5844-456A/skus"
+	defaultGCPPageSize        = 5000
+	defaultGCPRequestLimit    = 12
+	maximumGCPRequestLimit    = 16
+	maximumGCPResponseBytes   = 32 << 20
+	gcpCatalogRefreshTimeout  = 2 * time.Minute
+	gcpComputeEngineServiceID = "6F81-5844-456A"
+)
+
+var (
+	gcpSKUIDPattern  = regexp.MustCompile(`^[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}$`)
+	gcpRegionPattern = regexp.MustCompile(`^[a-z][a-z0-9]*(?:-[a-z0-9]+)+[0-9]$`)
+)
+
+// reviewedGCPGPUDescriptions maps the exact, first-party Compute Engine billing
+// description stem to the accelerator resource identifier accepted by the GCP
+// Compute API. A prefix or model substring is intentionally insufficient: new
+// virtual-workstation, Spot, DWS, or differently provisioned SKUs must be
+// reviewed before they can become comparable price evidence.
+var reviewedGCPGPUDescriptions = map[string]string{
+	"Nvidia Tesla T4 GPU":          "nvidia-tesla-t4",
+	"Nvidia Tesla P4 GPU":          "nvidia-tesla-p4",
+	"Nvidia Tesla P100 GPU":        "nvidia-tesla-p100",
+	"Nvidia Tesla V100 GPU":        "nvidia-tesla-v100",
+	"Nvidia Tesla A100 GPU":        "nvidia-tesla-a100",
+	"Nvidia Tesla A100 80GB GPU":   "nvidia-a100-80gb",
+	"Nvidia L4 GPU":                "nvidia-l4",
+	"Nvidia H100 80GB GPU":         "nvidia-h100-80gb",
+	"Nvidia H100 80GB Mega GPU":    "nvidia-h100-mega-80gb",
+	"H200 141GB GPU":               "nvidia-h200-141gb",
+	"A4 Nvidia B200 (1 gpu slice)": "nvidia-b200",
+	"RTX 6000 96GB":                "nvidia-rtx-pro-6000",
+}
+
+// GCPFeed reads current public USD on-demand GPU-device rates from the Google
+// Cloud Billing Catalog API. These rates are billing components, not complete
+// VM prices: accelerator-optimized VMs can also bill CPU, RAM, local SSD, and
+// networking. Catalog publication is likewise not evidence of stock, quota, or
+// exact-zone deployability; the GCP launch probe owns those checks.
+//
+// Google's public catalog requires an API consumer identity. APIKey should be a
+// restricted key for cloudbilling.googleapis.com. BaseURL exists for tests; a
+// real API key is never sent anywhere except the official HTTPS origin.
+type GCPFeed struct {
+	APIKey       string
+	BaseURL      string
+	Client       *http.Client
+	ValidFor     time.Duration
+	Now          func() time.Time
+	RequestLimit int
+}
+
+type gcpCatalogPage struct {
+	SKUs          []gcpCatalogSKU `json:"skus"`
+	NextPageToken string          `json:"nextPageToken"`
+}
+
+type gcpCatalogSKU struct {
+	Name                string           `json:"name"`
+	SKUID               string           `json:"skuId"`
+	Description         string           `json:"description"`
+	ServiceRegions      []string         `json:"serviceRegions"`
+	ServiceProviderName string           `json:"serviceProviderName"`
+	Category            gcpSKUCategory   `json:"category"`
+	PricingInfo         []gcpPricingInfo `json:"pricingInfo"`
+	GeoTaxonomy         struct {
+		Type    string   `json:"type"`
+		Regions []string `json:"regions"`
+	} `json:"geoTaxonomy"`
+}
+
+type gcpSKUCategory struct {
+	ServiceDisplayName string `json:"serviceDisplayName"`
+	ResourceFamily     string `json:"resourceFamily"`
+	ResourceGroup      string `json:"resourceGroup"`
+	UsageType          string `json:"usageType"`
+}
+
+type gcpPricingInfo struct {
+	EffectiveTime     string               `json:"effectiveTime"`
+	PricingExpression gcpPricingExpression `json:"pricingExpression"`
+}
+
+type gcpPricingExpression struct {
+	UsageUnit       string        `json:"usageUnit"`
+	DisplayQuantity float64       `json:"displayQuantity"`
+	TieredRates     []gcpTierRate `json:"tieredRates"`
+}
+
+type gcpTierRate struct {
+	StartUsageAmount float64  `json:"startUsageAmount"`
+	UnitPrice        gcpMoney `json:"unitPrice"`
+}
+
+type gcpMoney struct {
+	CurrencyCode string `json:"currencyCode"`
+	Units        string `json:"units"`
+	Nanos        int64  `json:"nanos"`
+}
+
+type gcpCandidate struct {
+	estimate  pricing.Estimate
+	effective time.Time
+}
+
+func (f GCPFeed) Refresh(ctx context.Context, catalog *pricing.DynamicCatalog) error {
+	if catalog == nil {
+		return errors.New("GPU price catalog is nil")
+	}
+	endpoint, official, err := gcpCatalogEndpoint(f.BaseURL)
+	if err != nil {
+		return err
+	}
+	apiKey := strings.TrimSpace(f.APIKey)
+	if official && apiKey == "" {
+		return errors.New("Google Cloud Billing Catalog API key is required")
+	}
+	if apiKey != "" && !official {
+		return errors.New("refusing to send Google Cloud Billing credentials to an untrusted endpoint")
+	}
+	requestLimit := f.RequestLimit
+	if requestLimit <= 0 {
+		requestLimit = defaultGCPRequestLimit
+	}
+	if requestLimit > maximumGCPRequestLimit {
+		requestLimit = maximumGCPRequestLimit
+	}
+	client := f.Client
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	now := time.Now().UTC()
+	if f.Now != nil {
+		now = f.Now().UTC()
+	}
+	validFor := f.ValidFor
+	if validFor <= 0 {
+		validFor = 6 * time.Hour
+	}
+
+	refreshCtx, cancel := context.WithTimeout(ctx, gcpCatalogRefreshTimeout)
+	defer cancel()
+	candidates := make(map[pricing.Request]gcpCandidate)
+	seenTokens := map[string]struct{}{"": {}}
+	pageToken := ""
+	for page := 0; ; page++ {
+		if page >= requestLimit {
+			return fmt.Errorf("Google Cloud Billing Catalog pagination exceeded the %d-request refresh budget", requestLimit)
+		}
+		pageURL := *endpoint
+		query := pageURL.Query()
+		query.Set("currencyCode", "USD")
+		query.Set("pageSize", strconv.Itoa(defaultGCPPageSize))
+		if pageToken != "" {
+			query.Set("pageToken", pageToken)
+		}
+		if apiKey != "" {
+			query.Set("key", apiKey)
+		}
+		pageURL.RawQuery = query.Encode()
+		payload, fetchErr := fetchGCPCatalogPage(refreshCtx, client, endpoint, &pageURL)
+		if fetchErr != nil {
+			return fetchErr
+		}
+		for _, sku := range payload.SKUs {
+			gpu, ok := reviewedGCPGPU(sku.Description)
+			if !ok || !validGCPCatalogSKU(sku) {
+				continue
+			}
+			hourly, effective, ok := currentGCPHourlyPrice(sku.PricingInfo, now)
+			if !ok {
+				continue
+			}
+			fragment := url.Values{"billing_component": {"gpu"}, "sku_id": {sku.SKUID}}.Encode()
+			source := defaultGCPCatalogURL + "?currencyCode=USD&pageSize=" + strconv.Itoa(defaultGCPPageSize) + "#" + fragment
+			for _, region := range gcpSKURegions(sku) {
+				request := pricing.Request{Cloud: "gcp", Region: region, GPU: gpu, GPUCount: 1, Replicas: 1}
+				estimate := pricing.Estimate{Currency: "USD", Hourly: hourly, Source: source, ObservedAt: now, StaleAfter: validFor}
+				prior, found := candidates[request]
+				if !found || effective.After(prior.effective) || effective.Equal(prior.effective) && estimate.Hourly < prior.estimate.Hourly {
+					candidates[request] = gcpCandidate{estimate: estimate, effective: effective}
+				}
+			}
+		}
+		next := strings.TrimSpace(payload.NextPageToken)
+		if next == "" {
+			break
+		}
+		if len(next) > 4096 {
+			return errors.New("Google Cloud Billing Catalog returned an oversized page token")
+		}
+		if _, duplicate := seenTokens[next]; duplicate {
+			return errors.New("Google Cloud Billing Catalog returned a repeated page token")
+		}
+		seenTokens[next] = struct{}{}
+		pageToken = next
+	}
+
+	prices := make(map[pricing.Request]pricing.Estimate, len(candidates))
+	for request, candidate := range candidates {
+		prices[request] = candidate.estimate
+	}
+	if len(prices) == 0 {
+		return errors.New("Google Cloud Billing Catalog returned no current reviewed on-demand GPU prices")
+	}
+	// Publication is deliberately below the complete pagination loop. A partial,
+	// oversized, timed-out, or unauthenticated refresh keeps the last-good GCP
+	// snapshot byte-for-byte intact.
+	catalog.ReplaceProvider("gcp", prices)
+	return nil
+}
+
+func gcpCatalogEndpoint(raw string) (*url.URL, bool, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		value = defaultGCPCatalogURL
+	}
+	endpoint, err := url.Parse(value)
+	if err != nil || endpoint.Scheme != "https" && endpoint.Scheme != "http" || endpoint.Host == "" || endpoint.User != nil || endpoint.Fragment != "" {
+		return nil, false, errors.New("Google Cloud Billing Catalog endpoint is invalid")
+	}
+	official := strings.EqualFold(endpoint.Scheme, "https") && strings.EqualFold(endpoint.Hostname(), "cloudbilling.googleapis.com") && effectivePort(endpoint) == "443" && endpoint.Path == "/v1/services/"+gcpComputeEngineServiceID+"/skus"
+	return endpoint, official, nil
+}
+
+func fetchGCPCatalogPage(ctx context.Context, client *http.Client, origin, pageURL *url.URL) (gcpCatalogPage, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL.String(), nil)
+	if err != nil {
+		return gcpCatalogPage{}, fmt.Errorf("prepare Google Cloud Billing Catalog request: %w", err)
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("User-Agent", "InferCrane-GPU-Market/1.0")
+	response, err := client.Do(request)
+	if err != nil {
+		if ctx.Err() != nil {
+			return gcpCatalogPage{}, ctx.Err()
+		}
+		return gcpCatalogPage{}, fmt.Errorf("fetch Google Cloud Billing Catalog: %w", err)
+	}
+	defer response.Body.Close()
+	if !sameAzureOrigin(origin, response.Request.URL) {
+		return gcpCatalogPage{}, errors.New("Google Cloud Billing Catalog redirected outside its configured origin")
+	}
+	data, err := io.ReadAll(io.LimitReader(response.Body, maximumGCPResponseBytes+1))
+	if err != nil {
+		return gcpCatalogPage{}, fmt.Errorf("read Google Cloud Billing Catalog: %w", err)
+	}
+	if len(data) > maximumGCPResponseBytes {
+		return gcpCatalogPage{}, errors.New("Google Cloud Billing Catalog response exceeded the body limit")
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return gcpCatalogPage{}, fmt.Errorf("Google Cloud Billing Catalog returned HTTP %d", response.StatusCode)
+	}
+	var payload gcpCatalogPage
+	if err = json.Unmarshal(data, &payload); err != nil {
+		return gcpCatalogPage{}, fmt.Errorf("decode Google Cloud Billing Catalog: %w", err)
+	}
+	return payload, nil
+}
+
+func reviewedGCPGPU(description string) (string, bool) {
+	description = strings.TrimSpace(description)
+	for stem, gpu := range reviewedGCPGPUDescriptions {
+		if strings.HasPrefix(description, stem+" running in ") && len(strings.TrimSpace(strings.TrimPrefix(description, stem+" running in "))) > 0 {
+			return gpu, true
+		}
+	}
+	return "", false
+}
+
+func validGCPCatalogSKU(sku gcpCatalogSKU) bool {
+	return gcpSKUIDPattern.MatchString(strings.TrimSpace(sku.SKUID)) &&
+		strings.TrimSpace(sku.Name) == "services/"+gcpComputeEngineServiceID+"/skus/"+strings.TrimSpace(sku.SKUID) &&
+		strings.EqualFold(strings.TrimSpace(sku.ServiceProviderName), "Google") &&
+		strings.EqualFold(strings.TrimSpace(sku.Category.ServiceDisplayName), "Compute Engine") &&
+		strings.EqualFold(strings.TrimSpace(sku.Category.ResourceFamily), "Compute") &&
+		strings.EqualFold(strings.TrimSpace(sku.Category.UsageType), "OnDemand")
+}
+
+func currentGCPHourlyPrice(infos []gcpPricingInfo, now time.Time) (float64, time.Time, bool) {
+	selected := -1
+	var selectedAt time.Time
+	for index, info := range infos {
+		effective, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(info.EffectiveTime))
+		if err != nil || effective.After(now) {
+			continue
+		}
+		if effective.Equal(selectedAt) {
+			// The latest catalog endpoint documents a chronological timeline.
+			// Conflicting entries at the same instant are not safe to guess between.
+			return 0, time.Time{}, false
+		}
+		if selected < 0 || effective.After(selectedAt) {
+			selected, selectedAt = index, effective.UTC()
+		}
+	}
+	if selected < 0 {
+		return 0, time.Time{}, false
+	}
+	expression := infos[selected].PricingExpression
+	if expression.UsageUnit != "h" || expression.DisplayQuantity != 1 || len(expression.TieredRates) != 1 || expression.TieredRates[0].StartUsageAmount != 0 {
+		return 0, time.Time{}, false
+	}
+	money := expression.TieredRates[0].UnitPrice
+	if money.CurrencyCode != "USD" || money.Nanos < 0 || money.Nanos > 999999999 {
+		return 0, time.Time{}, false
+	}
+	units, err := strconv.ParseInt(money.Units, 10, 64)
+	if err != nil || units < 0 {
+		return 0, time.Time{}, false
+	}
+	hourly := float64(units) + float64(money.Nanos)/1e9
+	if hourly <= 0 || math.IsNaN(hourly) || math.IsInf(hourly, 0) {
+		return 0, time.Time{}, false
+	}
+	return hourly, selectedAt, true
+}
+
+func gcpSKURegions(sku gcpCatalogSKU) []string {
+	regions := sku.GeoTaxonomy.Regions
+	if len(regions) == 0 {
+		regions = sku.ServiceRegions
+	}
+	seen := make(map[string]struct{}, len(regions))
+	result := make([]string, 0, len(regions))
+	for _, raw := range regions {
+		region := strings.ToLower(strings.TrimSpace(raw))
+		if !gcpRegionPattern.MatchString(region) {
+			continue
+		}
+		if _, duplicate := seen[region]; duplicate {
+			continue
+		}
+		seen[region] = struct{}{}
+		result = append(result, region)
+	}
+	return result
+}

--- a/internal/priceingest/gcp_test.go
+++ b/internal/priceingest/gcp_test.go
@@ -1,0 +1,200 @@
+package priceingest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/pricing"
+)
+
+func TestGCPFeedPublishesExactCurrentOnDemandGPUComponents(t *testing.T) {
+	now := time.Date(2026, 9, 1, 8, 0, 0, 0, time.UTC)
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if r.Method != http.MethodGet || r.URL.Query().Get("currencyCode") != "USD" || r.URL.Query().Get("pageSize") != "5000" {
+			t.Errorf("unexpected GCP request: %s %s", r.Method, r.URL.String())
+		}
+		switch r.URL.Query().Get("pageToken") {
+		case "":
+			writeGCPPage(t, w, []gcpCatalogSKU{
+				gcpSKU("88B8-C3ED-03F0", "Nvidia Tesla T4 GPU running in Americas", []string{"us-central1", "us-east1"}, 0, 350_000_000, now.Add(-12*time.Hour)),
+				gcpSKU("1111-2222-3333", "Nvidia L4 GPU running in Netherlands", []string{"europe-west4"}, 0, 70_600_000, now.Add(-24*time.Hour)),
+				gcpSKU("1111-2222-3333", "Nvidia L4 GPU running in Netherlands", []string{"europe-west4"}, 0, 672_000_000, now.Add(-time.Hour)),
+				gcpSKU("AAAA-BBBB-CCCC", "Nvidia L40 GPU running in Netherlands", []string{"europe-west4"}, 0, 1, now.Add(-time.Hour)),
+			}, "page-two")
+		case "page-two":
+			spot := gcpSKU("4444-5555-6666", "Nvidia Tesla T4 GPU running in Americas", []string{"us-central1"}, 0, 10_000_000, now.Add(-time.Hour))
+			spot.Category.UsageType = "Preemptible"
+			future := gcpSKU("7777-8888-9999", "Nvidia Tesla V100 GPU running in Americas", []string{"us-central1"}, 1, 0, now.Add(time.Hour))
+			foreign := gcpSKU("ABCD-EF01-2345", "Nvidia Tesla V100 GPU running in Americas", []string{"us-central1"}, 1, 0, now.Add(-time.Hour))
+			foreign.ServiceProviderName = "Partner"
+			writeGCPPage(t, w, []gcpCatalogSKU{spot, future, foreign}, "")
+		default:
+			t.Errorf("unexpected page token %q", r.URL.Query().Get("pageToken"))
+		}
+	}))
+	defer server.Close()
+
+	catalog := pricing.NewDynamicCatalog(nil)
+	feed := GCPFeed{BaseURL: server.URL + "/catalog", Client: server.Client(), Now: func() time.Time { return now }, ValidFor: time.Hour}
+	if err := feed.Refresh(context.Background(), catalog); err != nil {
+		t.Fatal(err)
+	}
+	for request, want := range map[pricing.Request]float64{
+		{Cloud: "gcp", Region: "us-central1", GPU: "nvidia-tesla-t4", GPUCount: 1, Replicas: 1}: 0.35,
+		{Cloud: "gcp", Region: "us-east1", GPU: "nvidia-tesla-t4", GPUCount: 1, Replicas: 1}:    0.35,
+		{Cloud: "gcp", Region: "europe-west4", GPU: "nvidia-l4", GPUCount: 1, Replicas: 1}:      0.672,
+	} {
+		estimate, err := catalog.Estimate(context.Background(), request)
+		if err != nil || estimate.Hourly != want || estimate.Currency != "USD" || estimate.ObservedAt != now || estimate.StaleAfter != time.Hour || !estimate.GuaranteedUntil.IsZero() {
+			t.Fatalf("unexpected GCP estimate for %#v: %#v err=%v", request, estimate, err)
+		}
+		if !strings.HasPrefix(estimate.Source, defaultGCPCatalogURL+"?currencyCode=USD&pageSize=5000#billing_component=gpu&sku_id=") || strings.Contains(estimate.Source, server.URL) || strings.Contains(estimate.Source, "key=") {
+			t.Fatalf("GCP source lacks safe official SKU provenance: %s", estimate.Source)
+		}
+	}
+	if got := len(catalog.Snapshot()); got != 3 {
+		t.Fatalf("published %d GCP prices, want only three reviewed region tuples: %#v", got, catalog.Snapshot())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("GCP pages fetched=%d want 2", calls.Load())
+	}
+}
+
+func TestGCPFeedPaginationFailurePreservesLastGoodSnapshot(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		writeGCPPage(t, w, []gcpCatalogSKU{gcpSKU("1111-2222-3333", "Nvidia L4 GPU running in Netherlands", []string{"europe-west4"}, 0, 672_000_000, time.Now().Add(-time.Hour))}, "again")
+	}))
+	defer server.Close()
+	key := pricing.Request{Cloud: "gcp", Region: "europe-west4", GPU: "nvidia-l4", GPUCount: 1, Replicas: 1}
+	catalog := pricing.NewDynamicCatalog(nil)
+	catalog.ReplaceProvider("gcp", map[pricing.Request]pricing.Estimate{key: {Currency: "USD", Hourly: 9, Source: "last-good", ObservedAt: time.Now(), StaleAfter: time.Hour}})
+	err := (GCPFeed{BaseURL: server.URL, Client: server.Client(), RequestLimit: 2}).Refresh(context.Background(), catalog)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") || calls.Load() != 2 {
+		t.Fatalf("unexpected bounded pagination result: calls=%d err=%v", calls.Load(), err)
+	}
+	estimate, lookupErr := catalog.Estimate(context.Background(), key)
+	if lookupErr != nil || estimate.Source != "last-good" {
+		t.Fatalf("failed GCP refresh replaced last good: %#v err=%v", estimate, lookupErr)
+	}
+}
+
+func TestGCPFeedBoundsRequestsAndResponseBodies(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, strings.Repeat("x", maximumGCPResponseBytes+1))
+	}))
+	defer server.Close()
+	err := (GCPFeed{BaseURL: server.URL, Client: server.Client()}).Refresh(context.Background(), pricing.NewDynamicCatalog(nil))
+	if err == nil || !strings.Contains(err.Error(), "body limit") {
+		t.Fatalf("expected bounded GCP body error, got %v", err)
+	}
+
+	calls := 0
+	paged := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		writeGCPPage(t, w, nil, fmt.Sprintf("page-%d", calls))
+	}))
+	defer paged.Close()
+	err = (GCPFeed{BaseURL: paged.URL, Client: paged.Client(), RequestLimit: 2}).Refresh(context.Background(), pricing.NewDynamicCatalog(nil))
+	if err == nil || !strings.Contains(err.Error(), "2-request") || calls != 2 {
+		t.Fatalf("GCP request budget was not enforced: calls=%d err=%v", calls, err)
+	}
+}
+
+func TestGCPFeedRequiresAndProtectsOfficialAPIKey(t *testing.T) {
+	if err := (GCPFeed{}).Refresh(context.Background(), pricing.NewDynamicCatalog(nil)); err == nil || !strings.Contains(err.Error(), "API key is required") {
+		t.Fatalf("missing official GCP API key was accepted: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("credential-bearing request reached an untrusted endpoint")
+	}))
+	defer server.Close()
+	if err := (GCPFeed{BaseURL: server.URL, APIKey: "secret", Client: server.Client()}).Refresh(context.Background(), pricing.NewDynamicCatalog(nil)); err == nil || !strings.Contains(err.Error(), "untrusted endpoint") {
+		t.Fatalf("GCP API key was allowed for a foreign origin: %v", err)
+	}
+}
+
+func TestGCPFeedRejectsRedirectsOutsideConfiguredOrigin(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeGCPPage(t, w, nil, "")
+	}))
+	defer target.Close()
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer origin.Close()
+	err := (GCPFeed{BaseURL: origin.URL, Client: origin.Client()}).Refresh(context.Background(), pricing.NewDynamicCatalog(nil))
+	if err == nil || !strings.Contains(err.Error(), "redirected outside") {
+		t.Fatalf("foreign GCP redirect accepted: %v", err)
+	}
+}
+
+func TestReviewedGCPGPUDescriptionsAreExact(t *testing.T) {
+	for description, want := range map[string]string{
+		"Nvidia L4 GPU running in Netherlands":                "nvidia-l4",
+		"Nvidia Tesla A100 80GB GPU running in Americas":      "nvidia-a100-80gb",
+		"Nvidia H100 80GB Mega GPU running in Frankfurt":      "nvidia-h100-mega-80gb",
+		"H200 141GB GPU running in Belgium":                   "nvidia-h200-141gb",
+		"A4 Nvidia B200 (1 gpu slice) running in Netherlands": "nvidia-b200",
+		"RTX 6000 96GB running in Oregon":                     "nvidia-rtx-pro-6000",
+	} {
+		if got, ok := reviewedGCPGPU(description); !ok || got != want {
+			t.Errorf("reviewedGCPGPU(%q)=(%q,%t), want %q", description, got, ok, want)
+		}
+	}
+	for _, description := range []string{
+		"Nvidia L40 GPU running in Netherlands",
+		"Nvidia L4 Virtual Workstation GPU running in Netherlands",
+		"Nvidia L4 GPU attached to Spot Preemptible VMs running in Netherlands",
+		"Commitment v1: Nvidia L4 GPU running in Netherlands for 1 Year",
+	} {
+		if gpu, ok := reviewedGCPGPU(description); ok {
+			t.Errorf("unreviewed GCP description %q mapped to %q", description, gpu)
+		}
+	}
+}
+
+func TestGCPPriceDoesNotFallBackPastAnUnsupportedCurrentRate(t *testing.T) {
+	now := time.Date(2026, 9, 1, 8, 0, 0, 0, time.UTC)
+	old := gcpSKU("1111-2222-3333", "Nvidia L4 GPU running in Netherlands", []string{"europe-west4"}, 0, 500_000_000, now.Add(-24*time.Hour)).PricingInfo[0]
+	current := gcpSKU("1111-2222-3333", "Nvidia L4 GPU running in Netherlands", []string{"europe-west4"}, 0, 600_000_000, now.Add(-time.Hour)).PricingInfo[0]
+	current.PricingExpression.UsageUnit = "GiBy.mo"
+	if price, effective, ok := currentGCPHourlyPrice([]gcpPricingInfo{old, current}, now); ok {
+		t.Fatalf("unsupported latest GCP rate fell back to an old price: price=%f effective=%s", price, effective)
+	}
+}
+
+func gcpSKU(id, description string, regions []string, units int64, nanos int64, effective time.Time) gcpCatalogSKU {
+	sku := gcpCatalogSKU{
+		Name: "services/" + gcpComputeEngineServiceID + "/skus/" + id, SKUID: id, Description: description,
+		ServiceRegions: regions, ServiceProviderName: "Google",
+		Category: gcpSKUCategory{ServiceDisplayName: "Compute Engine", ResourceFamily: "Compute", ResourceGroup: "GPU", UsageType: "OnDemand"},
+		PricingInfo: []gcpPricingInfo{{
+			EffectiveTime: effective.UTC().Format(time.RFC3339Nano),
+			PricingExpression: gcpPricingExpression{UsageUnit: "h", DisplayQuantity: 1, TieredRates: []gcpTierRate{{
+				UnitPrice: gcpMoney{CurrencyCode: "USD", Units: fmt.Sprintf("%d", units), Nanos: nanos},
+			}}},
+		}},
+	}
+	sku.GeoTaxonomy.Type = "REGIONAL"
+	sku.GeoTaxonomy.Regions = append([]string(nil), regions...)
+	return sku
+}
+
+func writeGCPPage(t *testing.T, w http.ResponseWriter, skus []gcpCatalogSKU, next string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(gcpCatalogPage{SKUs: skus, NextPageToken: next}); err != nil {
+		t.Error(err)
+	}
+}

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -37,10 +37,11 @@ if [ "${1:-}" != "infercrane" ] || [ "${2:-}" != "serve" ]; then
 fi
 
 skypilot_mode=${INFERCRANE_SKYPILOT_API:-auto}
+skypilot_providers=${INFERCRANE_SKYPILOT_PROVIDERS_JSON:-}
 case "$skypilot_mode" in
-  auto) [ -n "${RUNPOD_API_KEY:-}" ] || exec "$@" ;;
-  enabled) [ -n "${RUNPOD_API_KEY:-}" ] || {
-    echo "INFERCRANE_SKYPILOT_API=enabled requires a RunPod API key" >&2
+  auto) [ -n "$skypilot_providers" ] || exec "$@" ;;
+  enabled) [ -n "$skypilot_providers" ] || {
+    echo "INFERCRANE_SKYPILOT_API=enabled requires INFERCRANE_SKYPILOT_PROVIDERS_JSON" >&2
     exit 1
   } ;;
   disabled) exec "$@" ;;
@@ -49,6 +50,7 @@ case "$skypilot_mode" in
     exit 1
     ;;
 esac
+unset skypilot_providers
 
 sky api start --host 127.0.0.1 --foreground &
 sky_pid=$!

--- a/scripts/test-entrypoint.sh
+++ b/scripts/test-entrypoint.sh
@@ -44,12 +44,12 @@ RUNPOD_API_KEY_FILE="$key_file" INFERCRANE_SKYPILOT_API=disabled \
 grep -qx 'runpod:config test-only-key' "$ENTRYPOINT_TEST_LOG"
 grep -qx 'infercrane:version' "$ENTRYPOINT_TEST_LOG"
 
-if env -u RUNPOD_API_KEY -u RUNPOD_API_KEY_FILE INFERCRANE_SKYPILOT_API=enabled \
+if env -u INFERCRANE_SKYPILOT_PROVIDERS_JSON INFERCRANE_SKYPILOT_API=enabled \
   sh "$root/scripts/entrypoint.sh" infercrane serve >"$fixture/out" 2>"$fixture/error"; then
-  echo 'enabled SkyPilot mode accepted a missing RunPod credential' >&2
+  echo 'enabled SkyPilot mode accepted a missing provider manifest' >&2
   exit 1
 fi
-grep -q 'requires a RunPod API key' "$fixture/error"
+grep -q 'requires INFERCRANE_SKYPILOT_PROVIDERS_JSON' "$fixture/error"
 
 if INFERCRANE_SKYPILOT_API=invalid sh "$root/scripts/entrypoint.sh" infercrane serve \
   >"$fixture/out" 2>"$fixture/error"; then

--- a/scripts/test-fly-config.sh
+++ b/scripts/test-fly-config.sh
@@ -25,7 +25,7 @@ env = data["env"]
 assert env["INFERCRANE_ENV"] == "production"
 assert env["INFERCRANE_HOST"] == "0.0.0.0"
 assert env["INFERCRANE_PORT"] == "8080"
-assert env["INFERCRANE_SKYPILOT_API"] == "auto"
+assert env["INFERCRANE_SKYPILOT_API"] == "disabled"
 assert env["SKYPILOT_DISABLE_USAGE_COLLECTION"] == "1"
 assert env["INFERCRANE_GPU_PRICE_SYNC_SECONDS"] == "75"
 assert "INFERCRANE_INSTANCE_ID" not in env, "replica identity must default to the unique machine hostname"

--- a/scripts/test-production-compose.sh
+++ b/scripts/test-production-compose.sh
@@ -81,9 +81,12 @@ INFERCRANE_POSTGRES_PASSWORD=test-only-postgres-password \
 RUNPOD_KEY_FILE="$fixture_key" \
   docker compose -f "$compose_file" -f "$runpod_compose_file" config >"$runpod_rendered"
 
-grep -q 'INFERCRANE_SKYPILOT_API: enabled' "$runpod_rendered"
+grep -q 'INFERCRANE_SKYPILOT_API: disabled' "$runpod_rendered"
 grep -q 'target: /run/secrets/runpod-api-key' "$runpod_rendered"
-grep -q 'source: skypilot-state' "$runpod_rendered"
+if grep -q 'source: skypilot-state' "$runpod_rendered"; then
+  echo 'native RunPod production overlay unexpectedly persists SkyPilot state' >&2
+  exit 1
+fi
 grep -q 'source: runpod-state' "$runpod_rendered"
 if grep -Eq 'fake-vllm|fake-router|runpod-fault-proxy|infercrane-runpod-acceptance-key' "$runpod_rendered"; then
   echo 'RunPod production overlay includes a development or acceptance-only component' >&2


### PR DESCRIPTION
## Summary
- make native RunPod Pods the default and require explicit SkyPilot provider manifests
- disable SkyPilot in the hosted production profile so RunPod credentials do not activate an upstream catalog dependency
- ingest GCP GPU billing components from the official Cloud Billing Catalog API when a restricted key is configured
- update provider setup and production documentation to preserve price, capacity, and execution boundaries

## Evidence
- `go test ./...`
- `go vet ./...`
- `sh scripts/test-entrypoint.sh`
- `sh scripts/test-fly-config.sh`
- `sh scripts/test-production-compose.sh`
- `git diff --check`

## Limits
- GCP rows are GPU billing components, not complete VM totals or capacity claims.
- GCP ingestion remains disabled until `GOOGLE_CLOUD_BILLING_API_KEY` is configured.
- SkyPilot remains available only through an explicit `INFERCRANE_SKYPILOT_PROVIDERS_JSON` manifest; it is not InferCrane's pricing authority.
