### PR TITLE
Add bounded Hugging Face catalog and hosted-to-own-cloud architecture

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -25,3 +25,6 @@ INFERCRANE_PORT=8080
 # must be readable only by the control plane; its internal fields are never
 # returned by the customer catalog API.
 # INFERCRANE_MODEL_API_CATALOG_FILE=/run/secrets/model-api-catalog.json
+# Set to 21600 for a six-hour refresh of bounded metadata for reviewed Hugging Face repositories.
+# Optional HF_TOKEN should be a fine-grained read token and is sent only to https://huggingface.co.
+# INFERCRANE_HF_CATALOG_REFRESH_SECONDS=21600

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -5449,6 +5449,42 @@
         ]
       }
     },
+    "/api/v1/catalog/hugging-face/models": {
+      "get": {
+        "operationId": "listHuggingFaceCatalogModels",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Object"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Typed API error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Inspect bounded normalized Hugging Face metadata without promoting it to a reviewed recipe",
+        "tags": [
+          "Model catalog"
+        ]
+      }
+    },
     "/api/v1/catalog/models": {
       "get": {
         "operationId": "listCatalogModels",

--- a/cmd/infercrane/main.go
+++ b/cmd/infercrane/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/infercrane/infercrane/internal/domain"
 	"github.com/infercrane/infercrane/internal/external"
 	"github.com/infercrane/infercrane/internal/gateway"
+	"github.com/infercrane/infercrane/internal/hfcatalog"
 	"github.com/infercrane/infercrane/internal/integration"
 	"github.com/infercrane/infercrane/internal/managedbilling"
 	"github.com/infercrane/infercrane/internal/modelapicatalog"
@@ -4280,6 +4281,39 @@ func serve(parent context.Context, cfg config.Config, s *store.Store) error {
 	if catalogErr != nil {
 		return fmt.Errorf("configure Model API catalog: %w", catalogErr)
 	}
+	hfRepositories := make([]string, 0)
+	for _, entry := range curatedrecipe.All() {
+		hfRepositories = append(hfRepositories, entry.Model)
+	}
+	hfCatalog, catalogErr := hfcatalog.New(hfRepositories)
+	if catalogErr != nil {
+		return fmt.Errorf("configure Hugging Face catalog: %w", catalogErr)
+	}
+	if cfg.HFCatalogRefreshInterval > 0 {
+		hfClient := hfcatalog.Client{Token: os.Getenv("HF_TOKEN")}
+		refreshHFCatalog := func(refreshCtx context.Context) error {
+			refreshCtx, cancel := context.WithTimeout(refreshCtx, 45*time.Second)
+			defer cancel()
+			return hfCatalog.Refresh(refreshCtx, hfClient)
+		}
+		go func() {
+			if refreshErr := refreshHFCatalog(ctx); refreshErr != nil {
+				logger.Warn("initial Hugging Face catalog refresh failed; retaining last-good metadata", "error", refreshErr)
+			}
+			ticker := time.NewTicker(cfg.HFCatalogRefreshInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					if refreshErr := refreshHFCatalog(ctx); refreshErr != nil {
+						logger.Warn("Hugging Face catalog refresh failed; retaining last-good metadata", "error", refreshErr)
+					}
+				}
+			}
+		}()
+	}
 	computeProviders := computeProviderInventory(cfg, configuredSkyPilotProviders)
 	var gcpProvider provision.GCPCompute
 	if cfg.GCPEnabled() {
@@ -4302,7 +4336,7 @@ func serve(parent context.Context, cfg config.Config, s *store.Store) error {
 			launchProbers[provider.ID] = provision.ConfiguredLaunchProbe{Provider: provider.ID}
 		}
 	}
-	controlAPI := controlapi.API{Store: s, APIKey: cfg.APIKey, Authenticator: controlAuthenticator, BenchmarkRunner: benchmark.Runner{}, Diagnostics: diagnostics, Backends: benchmarkBackends, Integrations: integrationRegistry.Snapshot(), GatewayURL: cfg.ControlURL, AIPerfBinary: cfg.AIPerfBinary, PassportPrivateKey: passportKey, EndpointRefresh: rec.RefreshEndpoints, CredentialRefresh: credentialCache.Refresh, AlertDeliverer: alert.Deliverer{Store: s, Secrets: secrets.Environment{}}, ContextPassports: contextPassports, ArtifactCacheAdapters: artifactCacheAdapters, ProductVersion: version, GatewayInstanceID: cfg.InstanceID, AdmissionState: admissionPool, OptimizationCosts: optimizationCosts, ModelAPICatalog: modelAPICatalog, ComputeProviders: computeProviders, GPUPriceCatalog: priceCatalog, LaunchProbers: launchProbers, DefaultProviderAdapters: defaultProviderAdapters}
+	controlAPI := controlapi.API{Store: s, APIKey: cfg.APIKey, Authenticator: controlAuthenticator, BenchmarkRunner: benchmark.Runner{}, Diagnostics: diagnostics, Backends: benchmarkBackends, Integrations: integrationRegistry.Snapshot(), GatewayURL: cfg.ControlURL, AIPerfBinary: cfg.AIPerfBinary, PassportPrivateKey: passportKey, EndpointRefresh: rec.RefreshEndpoints, CredentialRefresh: credentialCache.Refresh, AlertDeliverer: alert.Deliverer{Store: s, Secrets: secrets.Environment{}}, ContextPassports: contextPassports, ArtifactCacheAdapters: artifactCacheAdapters, ProductVersion: version, GatewayInstanceID: cfg.InstanceID, AdmissionState: admissionPool, OptimizationCosts: optimizationCosts, ModelAPICatalog: modelAPICatalog, HFCatalog: hfCatalog, ComputeProviders: computeProviders, GPUPriceCatalog: priceCatalog, LaunchProbers: launchProbers, DefaultProviderAdapters: defaultProviderAdapters}
 	if cfg.StripeEnabled() {
 		stripeBilling, stripeErr := managedbilling.NewStripe(cfg.StripeSecretKey, cfg.StripeWebhookSecret, cfg.StripeBillingReturnURL, cfg.StripePriceIDs, cfg.StripeLivemode)
 		if stripeErr != nil {

--- a/docs/architecture/hosted-to-customer-cloud.mdx
+++ b/docs/architecture/hosted-to-customer-cloud.mdx
@@ -1,0 +1,251 @@
+---
+title: Hosted Model APIs to customer cloud
+description: Decision record for supplier-neutral hosted inference and evidence-gated promotion to customer-owned capacity.
+---
+
+# Hosted Model APIs to customer cloud
+
+**Status:** Proposed, 2026-09-01. This record refines the [Managed Model API architecture](/architecture/managed-model-apis); it does not announce additional provider support.
+
+The following labels are normative throughout this record:
+
+- **Implemented** means the behavior exists in this repository. It may still require a separately documented real-provider qualification before production use.
+- **Registered/deferred** means an interface, profile, or local adapter exists, but the real provider path is not qualified.
+- **Proposed** means an architecture decision or an inference from the linked provider documentation. It is not implemented product behavior.
+
+## Decision
+
+InferCrane should expose one tenant-scoped OpenAI-compatible endpoint and stable logical model ID,
+then satisfy it from three explicit supply lanes:
+
+1. a token-priced hosted supplier for immediate access and burst traffic;
+2. an InferCrane-operated, exact-artifact elastic or warm pool for portable open models; and
+3. a customer-owned deployment when sustained load, data policy, or infrastructure ownership makes
+   it the better fit.
+
+The public API contract is stable across lanes, but a route may move only between bindings that
+preserve the exact model and required protocol capabilities. Provider identity, commercial rate,
+or a similar model name is not sufficient evidence.
+
+“Promotion to customer cloud” means that InferCrane produces and validates an immutable deployment
+specification, launches a new candidate using customer-authorized credentials, measures that exact
+candidate, and promotes its serving plan only after Release Guard passes. It does **not** move an
+upstream provider resource, conversation state, KV cache, supplier credentials, or upstream IDs.
+The hosted binding remains active until the customer explicitly promotes and later retires it.
+
+## Current implementation boundary
+
+The decision builds on these repository facts:
+
+| Capability | Status and implementation evidence |
+| --- | --- |
+| Stable OpenAI surface | **Implemented:** `internal/gateway/gateway.go` handles models, chat, responses, embeddings, completions, and batch surfaces; streaming and cancellation stay on the selected binding. |
+| Tenant routing | **Implemented:** `internal/routes/routes.go` publishes immutable in-memory route snapshots, supports weighted selection and affinity hints, and pins an in-flight generation. The database is not on the request hot path. |
+| Prepaid managed requests | **Implemented:** `internal/gateway/gateway.go`, `internal/managedbilling`, and `internal/store/managed_billing.go` reserve worst-case integer-microusd cost before supplier transmission and settle from reported usage. Missing usage remains reserved for reconciliation. |
+| Governed external APIs | **Implemented contract:** `internal/external/binding.go` requires reference-only secrets, privacy acknowledgment, hard limits, a current cost basis, and the margin floor. It names OpenAI-compatible external, Modal, and RunPod Serverless API profiles. This does not by itself qualify any real target. |
+| Supplier selection | **Implemented:** `internal/modelapicatalog/catalog.go` and `internal/modelapisupply/plan.go` reject stale price, access, capacity, health, cost, margin, and mismatched performance evidence. A catalog row is not a capacity claim. |
+| RunPod Serverless lifecycle | **Implemented locally; real target deferred:** `internal/provision/runpod_serverless.go` and `internal/workflows/serverless.go` reconcile a pinned model revision, runtime options, GPU, worker bounds, and endpoint lifecycle. Real queue-versus-load-balancer, OpenAI streaming, usage, billing, cold-start, adoption, and deletion behavior still require bounded qualification. |
+| Customer AWS and GCP | **Implemented adapters; exact real tuples require qualification:** `internal/provision/aws_ec2.go` targets private EC2 and `internal/provision/gcp_compute.go` targets private Compute Engine. The repository does not currently implement SageMaker or Vertex AI deployment lifecycles. |
+| Candidate promotion | **Implemented:** `internal/store/endpoints.go` separates active and candidate serving plans and requires a current Release Guard pass before promotion. `internal/benchmark`, `internal/releaseguard`, and `internal/replay` provide the evidence path. |
+| Portable deployment description | **Implemented contract:** `docs/deployment-spec.md` defines immutable model, runtime, image, provider, GPU, scaling, and route fields. Terraform resources are not yet a complete export of every workload detail. |
+
+Fireworks and Lightning are not named lifecycle adapters today. A generic OpenAI-compatible binding
+can describe an external URL, but it must not be represented as provider-qualified until identity,
+streaming, cancellation, usage, hard-budget, and failure behavior pass a real target contract.
+
+## Portability classes
+
+Every hosted offer must declare one of these classes before publication:
+
+- **Exact artifact:** immutable repository/revision or content digest, tokenizer and chat template,
+  quantization, runtime image digest/version/arguments, protocol capabilities, and tool parser are
+  all known. Only this class may create a customer-cloud promotion candidate.
+- **Semantic only:** the provider claims the same model family or label, but InferCrane cannot prove
+  the artifact/runtime tuple. A separately benchmarked replacement can be offered, but not as a
+  seamless promotion.
+- **Provider only:** the model or behavior cannot be reproduced outside that supplier. It is a
+  hosted API only and must be labeled non-exportable.
+
+This classification prevents a cheap supplier rate from becoming false evidence that a customer
+can reproduce the same model in their account.
+
+## Control plane and data plane
+
+The control plane owns desired state and evidence: logical models, artifact manifests, provider
+qualifications, expiring rates, supply plans, wallets, deployment drafts, candidate plans,
+benchmarks, Release Guard decisions, and audit records. Provider reconcilers consume desired state;
+they do not publish a route until inventory and health establish the expected resource identity.
+
+The data plane performs tenant authentication, request-size/deadline/quota admission, prepaid
+reservation, capability-safe route selection, streaming proxying, cancellation, settlement, and
+content-free telemetry. It reads an immutable route snapshot. A control-plane outage must not turn
+into a database lookup or provider discovery call on each inference request.
+
+```text
+customer SDK -> tenant gateway -> immutable route snapshot -> qualified binding -> supplier/runtime
+                    |                     ^
+              reserve/settle              |
+                    v                     |
+             prepaid ledger       control-plane publish
+                                          ^
+artifact + rates + provider state -> candidate -> benchmark/guard -> promotion
+```
+
+Secrets remain references resolved at the execution boundary. A supplier credential, customer
+cloud role, or model API key must never enter the route snapshot, deployment specification, logs,
+or browser payload.
+
+## Cold starts and warm capacity
+
+InferCrane should normalize cold-start observations into
+`zero -> allocating -> image_weights -> runtime_ready -> warm -> draining`, while retaining the raw
+provider state, source, timestamp, and request ID. Unknown stages remain unknown.
+
+Provider behavior is not interchangeable:
+
+- RunPod [queue-based endpoints](https://docs.runpod.io/serverless/endpoints/overview) queue work and
+  can retry; load-balancing endpoints send direct HTTP traffic and do not retry. RunPod bills Flex
+  workers from start through execution and idle time, while Active workers remain running
+  ([pricing](https://docs.runpod.io/serverless/pricing)). The endpoint type must therefore be pinned
+  and qualified, not inferred from a URL.
+- Fireworks dedicated deployments can scale to zero, but the first request receives a `503` while
+  capacity starts; it is not queued and cold start can take minutes
+  ([autoscaling](https://docs.fireworks.ai/deployments/autoscaling)).
+- SageMaker inference components can scale to zero, but the first requests fail while an instance
+  provisions, which can take several minutes
+  ([AWS guide](https://docs.aws.amazon.com/en_en/sagemaker/latest/dg/endpoint-auto-scaling-zero-instances.html)).
+- Vertex AI scale-to-zero is preview, drops the first request with `429`, and can encounter stockout
+  without a reservation
+  ([GCP autoscaling guide](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/predictions/autoscaling)).
+- Modal exposes minimum, maximum, buffer, and concurrency controls; its cold-start guidance favors
+  volumes for weights and explicitly distinguishes memory snapshots from loading model weights
+  ([scaling](https://modal.com/docs/guide/scale), [cold starts](https://modal.com/docs/guide/cold-start),
+  [model weights](https://modal.com/docs/guide/model-weights)).
+
+Consequently, **proposed** synchronous behavior is either an already-warm compatible fallback or a
+bounded `503` with retry guidance. The gateway must not hide multi-minute allocation inside an
+unbounded retry, replay a request after an upstream may have accepted it, or retry a started stream.
+Economy tiers may scale to zero; a latency SLO requires measured warm capacity and includes its idle
+cost in the price.
+
+## Pooling and routing
+
+A reusable worker pool is keyed by the complete artifact manifest, runtime/topology, accelerator,
+region, and security class. “Same model family” is not a pool key. Continuous batching and target
+concurrency are selected from measured workload evidence rather than GPU memory arithmetic alone.
+
+Physical capacity may be shared across tenants only for an explicitly shared service tier with
+per-tenant admission, quotas, billing attribution, credentials, and log partitioning. Prompt,
+response, session, and KV/prefix-cache state must not cross tenant boundaries unless the runtime's
+isolation has been specifically qualified. Strict privacy tiers use dedicated tenant pools.
+
+At request time, routing considers only current healthy, capability-compatible bindings. Reliability
+wins over cache/session affinity. Weighted canaries require evidence, and a stream remains pinned to
+one target. Supplier failover must preserve the public model contract; otherwise the request fails
+closed.
+
+## Pricing decision
+
+Retail prices are immutable, expiring rate cards with first-party provenance:
+
+- token suppliers use their published token rate plus reported usage and invoice reconciliation;
+- RunPod, Modal, AWS, GCP, and Lightning capacity uses provider-reported compute, CPU, memory,
+  storage, and network units at the applicable account rate;
+- AWS public list prices can be queried through the
+  [Price List Query API](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/using-price-list-query-api.html),
+  but AWS warns that it does not include every account discount;
+- Modal exposes machine-readable account rates through
+  [`modal billing rates --json`](https://modal.com/docs/cli/latest/billing); and
+- Fireworks publishes separate [serverless token pricing](https://docs.fireworks.ai/serverless/pricing)
+  and bills dedicated deployments by GPU-second.
+
+A GPU-second price must not be converted to a token price until InferCrane has measured exact-tuple
+goodput and utilization. Cost basis also includes startup and idle time, CPU/RAM, volumes and image
+storage, network transfer, provider fees, payment fees/refunds, failure allowance, and operational
+reserve. Provider pages are discovery sources; account invoices or billing exports are the
+reconciliation authority. Expired or unreconciled rates cannot authorize managed traffic.
+
+The expected economic progression is token-priced burst, elastic exact-artifact capacity for
+intermittent demand, warm or reserved capacity for steady demand, then customer-owned capacity when
+measured utilization or policy justifies it. This is a workload-specific crossover calculation,
+not a universal “cheapest provider” ranking.
+
+## Observability and tenancy
+
+**Implemented:** gateway telemetry already records tenant, deployment/revision, binding/target,
+provider/runtime/mode, status, latency, queue time, TTFT, reported tokens, retries, cold state, and
+hashed session identifiers without prompt or response content.
+
+**Proposed additions:** record each cold-start phase, worker/replica count, provider queue duration,
+supplier request ID, reserved/settled/reconciled cost, rate-card version, route reason, and raw
+provider observation provenance. Provider signals should be imported but never silently promoted
+to stronger evidence: Fireworks exposes a rate-limited
+[Prometheus endpoint](https://docs.fireworks.ai/deployments/exporting-metrics), Modal can export
+[OpenTelemetry](https://modal.com/docs/guide/otel-integration), SageMaker emits
+[enhanced CloudWatch metrics](https://docs.aws.amazon.com/sagemaker/latest/dg/monitoring-cloudwatch-enhanced-metrics.html),
+and Vertex publishes prediction/autoscaling metrics.
+
+All dashboards, traces, cost ledgers, and audit queries are tenant scoped. Content logging remains
+off by default. A customer-supplied provider account changes resource ownership, not the tenant
+isolation or gateway authorization boundary.
+
+## Provider fit
+
+| Provider primitive | Official behavior relevant to this decision | InferCrane decision |
+| --- | --- | --- |
+| RunPod Serverless | Queue and load-balancing endpoint modes; Flex scale-to-zero and Active workers; vLLM exposes an [OpenAI-compatible endpoint](https://docs.runpod.io/serverless/vllm/overview). | **First proposed exact-artifact managed lane**, because a local lifecycle already exists. Qualify the real endpoint type, immutable artifact, streaming/cancel/usage, cold and warm paths, invoice, adoption, and deletion before publication. |
+| Modal | Web endpoints support direct URLs and [container concurrency](https://modal.com/docs/guide/concurrent-inputs); autoscaling has min/max/buffer controls. | **Registered/deferred.** The repository has a governed external profile, not lifecycle reconciliation. Add only after real target qualification and an authoritative rate import. |
+| Fireworks | Shared serverless models are token-priced and best-effort; dedicated deployments allow custom models and GPU-second billing ([model overview](https://docs.fireworks.ai/models/overview)). The API is [OpenAI compatible](https://docs.fireworks.ai/tools-sdks/python-client/sdk-reference). | **Proposed burst supplier.** Provider-only models are non-exportable. An open model is portable only after exact artifact identity is proven. Add a governed binding before any lifecycle adapter. |
+| AWS | Current InferCrane path is private EC2. SageMaker inference components add managed autoscaling and scale-to-zero, with cold-request failures. | **Customer-cloud promotion uses EC2 first.** SageMaker is future work, not current support; adopt it only after a dedicated reconciler, pricing, cold-start, and metrics contract. |
+| GCP | Current InferCrane path is private Compute Engine. Custom vLLM on Vertex requires [raw inference requests](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/open-models/deploy-custom-vllm) rather than the normal prediction envelope. | **Customer-cloud promotion uses Compute Engine first.** Vertex needs a translation adapter and preview-risk qualification; it is not currently a pass-through OpenAI target. |
+| Lightning | Lightning Inference documents custom containers, streaming, health, autoscaling to zero, secrets, and customer cloud accounts through its [deployment SDK](https://lightning.ai/docs/overview/lightning-deploy/sdk). | **Deferred.** No current InferCrane adapter. Require idempotent ensure/adopt/inventory/delete, API semantics, metrics, pricing, and real-target evidence before registration. |
+
+## Phased implementation
+
+### Phase 0 — close the truth gap
+
+Qualify one bounded real RunPod vLLM tuple end to end: endpoint mode, exact artifact, first/cold/warm
+request, stream and cancellation, token usage, no-balance/no-transmission, invoice reconciliation,
+adoption, deletion, and zero-resource proof. Do not publish a hosted SKU before these pass.
+
+### Phase 1 — one portable hosted SKU
+
+Publish a single pinned open-model manifest behind the stable gateway. Offer an economy Flex tier and
+a paid warm tier only if their measured cold-start and TTFT distributions support the advertised
+contract. A Fireworks binding may provide burst fallback after the same identity, protocol, prepaid,
+and billing gates; otherwise expose it as a distinct, non-portable offer.
+
+### Phase 2 — customer-cloud promotion MVP
+
+Compile the hosted artifact manifest into the existing deployment specification for private AWS EC2
+or GCP Compute. Resolve customer credentials only at execution, perform read-only prerequisite and
+quota checks, launch an explicit candidate, bind it without traffic, benchmark/replay the exact
+tuple, require Release Guard, and ask for explicit promotion. Keep the hosted lane available for
+rollback until the customer retires it.
+
+### Phase 3 — measured efficiency
+
+Use observed arrival rate, batch shape, TTFT, goodput, cache locality, cold-start distribution, and
+idle cost to tune warm count, worker concurrency, and pool boundaries. Add reserved capacity only
+where sustained measured utilization beats elastic capacity after risk and operational cost.
+
+### Phase 4 — supplier breadth
+
+Add Modal lifecycle, Fireworks dedicated, Lightning, SageMaker, or Vertex one at a time. Each needs a
+provider-specific reconciliation contract and bounded real qualification; a generic catalog entry
+or OpenAI-shaped response is not sufficient.
+
+## Release gates
+
+A new hosted or promotion path is not releasable until it proves:
+
+- immutable artifact and runtime identity, protocol capabilities, and tenant isolation;
+- real first, cold, warm, streaming, cancellation, timeout, quota, and provider-outage behavior;
+- no supplier transmission without a valid route, current price, sufficient balance, and hard cap;
+- reported-usage settlement plus invoice reconciliation with explainable variance;
+- content-free logs, reference-only secrets, and no provider identity leaked through the public API;
+- replay-safe ensure/adopt, inventory, health, rollback, deletion, and absence proof; and
+- a current exact-tuple benchmark and Release Guard pass before customer traffic promotion.
+
+These gates make low price and deployability measured properties of a specific supply tuple, not
+claims inferred from a provider catalog or accelerator name.

--- a/docs/features/model-catalog.mdx
+++ b/docs/features/model-catalog.mdx
@@ -246,3 +246,35 @@ curl -sS "$INFERCRANE_CONTROL_URL/api/v1/catalog/models/qwen3-8b" \
 The response includes `performance_claims: false`. Trustworthy performance comes from
 [AIPerf benchmarking](/features/benchmarking), [Inference Lab](/features/recipes-lab), and the exact
 evidence attached to a revision.
+
+## Bounded Hugging Face metadata cache
+
+InferCrane can refresh normalized metadata for the repositories already present in the reviewed
+catalog. Enable the opt-in background refresh with a value from 300 to 86400 seconds:
+
+```bash
+export INFERCRANE_HF_CATALOG_REFRESH_SECONDS=21600
+# Optional for private or gated metadata. Use a fine-grained read token.
+export HF_TOKEN=hf_replace
+```
+
+The collector uses Hugging Face's official
+[`model_info`](https://huggingface.co/docs/huggingface_hub/package_reference/hf_api#huggingface_hub.HfApi.model_info)
+API surface. Requests have per-call and whole-refresh time limits, at most four execute concurrently,
+responses are capped at 1 MiB, and only the bounded reviewed repository set is requested. A token is
+sent only to `https://huggingface.co`.
+
+```bash
+curl -sS "$INFERCRANE_CONTROL_URL/api/v1/catalog/hugging-face/models?query=qwen" \
+  -H "Authorization: Bearer $INFERCRANE_API_KEY"
+```
+
+The process-local cache publishes repository identity, immutable revision when reported, access
+state, selected card fields, tags, timestamps, explicit unknown fields, and source/retrieval
+provenance. Unknown or new upstream JSON is not copied wholesale into the public response. Refreshes
+atomically retain the last good record for any repository whose latest fetch fails.
+
+This surface is discovery evidence only. It cannot create or modify a reviewed recipe and does not
+claim runtime compatibility, GPU fit, performance, price, stock, quota, license approval, or
+deployability. The reviewed `/api/v1/catalog/models` contract remains the deployment starting-point
+authority.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5449,6 +5449,42 @@
         ]
       }
     },
+    "/api/v1/catalog/hugging-face/models": {
+      "get": {
+        "operationId": "listHuggingFaceCatalogModels",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Object"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Typed API error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Inspect bounded normalized Hugging Face metadata without promoting it to a reviewed recipe",
+        "tags": [
+          "Model catalog"
+        ]
+      }
+    },
     "/api/v1/catalog/models": {
       "get": {
         "operationId": "listCatalogModels",

--- a/docs/product-capabilities.md
+++ b/docs/product-capabilities.md
@@ -1,0 +1,125 @@
+# InferCrane product capability map
+
+This is the short product-truth checklist for the website, console, demos, and
+planning work. It summarizes implemented contracts; the qualification matrix
+remains the source of truth for exact evidence and real-infrastructure status.
+
+## Core promise
+
+InferCrane turns a model, an existing endpoint, or an application requirement
+into one stable OpenAI-compatible endpoint. A user can use InferCrane-hosted
+capacity, deploy reviewed capacity into their own infrastructure, adopt what
+already exists, or combine those paths behind the same endpoint contract.
+
+## Product capabilities
+
+### 1. Plan and select
+
+- Resolve a bounded intent into an exact model, runtime, GPU, provider, region,
+  scaling policy, and editable deployment draft without creating resources.
+- Use curated, content-addressed recipes and immutable Hugging Face artifact
+  identities; never silently substitute a model.
+- Compare sourced GPU price observations separately from stock, quota,
+  launchability, and measured performance.
+- Probe launch-time capacity and connection readiness before a paid mutation.
+- Preserve evidence as measured, modeled, compatibility-only, or unknown.
+
+### 2. Deploy or adopt capacity
+
+- Provision through AWS, GCP, RunPod, Kubernetes/KServe, and declared SkyPilot
+  multi-cloud targets where their exact adapter is configured and qualified.
+- Serve with vLLM, SGLang, a reviewed custom OCI runtime, or adopt a compatible
+  external endpoint such as LiteLLM/OpenRouter without exposing credentials.
+- Support elastic and provider-native serverless deployment contracts, including
+  zero/warm/cold lifecycle semantics where the provider adapter supports them.
+- Persist idempotent operations so launch, watch, cancel, restart, reconcile,
+  cleanup, and orphan recovery survive client or control-plane interruption.
+- Track immutable model artifacts and provider cache/prefetch observations.
+
+### 3. Serve through one stable endpoint
+
+- Keep the application-facing endpoint stable while backends, providers, and
+  revisions change behind it.
+- Proxy capability-qualified Chat Completions, Responses, Embeddings, legacy
+  Completions, streaming, tool calls, structured output, and online batch.
+- Apply request admission, deadlines, bounded retries, distributed quota,
+  health-aware routing, session hints, and explicit governed overflow.
+- Support active/candidate/fallback bindings and deterministic weighted plans
+  without putting PostgreSQL in the request data path.
+
+### 4. Observe and operate
+
+- Show request rate, tokens, latency/TTFT, errors, spend, route/revision identity,
+  cold starts, and fresh hardware evidence without storing prompt content.
+- Provide a content-free Request Inspector, deterministic Doctor/explanations,
+  signed alert webhooks, audit history, and durable operation progress.
+- Attribute managed Model API usage through a prepaid, append-only ledger while
+  keeping missing supplier usage pending instead of inventing a charge.
+- Surface capacity history, queue pressure, SLO attainment, OpenCost/FinOps data,
+  and evidence freshness for operator decisions.
+
+### 5. Benchmark and optimize
+
+- Run explicit AIPerf benchmarks and bounded replays against exact immutable
+  model/runtime/version/args/provider/region/GPU tuples.
+- Create immutable optimization proposals and durable campaigns without changing
+  production until cost authority and approval are explicit.
+- Compare measured candidates in the Inference Lab; attach external task-quality
+  evidence and optimized-artifact provenance when available.
+- Recommend scaling, cold-start, capacity, and cost actions with missing evidence
+  left unknown; advisory autopilot does not silently mutate production.
+
+### 6. Release and recover safely
+
+- Stage immutable candidates, validate them, and return Release Guard decisions
+  of ACCEPT, REJECT, or WAIT from persisted evidence.
+- Promote explicitly, preserve the active revision when evidence is missing or
+  rejected, fence stale actions, and support rollback and cleanup.
+- Issue verifiable inference passports for approved deployment evidence.
+
+### 7. Interfaces and platform controls
+
+- Web console, CLI/TUI, control API/OpenAPI, Python and TypeScript SDKs, Terraform,
+  and release artifacts share the same control-plane contracts.
+- Tenant isolation, scoped principals, audit logs, secret references/redaction,
+  TLS/mTLS boundaries, PostgreSQL durability, migrations, and backup/restore are
+  platform capabilities rather than landing-page features.
+
+## Hosted Model APIs
+
+The customer sees a curated, supplier-neutral model identity, public price,
+context/capability contract, availability state, usage, and one InferCrane API
+key. Internally, InferCrane compiles fresh private supply offers into immutable
+primary/fallback plans, reserves wallet funds before transmission, settles from
+returned usage, and fails closed when rates, health, evidence, or usage are stale.
+
+The same reviewed model configuration can later become a customer-owned
+deployment. Hosted API and own-cloud deployment are two delivery modes of one
+model contract, not separate product catalogs.
+
+## Truth boundaries
+
+- Compatibility, price, availability, capacity, performance, and quality are
+  different claims and must never be collapsed into a generic score.
+- A provider or runtime name means an implemented contract, not universal
+  qualification. Every real claim is exact-tuple and evidence-bound.
+- Public GPU prices do not prove inventory, account quota, or launch success.
+- Managed Model API availability and economics require a fresh operated supply
+  catalog and real supplier reconciliation; local contracts alone do not prove it.
+- Unsupported accelerators, runtimes, and optimizers remain absent or explicitly
+  experimental until an adapter and evidence exist.
+
+## UI coverage rule
+
+- **Landing page:** communicate six verbs only — plan, deploy, serve, observe,
+  optimize, guard — plus the choice of InferCrane-hosted or customer-owned compute.
+- **Build:** ask for delivery mode, model/outcome, workload, and primary objective;
+  reveal infrastructure only when it changes the plan.
+- **Plan Canvas:** show architecture, exact configuration, evidence, alternatives,
+  expected cost, and the next reversible action before mutation.
+- **Dashboard:** lead with real endpoints, requests/spend, attention, operations,
+  optimization candidates, and Release Guard state.
+- **Catalog/detail:** show identity, capabilities, price, measured performance,
+  availability, provenance, usage, and deploy/hosted-API actions with unknowns clear.
+- **Advanced surfaces:** keep policy, security, provider credentials, recipes,
+  telemetry, automation, and evidence administration out of the primary flow.

--- a/internal/apicontract/contract.go
+++ b/internal/apicontract/contract.go
@@ -38,6 +38,7 @@ var Routes = []Route{
 	{"GET", "/integrations", "listIntegrations", "System", "Inspect registered integration capabilities", "", "Object", 200, false},
 	{"GET", "/catalog/models", "listCatalogModels", "Model catalog", "Search reviewed model starting points", "", "ObjectList", 200, false},
 	{"GET", "/catalog/models/{name}", "getCatalogModel", "Model catalog", "Inspect one reviewed model and its serving profiles", "", "Object", 200, false},
+	{"GET", "/catalog/hugging-face/models", "listHuggingFaceCatalogModels", "Model catalog", "Inspect bounded normalized Hugging Face metadata without promoting it to a reviewed recipe", "", "Object", 200, false},
 	{"POST", "/planning/intents", "planIntent", "Planning", "Compile bounded user intent into an editable reviewed configuration", "IntentPlanRequest", "IntentPlanEnvelope", 200, false},
 	{"GET", "/model-api-catalog", "listModelAPICatalog", "Model APIs", "Browse supplier-neutral managed Model API identities", "", "ObjectList", 200, false},
 	{"GET", "/model-api-catalog/{id}", "getModelAPICatalogEntry", "Model APIs", "Inspect one managed Model API identity without supplier disclosure", "", "Object", 200, false},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,7 +50,7 @@ type Config struct {
 	DynamoVLLMImageDigest, DynamoVLLMRuntimeVersion, DynamoSGLangImageDigest, DynamoSGLangRuntimeVersion               string
 	DynamoModelSecretName                                                                                              string
 	Port, RouterStartPort, DatabaseMaxOpen, DatabaseMaxIdle                                                            int
-	HealthInterval, UpstreamTimeout, ShutdownTimeout, RequestRetention, GPUPriceSyncInterval                           time.Duration
+	HealthInterval, UpstreamTimeout, ShutdownTimeout, RequestRetention, GPUPriceSyncInterval, HFCatalogRefreshInterval time.Duration
 	OptimizationPrices                                                                                                 []OptimizationPrice
 }
 
@@ -299,6 +299,10 @@ func load(requireAPIKey bool) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	hfCatalogRefreshSeconds, err := envInt("INFERCRANE_HF_CATALOG_REFRESH_SECONDS", 0)
+	if err != nil {
+		return Config{}, err
+	}
 	runPodContainerDiskGiB, err := envInt("INFERCRANE_RUNPOD_CONTAINER_DISK_GIB", 100)
 	if err != nil {
 		return Config{}, err
@@ -452,7 +456,8 @@ func load(requireAPIKey bool) (Config, error) {
 		Port:                                port, RouterStartPort: routerPort, DatabaseMaxOpen: maxOpen, DatabaseMaxIdle: maxIdle,
 		HealthInterval: time.Duration(healthSeconds) * time.Second, UpstreamTimeout: time.Duration(upstreamSeconds) * time.Second,
 		ShutdownTimeout: time.Duration(shutdownSeconds) * time.Second, RequestRetention: time.Duration(retentionHours) * time.Hour,
-		GPUPriceSyncInterval: time.Duration(gpuPriceSyncSeconds) * time.Second,
+		GPUPriceSyncInterval:     time.Duration(gpuPriceSyncSeconds) * time.Second,
+		HFCatalogRefreshInterval: time.Duration(hfCatalogRefreshSeconds) * time.Second,
 	}
 	// SkyPilot is an explicit long-tail execution boundary. A RunPod API key by
 	// itself selects the native RunPod adapter and must not silently opt the
@@ -498,6 +503,9 @@ func load(requireAPIKey bool) (Config, error) {
 	}
 	if config.GPUPriceSyncInterval != 0 && (config.GPUPriceSyncInterval < time.Minute || config.GPUPriceSyncInterval > 24*time.Hour) {
 		return Config{}, fmt.Errorf("INFERCRANE_GPU_PRICE_SYNC_SECONDS must be 0 or between 60 and 86400")
+	}
+	if config.HFCatalogRefreshInterval != 0 && (config.HFCatalogRefreshInterval < 5*time.Minute || config.HFCatalogRefreshInterval > 24*time.Hour) {
+		return Config{}, fmt.Errorf("INFERCRANE_HF_CATALOG_REFRESH_SECONDS must be 0 or between 300 and 86400")
 	}
 	if config.RunPodContainerDiskGiB < 50 || config.RunPodContainerDiskGiB > 2048 {
 		return Config{}, fmt.Errorf("INFERCRANE_RUNPOD_CONTAINER_DISK_GIB must be between 50 and 2048")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -100,6 +100,23 @@ func TestGPUPriceSyncIntervalIsBounded(t *testing.T) {
 	}
 }
 
+func TestHFCatalogRefreshIntervalIsBoundedAndOptIn(t *testing.T) {
+	t.Setenv("INFERCRANE_API_KEY", "test-key")
+	cfg, err := Load()
+	if err != nil || cfg.HFCatalogRefreshInterval != 0 {
+		t.Fatalf("default Hugging Face refresh=%s err=%v", cfg.HFCatalogRefreshInterval, err)
+	}
+	t.Setenv("INFERCRANE_HF_CATALOG_REFRESH_SECONDS", "21600")
+	cfg, err = Load()
+	if err != nil || cfg.HFCatalogRefreshInterval != 6*time.Hour {
+		t.Fatalf("configured Hugging Face refresh=%s err=%v", cfg.HFCatalogRefreshInterval, err)
+	}
+	t.Setenv("INFERCRANE_HF_CATALOG_REFRESH_SECONDS", "299")
+	if _, err = Load(); err == nil || !strings.Contains(err.Error(), "INFERCRANE_HF_CATALOG_REFRESH_SECONDS") {
+		t.Fatalf("unsafe Hugging Face refresh interval accepted: %v", err)
+	}
+}
+
 func TestRunPodNetworkVolumesRequireImmutableExactMappings(t *testing.T) {
 	t.Setenv("INFERCRANE_API_KEY", "secret")
 	t.Setenv("INFERCRANE_RUNPOD_ARTIFACT_CACHE_POLICY", "required")

--- a/internal/controlapi/api.go
+++ b/internal/controlapi/api.go
@@ -33,6 +33,7 @@ import (
 	"github.com/infercrane/infercrane/internal/domain"
 	"github.com/infercrane/infercrane/internal/external"
 	"github.com/infercrane/infercrane/internal/finops"
+	"github.com/infercrane/infercrane/internal/hfcatalog"
 	"github.com/infercrane/infercrane/internal/integration"
 	"github.com/infercrane/infercrane/internal/intentplan"
 	"github.com/infercrane/infercrane/internal/lab"
@@ -294,6 +295,7 @@ type API struct {
 		ParseWebhook([]byte, string) (domain.ManagedPaymentEvent, error)
 	}
 	ModelAPICatalog  modelapicatalog.Catalog
+	HFCatalog        *hfcatalog.Cache
 	ComputeProviders []ComputeProvider
 	GPUPrices        []GPUPriceObservation
 	GPUPriceCatalog  interface {
@@ -370,6 +372,7 @@ func (a API) Handler() http.Handler {
 	mux.HandleFunc("GET /api/v1/integrations", a.auth(authz.Read, a.integrations))
 	mux.HandleFunc("GET /api/v1/catalog/models", a.auth(authz.Read, a.catalogModels))
 	mux.HandleFunc("GET /api/v1/catalog/models/{name}", a.auth(authz.Read, a.catalogModel))
+	mux.HandleFunc("GET /api/v1/catalog/hugging-face/models", a.auth(authz.Read, a.huggingFaceCatalogModels))
 	mux.HandleFunc("POST /api/v1/planning/intents", a.auth(authz.Read, a.planIntent))
 	mux.HandleFunc("GET /api/v1/model-api-catalog", a.auth(authz.Read, a.modelAPIModels))
 	mux.HandleFunc("GET /api/v1/model-api-catalog/{id}", a.auth(authz.Read, a.modelAPIModel))
@@ -611,6 +614,22 @@ func (a API) catalogModel(w http.ResponseWriter, r *http.Request) {
 		"model":              entry,
 		"performance_claims": false,
 	})
+}
+
+func (a API) huggingFaceCatalogModels(w http.ResponseWriter, r *http.Request) {
+	for key := range r.URL.Query() {
+		if key != "query" {
+			writeError(w, http.StatusBadRequest, "invalid_query", "only the query filter is supported")
+			return
+		}
+	}
+	query := strings.TrimSpace(r.URL.Query().Get("query"))
+	if len(query) > 256 {
+		writeError(w, http.StatusBadRequest, "invalid_query", "query must not exceed 256 bytes")
+		return
+	}
+	snapshot := a.HFCatalog.Snapshot(time.Now().UTC(), query)
+	writeJSON(w, http.StatusOK, snapshot)
 }
 
 // planIntent compiles only a side-effect-free starting configuration. Provider

--- a/internal/controlapi/api_test.go
+++ b/internal/controlapi/api_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/infercrane/infercrane/internal/curatedrecipe"
 	"github.com/infercrane/infercrane/internal/doctor"
 	"github.com/infercrane/infercrane/internal/domain"
+	"github.com/infercrane/infercrane/internal/hfcatalog"
 	"github.com/infercrane/infercrane/internal/integration"
 	"github.com/infercrane/infercrane/internal/intentplan"
 	"github.com/infercrane/infercrane/internal/modelapicatalog"
@@ -582,6 +583,42 @@ func TestModelAPICatalogPaginatesAndNeverExposesSupplierRouting(t *testing.T) {
 	handler.ServeHTTP(response, request)
 	if response.Code != http.StatusBadRequest {
 		t.Fatalf("invalid limit status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestHuggingFaceCatalogReturnsOnlyNormalizedCachedMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"Qwen/Qwen3-8B","author":"Qwen","sha":"b968826d9c46dd6066d109eabc6255188de91218","private":false,"gated":false,"pipeline_tag":"text-generation","cardData":{"license":"apache-2.0"},"siblings":[{"rfilename":"do-not-expose.bin"}]}`))
+	}))
+	defer server.Close()
+	cache, err := hfcatalog.New([]string{"Qwen/Qwen3-8B"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = cache.Refresh(context.Background(), hfcatalog.Client{BaseURL: server.URL, HTTPClient: server.Client()}); err != nil {
+		t.Fatal(err)
+	}
+	handler := (API{APIKey: "secret", HFCatalog: cache}).Handler()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/catalog/hugging-face/models?query=qwen", nil)
+	request.Header.Set("Authorization", "Bearer secret")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	body := response.Body.String()
+	for _, expected := range []string{`"schema_version":"infercrane.hugging-face-catalog/v1"`, `"repository":"Qwen/Qwen3-8B"`, `"provider":"huggingface_hub_api"`, `"current":true`, `not an InferCrane-reviewed deployment recipe`} {
+		if response.Code != http.StatusOK || !strings.Contains(body, expected) {
+			t.Fatalf("Hugging Face catalog status=%d missing=%q body=%s", response.Code, expected, body)
+		}
+	}
+	if strings.Contains(body, "do-not-expose.bin") || strings.Contains(body, `"siblings"`) {
+		t.Fatalf("raw upstream payload crossed the normalized catalog boundary: %s", body)
+	}
+
+	request = httptest.NewRequest(http.MethodGet, "/api/v1/catalog/hugging-face/models?limit=10", nil)
+	request.Header.Set("Authorization", "Bearer secret")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("unsupported filter status=%d body=%s", response.Code, response.Body.String())
 	}
 }
 

--- a/internal/hfcatalog/catalog.go
+++ b/internal/hfcatalog/catalog.go
@@ -1,0 +1,601 @@
+// Package hfcatalog ingests bounded, normalized metadata from the official
+// Hugging Face Hub API. It is intentionally separate from curatedrecipe:
+// upstream metadata is discovery evidence, never a deployment recipe,
+// compatibility qualification, performance claim, or availability signal.
+package hfcatalog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	SchemaVersion       = "infercrane.hugging-face-catalog/v1"
+	defaultBaseURL      = "https://huggingface.co"
+	defaultValidFor     = 24 * time.Hour
+	defaultHTTPTimeout  = 10 * time.Second
+	maxRepositories     = 64
+	maxResponseBytes    = 1 << 20
+	maxTags             = 64
+	maxLanguages        = 32
+	maxMetadataTextSize = 256
+)
+
+var expandedFields = []string{"author", "cardData", "downloads", "gated", "lastModified", "library_name", "likes", "pipeline_tag", "private", "sha", "tags"}
+
+type Provenance struct {
+	Provider    string    `json:"provider"`
+	Endpoint    string    `json:"endpoint"`
+	RetrievedAt time.Time `json:"retrieved_at"`
+	ValidUntil  time.Time `json:"valid_until"`
+}
+
+// Model contains only normalized, bounded metadata needed for catalog
+// discovery. Pointer fields preserve the distinction between zero/false and
+// metadata the upstream response did not provide.
+type Model struct {
+	Repository        string     `json:"repository"`
+	Author            *string    `json:"author,omitempty"`
+	Revision          *string    `json:"revision,omitempty"`
+	PipelineTag       *string    `json:"pipeline_tag,omitempty"`
+	LibraryName       *string    `json:"library_name,omitempty"`
+	Private           *bool      `json:"private,omitempty"`
+	Access            string     `json:"access"`
+	Downloads         *int64     `json:"downloads,omitempty"`
+	Likes             *int64     `json:"likes,omitempty"`
+	LastModified      *time.Time `json:"last_modified,omitempty"`
+	License           *string    `json:"license,omitempty"`
+	Languages         []string   `json:"languages,omitempty"`
+	Tags              []string   `json:"tags,omitempty"`
+	UnknownFields     []string   `json:"unknown_fields,omitempty"`
+	MetadataTruncated bool       `json:"metadata_truncated"`
+	Current           bool       `json:"current"`
+	Provenance        Provenance `json:"provenance"`
+}
+
+type Snapshot struct {
+	SchemaVersion       string     `json:"schema_version"`
+	State               string     `json:"state"`
+	Models              []Model    `json:"models"`
+	ConfiguredCount     int        `json:"configured_count"`
+	LastRefreshAttempt  *time.Time `json:"last_refresh_attempt,omitempty"`
+	LastSuccessfulFetch *time.Time `json:"last_successful_fetch,omitempty"`
+	Limitations         []string   `json:"limitations"`
+}
+
+// Cache publishes an atomic snapshot. A failed fetch retains the last good
+// record for that repository rather than replacing it with missing data.
+type Cache struct {
+	mu           sync.RWMutex
+	repositories []string
+	models       map[string]Model
+	lastAttempt  time.Time
+	lastSuccess  time.Time
+	lastPartial  bool
+}
+
+func New(repositories []string) (*Cache, error) {
+	if len(repositories) == 0 {
+		return nil, errors.New("Hugging Face catalog requires at least one repository")
+	}
+	if len(repositories) > maxRepositories {
+		return nil, fmt.Errorf("Hugging Face catalog supports at most %d repositories", maxRepositories)
+	}
+	seen := make(map[string]struct{}, len(repositories))
+	normalized := make([]string, 0, len(repositories))
+	for _, repository := range repositories {
+		repository = strings.TrimSpace(repository)
+		if !validRepository(repository) {
+			return nil, fmt.Errorf("invalid Hugging Face repository %q", repository)
+		}
+		if _, exists := seen[strings.ToLower(repository)]; exists {
+			continue
+		}
+		seen[strings.ToLower(repository)] = struct{}{}
+		normalized = append(normalized, repository)
+	}
+	sort.Slice(normalized, func(i, j int) bool { return strings.ToLower(normalized[i]) < strings.ToLower(normalized[j]) })
+	return &Cache{repositories: normalized, models: make(map[string]Model)}, nil
+}
+
+func validRepository(repository string) bool {
+	parts := strings.Split(repository, "/")
+	if len(parts) != 2 || len(repository) > 192 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." || len(part) > 96 {
+			return false
+		}
+		for _, char := range part {
+			if char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' || char >= '0' && char <= '9' || char == '-' || char == '_' || char == '.' {
+				continue
+			}
+			return false
+		}
+	}
+	return true
+}
+
+type Client struct {
+	BaseURL, Token string
+	HTTPClient     *http.Client
+	ValidFor       time.Duration
+	Now            func() time.Time
+}
+
+func (c Client) Fetch(ctx context.Context, repository string) (Model, error) {
+	if !validRepository(repository) {
+		return Model{}, errors.New("invalid Hugging Face repository")
+	}
+	base := strings.TrimRight(strings.TrimSpace(c.BaseURL), "/")
+	if base == "" {
+		base = defaultBaseURL
+	}
+	parsedBase, err := url.Parse(base)
+	if err != nil || (parsedBase.Scheme != "http" && parsedBase.Scheme != "https") || parsedBase.Host == "" || parsedBase.User != nil || parsedBase.RawQuery != "" || parsedBase.Fragment != "" {
+		return Model{}, errors.New("invalid Hugging Face API base URL")
+	}
+	if strings.TrimSpace(c.Token) != "" && (parsedBase.Scheme != "https" || !strings.EqualFold(parsedBase.Hostname(), "huggingface.co") || parsedBase.Port() != "" && parsedBase.Port() != "443") {
+		return Model{}, errors.New("refusing to send Hugging Face credentials to an untrusted endpoint")
+	}
+	ctx, cancel := context.WithTimeout(ctx, defaultHTTPTimeout)
+	defer cancel()
+	parts := strings.Split(repository, "/")
+	endpoint := base + "/api/models/" + url.PathEscape(parts[0]) + "/" + url.PathEscape(parts[1])
+	parsedEndpoint, _ := url.Parse(endpoint)
+	query := parsedEndpoint.Query()
+	for _, field := range expandedFields {
+		query.Add("expand", field)
+	}
+	parsedEndpoint.RawQuery = query.Encode()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedEndpoint.String(), nil)
+	if err != nil {
+		return Model{}, fmt.Errorf("create Hugging Face metadata request: %w", err)
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("User-Agent", "infercrane-hf-catalog/1")
+	if strings.TrimSpace(c.Token) != "" {
+		request.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+	client := c.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	// Never forward a bearer token across a redirect. The official model-info
+	// endpoint is canonical and should answer directly.
+	boundedClient := *client
+	boundedClient.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	response, err := boundedClient.Do(request)
+	if err != nil {
+		return Model{}, errors.New("Hugging Face metadata request failed")
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return Model{}, fmt.Errorf("Hugging Face metadata returned HTTP %d", response.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
+	if err != nil {
+		return Model{}, errors.New("read Hugging Face metadata response")
+	}
+	if len(body) > maxResponseBytes {
+		return Model{}, errors.New("Hugging Face metadata response exceeded 1 MiB")
+	}
+	return c.normalize(repository, parsedEndpoint.String(), body)
+}
+
+func (c Client) normalize(repository, endpoint string, body []byte) (Model, error) {
+	var upstream struct {
+		ID           string          `json:"id"`
+		ModelID      string          `json:"modelId"`
+		Author       *string         `json:"author"`
+		SHA          *string         `json:"sha"`
+		PipelineTag  *string         `json:"pipeline_tag"`
+		LibraryName  *string         `json:"library_name"`
+		Private      *bool           `json:"private"`
+		Gated        json.RawMessage `json:"gated"`
+		Downloads    *int64          `json:"downloads"`
+		Likes        *int64          `json:"likes"`
+		LastModified *string         `json:"lastModified"`
+		Tags         []string        `json:"tags"`
+		CardData     json.RawMessage `json:"cardData"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	if err := decoder.Decode(&upstream); err != nil {
+		return Model{}, errors.New("decode Hugging Face metadata response")
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return Model{}, errors.New("Hugging Face metadata response must contain exactly one JSON object")
+	}
+	identity := upstream.ID
+	if identity == "" {
+		identity = upstream.ModelID
+	}
+	if !strings.EqualFold(strings.TrimSpace(identity), repository) {
+		return Model{}, errors.New("Hugging Face metadata identity did not match the requested repository")
+	}
+	now := time.Now().UTC()
+	if c.Now != nil {
+		now = c.Now().UTC()
+	}
+	validFor := c.ValidFor
+	if validFor <= 0 {
+		validFor = defaultValidFor
+	}
+	model := Model{
+		Repository:    repository,
+		Author:        boundedString(upstream.Author),
+		PipelineTag:   boundedString(upstream.PipelineTag),
+		LibraryName:   boundedString(upstream.LibraryName),
+		Private:       upstream.Private,
+		Access:        normalizeAccess(upstream.Private, upstream.Gated),
+		Downloads:     nonnegative(upstream.Downloads),
+		Likes:         nonnegative(upstream.Likes),
+		Provenance:    Provenance{Provider: "huggingface_hub_api", Endpoint: endpoint, RetrievedAt: now, ValidUntil: now.Add(validFor)},
+		UnknownFields: make([]string, 0, 8),
+	}
+	for _, value := range []*string{upstream.Author, upstream.PipelineTag, upstream.LibraryName} {
+		if value != nil && len(strings.TrimSpace(*value)) > maxMetadataTextSize {
+			model.MetadataTruncated = true
+		}
+	}
+	if upstream.SHA != nil && validCommit(*upstream.SHA) {
+		value := strings.ToLower(strings.TrimSpace(*upstream.SHA))
+		model.Revision = &value
+	} else {
+		model.UnknownFields = append(model.UnknownFields, "revision")
+	}
+	if upstream.LastModified != nil {
+		if parsed, err := time.Parse(time.RFC3339, *upstream.LastModified); err == nil {
+			parsed = parsed.UTC()
+			model.LastModified = &parsed
+		} else {
+			model.UnknownFields = append(model.UnknownFields, "last_modified")
+		}
+	} else {
+		model.UnknownFields = append(model.UnknownFields, "last_modified")
+	}
+	var tagsTruncated bool
+	model.Tags, tagsTruncated = boundedStrings(upstream.Tags, maxTags)
+	model.MetadataTruncated = model.MetadataTruncated || tagsTruncated
+	license, languages, cardUnknown, truncated := normalizeCardData(upstream.CardData)
+	model.License, model.Languages = license, languages
+	model.MetadataTruncated = model.MetadataTruncated || truncated
+	model.UnknownFields = append(model.UnknownFields, cardUnknown...)
+	if model.Author == nil {
+		model.UnknownFields = append(model.UnknownFields, "author")
+	}
+	if model.PipelineTag == nil {
+		model.UnknownFields = append(model.UnknownFields, "pipeline_tag")
+	}
+	if model.LibraryName == nil {
+		model.UnknownFields = append(model.UnknownFields, "library_name")
+	}
+	if model.Private == nil {
+		model.UnknownFields = append(model.UnknownFields, "private")
+	}
+	if model.Downloads == nil {
+		model.UnknownFields = append(model.UnknownFields, "downloads")
+	}
+	if model.Likes == nil {
+		model.UnknownFields = append(model.UnknownFields, "likes")
+	}
+	if upstream.Tags == nil {
+		model.UnknownFields = append(model.UnknownFields, "tags")
+	}
+	if len(upstream.Gated) == 0 || string(upstream.Gated) == "null" {
+		model.UnknownFields = append(model.UnknownFields, "gated")
+	}
+	sort.Strings(model.UnknownFields)
+	return model, nil
+}
+
+func boundedString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	normalized := strings.TrimSpace(*value)
+	if normalized == "" || len(normalized) > maxMetadataTextSize {
+		return nil
+	}
+	return &normalized
+}
+
+func nonnegative(value *int64) *int64 {
+	if value == nil || *value < 0 {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func validCommit(value string) bool {
+	value = strings.TrimSpace(value)
+	if len(value) < 40 || len(value) > 64 {
+		return false
+	}
+	for _, char := range value {
+		if char >= '0' && char <= '9' || char >= 'a' && char <= 'f' || char >= 'A' && char <= 'F' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func normalizeAccess(private *bool, gated json.RawMessage) string {
+	if private != nil && *private {
+		return "private"
+	}
+	var gatedBool bool
+	if len(gated) > 0 && json.Unmarshal(gated, &gatedBool) == nil {
+		if gatedBool {
+			return "gated"
+		}
+		if private != nil {
+			return "public"
+		}
+	}
+	var gatedMode string
+	if json.Unmarshal(gated, &gatedMode) == nil && gatedMode != "" {
+		if len(gatedMode) > 64 {
+			return "gated"
+		}
+		return "gated-" + strings.ToLower(gatedMode)
+	}
+	if private != nil && !*private {
+		return "unknown"
+	}
+	return "unknown"
+}
+
+func normalizeCardData(raw json.RawMessage) (*string, []string, []string, bool) {
+	unknown := make([]string, 0, 2)
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil, []string{"languages", "license"}, false
+	}
+	var card map[string]json.RawMessage
+	if json.Unmarshal(raw, &card) != nil {
+		return nil, nil, []string{"languages", "license"}, false
+	}
+	var license *string
+	truncated := false
+	if value, exists := card["license"]; exists {
+		var decoded string
+		if json.Unmarshal(value, &decoded) == nil {
+			license = boundedString(&decoded)
+			if len(strings.TrimSpace(decoded)) > maxMetadataTextSize {
+				unknown = append(unknown, "license")
+				truncated = true
+			}
+		}
+	}
+	if license == nil && !containsString(unknown, "license") {
+		unknown = append(unknown, "license")
+	}
+	languages, languagesTruncated := decodeStringList(card["language"], maxLanguages)
+	if len(languages) == 0 {
+		unknown = append(unknown, "languages")
+	}
+	return license, languages, unknown, truncated || languagesTruncated
+}
+
+func decodeStringList(raw json.RawMessage, limit int) ([]string, bool) {
+	if len(raw) == 0 {
+		return nil, false
+	}
+	var values []string
+	if json.Unmarshal(raw, &values) != nil {
+		var single string
+		if json.Unmarshal(raw, &single) != nil {
+			return nil, false
+		}
+		values = []string{single}
+	}
+	return boundedStrings(values, limit)
+}
+
+func boundedStrings(values []string, limit int) ([]string, bool) {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	truncated := false
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || len(value) > maxMetadataTextSize {
+			truncated = true
+			continue
+		}
+		key := strings.ToLower(value)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Slice(out, func(i, j int) bool { return strings.ToLower(out[i]) < strings.ToLower(out[j]) })
+	if len(out) > limit {
+		out = out[:limit]
+		truncated = true
+	}
+	return out, truncated
+}
+
+func (c *Cache) Refresh(ctx context.Context, client Client) error {
+	if c == nil {
+		return errors.New("Hugging Face catalog cache is nil")
+	}
+	repositories := append([]string(nil), c.repositories...)
+	type result struct {
+		model Model
+		err   error
+	}
+	results := make([]result, len(repositories))
+	jobs := make(chan int)
+	workers := min(4, len(repositories))
+	var group sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			for index := range jobs {
+				results[index].model, results[index].err = client.Fetch(ctx, repositories[index])
+			}
+		}()
+	}
+	for index := range repositories {
+		select {
+		case jobs <- index:
+		case <-ctx.Done():
+			close(jobs)
+			group.Wait()
+			return ctx.Err()
+		}
+	}
+	close(jobs)
+	group.Wait()
+
+	attemptedAt := time.Now().UTC()
+	if client.Now != nil {
+		attemptedAt = client.Now().UTC()
+	}
+	c.mu.Lock()
+	next := cloneModels(c.models)
+	succeeded := 0
+	failures := make([]string, 0)
+	for index, result := range results {
+		if result.err != nil {
+			failures = append(failures, repositories[index]+": "+result.err.Error())
+			continue
+		}
+		next[repositories[index]] = result.model
+		succeeded++
+	}
+	c.lastAttempt = attemptedAt
+	if succeeded > 0 {
+		c.models = next
+		c.lastSuccess = attemptedAt
+	}
+	c.lastPartial = len(failures) > 0
+	c.mu.Unlock()
+	if len(failures) > 0 {
+		return errors.New("Hugging Face catalog refresh incomplete: " + strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+func (c *Cache) Snapshot(now time.Time, query string) Snapshot {
+	if c == nil {
+		return Snapshot{SchemaVersion: SchemaVersion, State: "unavailable", Limitations: limitations()}
+	}
+	query = strings.ToLower(strings.TrimSpace(query))
+	c.mu.RLock()
+	models := cloneModels(c.models)
+	configuredCount := len(c.repositories)
+	lastAttempt, lastSuccess, lastPartial := c.lastAttempt, c.lastSuccess, c.lastPartial
+	c.mu.RUnlock()
+	items := make([]Model, 0, len(models))
+	currentCount := 0
+	for _, model := range models {
+		model.Current = !model.Provenance.RetrievedAt.IsZero() && now.Before(model.Provenance.ValidUntil)
+		if model.Current {
+			currentCount++
+		}
+		if query != "" && !modelMatches(model, query) {
+			continue
+		}
+		items = append(items, model)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return strings.ToLower(items[i].Repository) < strings.ToLower(items[j].Repository)
+	})
+	state := "current"
+	if len(models) == 0 {
+		state = "unavailable"
+	} else if currentCount == 0 {
+		state = "stale"
+	} else if currentCount != configuredCount || len(models) != configuredCount || lastPartial {
+		state = "partial"
+	}
+	snapshot := Snapshot{SchemaVersion: SchemaVersion, State: state, Models: items, ConfiguredCount: configuredCount, Limitations: limitations()}
+	if !lastAttempt.IsZero() {
+		value := lastAttempt
+		snapshot.LastRefreshAttempt = &value
+	}
+	if !lastSuccess.IsZero() {
+		value := lastSuccess
+		snapshot.LastSuccessfulFetch = &value
+	}
+	return snapshot
+}
+
+func modelMatches(model Model, query string) bool {
+	values := []string{model.Repository, model.Access}
+	for _, value := range []*string{model.Author, model.PipelineTag, model.LibraryName, model.License} {
+		if value != nil {
+			values = append(values, *value)
+		}
+	}
+	values = append(values, model.Tags...)
+	values = append(values, model.Languages...)
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), query) {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneModels(source map[string]Model) map[string]Model {
+	out := make(map[string]Model, len(source))
+	for key, model := range source {
+		model.Author = clonePointer(model.Author)
+		model.Revision = clonePointer(model.Revision)
+		model.PipelineTag = clonePointer(model.PipelineTag)
+		model.LibraryName = clonePointer(model.LibraryName)
+		model.Private = clonePointer(model.Private)
+		model.Downloads = clonePointer(model.Downloads)
+		model.Likes = clonePointer(model.Likes)
+		model.LastModified = clonePointer(model.LastModified)
+		model.License = clonePointer(model.License)
+		model.Tags = append([]string(nil), model.Tags...)
+		model.Languages = append([]string(nil), model.Languages...)
+		model.UnknownFields = append([]string(nil), model.UnknownFields...)
+		out[key] = model
+	}
+	return out
+}
+
+func clonePointer[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func limitations() []string {
+	return []string{
+		"Hugging Face metadata is upstream discovery evidence, not an InferCrane-reviewed deployment recipe.",
+		"Metadata does not establish runtime compatibility, GPU fit, performance, price, capacity, license approval, or deployability.",
+		"Only the bounded repositories already configured by InferCrane are fetched; this endpoint is not a mirror of the Hugging Face Hub.",
+	}
+}

--- a/internal/hfcatalog/catalog_test.go
+++ b/internal/hfcatalog/catalog_test.go
@@ -1,0 +1,153 @@
+package hfcatalog
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) { return f(request) }
+
+func TestOfficialMetadataIsBoundedNormalizedAndProvenanced(t *testing.T) {
+	now := time.Date(2026, time.September, 1, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/models/Qwen/Qwen3-8B" || r.Header.Get("Accept") != "application/json" || !strings.HasPrefix(r.Header.Get("User-Agent"), "infercrane-hf-catalog/") {
+			t.Fatalf("unexpected request: method=%s path=%s headers=%v", r.Method, r.URL.Path, r.Header)
+		}
+		if got := len(r.URL.Query()["expand"]); got != len(expandedFields) {
+			t.Fatalf("expand fields=%v", r.URL.Query()["expand"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "id":"Qwen/Qwen3-8B",
+  "author":"Qwen",
+  "sha":"b968826d9c46dd6066d109eabc6255188de91218",
+  "pipeline_tag":"text-generation",
+  "private":false,
+  "gated":false,
+  "downloads":42,
+  "likes":7,
+  "lastModified":"2026-08-31T10:00:00Z",
+  "tags":["transformers","text-generation","transformers"],
+  "cardData":{"license":"apache-2.0","language":["en","zh"]},
+  "siblings":[{"rfilename":"weights-secret-to-the-catalog.bin"}],
+  "future_upstream_field":{"large":"not copied into the normalized record"}
+}`))
+	}))
+	defer server.Close()
+
+	cache, err := New([]string{"Qwen/Qwen3-8B"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := Client{BaseURL: server.URL, HTTPClient: server.Client(), Now: func() time.Time { return now }, ValidFor: time.Hour}
+	if err = cache.Refresh(context.Background(), client); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := cache.Snapshot(now.Add(time.Minute), "qwen")
+	if snapshot.State != "current" || len(snapshot.Models) != 1 || snapshot.ConfiguredCount != 1 {
+		t.Fatalf("snapshot=%+v", snapshot)
+	}
+	model := snapshot.Models[0]
+	if model.Repository != "Qwen/Qwen3-8B" || model.Revision == nil || *model.Revision != "b968826d9c46dd6066d109eabc6255188de91218" || model.Access != "public" || model.License == nil || *model.License != "apache-2.0" || !model.Current {
+		t.Fatalf("model=%+v", model)
+	}
+	if len(model.Tags) != 2 || len(model.Languages) != 2 || !contains(model.UnknownFields, "library_name") || strings.Contains(model.Provenance.Endpoint, "weights-secret") {
+		t.Fatalf("unbounded or ambiguous normalized metadata=%+v", model)
+	}
+}
+
+func TestRefreshRetainsLastGoodRecordOnFailure(t *testing.T) {
+	now := time.Date(2026, time.September, 1, 12, 0, 0, 0, time.UTC)
+	var fail atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if fail.Load() {
+			http.Error(w, "temporary upstream detail", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"BAAI/bge-m3","sha":"5617a9f61b028005a4858fdac845db406aefb181","private":false,"gated":false,"cardData":{}}`))
+	}))
+	defer server.Close()
+
+	cache, err := New([]string{"BAAI/bge-m3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := Client{BaseURL: server.URL, HTTPClient: server.Client(), Now: func() time.Time { return now }}
+	if err = cache.Refresh(context.Background(), client); err != nil {
+		t.Fatal(err)
+	}
+	fail.Store(true)
+	now = now.Add(time.Hour)
+	if err = cache.Refresh(context.Background(), client); err == nil || strings.Contains(err.Error(), "temporary upstream detail") {
+		t.Fatalf("unsafe or missing refresh error: %v", err)
+	}
+	snapshot := cache.Snapshot(now, "")
+	if len(snapshot.Models) != 1 || snapshot.Models[0].Revision == nil || *snapshot.Models[0].Revision != "5617a9f61b028005a4858fdac845db406aefb181" || snapshot.State != "partial" {
+		t.Fatalf("last-good metadata was not retained: %+v", snapshot)
+	}
+}
+
+func TestClientBoundsResponsesAndProtectsToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"Qwen/Qwen3-8B","padding":"` + strings.Repeat("x", maxResponseBytes) + `"}`))
+	}))
+	defer server.Close()
+	_, err := (Client{BaseURL: server.URL, HTTPClient: server.Client()}).Fetch(context.Background(), "Qwen/Qwen3-8B")
+	if err == nil || !strings.Contains(err.Error(), "exceeded 1 MiB") {
+		t.Fatalf("oversized response err=%v", err)
+	}
+	_, err = (Client{BaseURL: server.URL, Token: "never-send-this", HTTPClient: server.Client()}).Fetch(context.Background(), "Qwen/Qwen3-8B")
+	if err == nil || !strings.Contains(err.Error(), "untrusted endpoint") || strings.Contains(err.Error(), "never-send-this") {
+		t.Fatalf("token boundary err=%v", err)
+	}
+}
+
+func TestClientDoesNotFollowAuthenticatedRedirects(t *testing.T) {
+	var calls atomic.Int32
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		if request.URL.Hostname() != "huggingface.co" || request.Header.Get("Authorization") != "Bearer secret" {
+			t.Fatalf("unexpected authenticated request: url=%s authorization=%q", request.URL, request.Header.Get("Authorization"))
+		}
+		return &http.Response{
+			StatusCode: http.StatusFound,
+			Header:     http.Header{"Location": []string{"https://attacker.example/steal"}},
+			Body:       io.NopCloser(strings.NewReader("redirect")),
+			Request:    request,
+		}, nil
+	})
+	_, err := (Client{Token: "secret", HTTPClient: &http.Client{Transport: transport}}).Fetch(context.Background(), "Qwen/Qwen3-8B")
+	if err == nil || !strings.Contains(err.Error(), "HTTP 302") || calls.Load() != 1 {
+		t.Fatalf("authenticated redirect was followed: calls=%d err=%v", calls.Load(), err)
+	}
+}
+
+func TestCatalogRejectsUnboundedOrUnsafeRepositorySets(t *testing.T) {
+	if _, err := New([]string{"../../etc/passwd"}); err == nil {
+		t.Fatal("unsafe repository was accepted")
+	}
+	repositories := make([]string, maxRepositories+1)
+	for index := range repositories {
+		repositories[index] = "org/model-" + strings.Repeat("x", index%3)
+	}
+	if _, err := New(repositories); err == nil {
+		t.Fatal("unbounded repository set was accepted")
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/sdk/python/src/infercrane/generated/api.py
+++ b/sdk/python/src/infercrane/generated/api.py
@@ -55,6 +55,10 @@ class ControlAPI:
         path = f"/catalog/models/{quote(name, safe='')}"
         return cast(dict[str, Any], self._transport.request("GET", path))
 
+    def list_hugging_face_catalog_models(self) -> dict[str, Any]:
+        path = "/catalog/hugging-face/models"
+        return cast(dict[str, Any], self._transport.request("GET", path))
+
     def plan_intent(self, *, body: dict[str, Any]) -> IntentPlanEnvelope:
         path = "/planning/intents"
         return cast(IntentPlanEnvelope, self._transport.request("POST", path, body=body))

--- a/sdk/typescript/src/generated/api.ts
+++ b/sdk/typescript/src/generated/api.ts
@@ -58,6 +58,11 @@ export class ControlApi {
     return this.transport.request('GET', path) as Promise<Record<string, JsonValue>>;
   }
 
+  listHuggingFaceCatalogModels(): Promise<Record<string, JsonValue>> {
+    const path = '/catalog/hugging-face/models';
+    return this.transport.request('GET', path) as Promise<Record<string, JsonValue>>;
+  }
+
   planIntent(body: JsonValue): Promise<IntentPlanEnvelope> {
     const path = '/planning/intents';
     return this.transport.request('POST', path, { body }) as Promise<IntentPlanEnvelope>;


### PR DESCRIPTION
## Outcome

- adds an authenticated, bounded Hugging Face metadata catalog with freshness and provenance
- records the hosted Model API to customer-cloud architecture and rollout boundaries
- adds a durable product capability map for website and console truth

## Verification

- ./scripts/verify-repository.sh
all modules verified
Repository hygiene boundaries verified.
Apache-2.0 core, SDK, archive, image, and dependency license boundaries verified.
Candidate and stable publication remain manual, protected, draft-first, attested, and OIDC-scoped.
Release tag safety verified.
ok  	github.com/infercrane/infercrane/cmd/infercrane	1.755s
ok  	github.com/infercrane/infercrane/internal/accounting	1.725s
ok  	github.com/infercrane/infercrane/internal/admission	2.050s
ok  	github.com/infercrane/infercrane/internal/alert	2.322s
ok  	github.com/infercrane/infercrane/internal/apicontract	2.630s
ok  	github.com/infercrane/infercrane/internal/artifact	2.798s
ok  	github.com/infercrane/infercrane/internal/artifactcache	3.027s
ok  	github.com/infercrane/infercrane/internal/asyncinference	4.262s
ok  	github.com/infercrane/infercrane/internal/authn	3.637s
ok  	github.com/infercrane/infercrane/internal/authz	3.716s
ok  	github.com/infercrane/infercrane/internal/autoscale	2.437s
ok  	github.com/infercrane/infercrane/internal/benchmark	2.667s
ok  	github.com/infercrane/infercrane/internal/burstguard	2.576s
ok  	github.com/infercrane/infercrane/internal/capacity	2.499s
ok  	github.com/infercrane/infercrane/internal/config	2.438s
ok  	github.com/infercrane/infercrane/internal/conformance	2.526s
ok  	github.com/infercrane/infercrane/internal/contextpassport	2.494s
ok  	github.com/infercrane/infercrane/internal/controlapi	2.365s
ok  	github.com/infercrane/infercrane/internal/controlclient	2.340s
ok  	github.com/infercrane/infercrane/internal/curatedrecipe	2.284s
ok  	github.com/infercrane/infercrane/internal/decision	2.311s
ok  	github.com/infercrane/infercrane/internal/doctor	2.598s
?   	github.com/infercrane/infercrane/internal/domain	[no test files]
ok  	github.com/infercrane/infercrane/internal/external	2.657s
ok  	github.com/infercrane/infercrane/internal/finops	2.663s
ok  	github.com/infercrane/infercrane/internal/gateway	2.884s
ok  	github.com/infercrane/infercrane/internal/hfcatalog	2.684s
ok  	github.com/infercrane/infercrane/internal/integration	2.753s
ok  	github.com/infercrane/infercrane/internal/intentplan	2.452s
ok  	github.com/infercrane/infercrane/internal/lab	2.631s
ok  	github.com/infercrane/infercrane/internal/managedbilling	2.693s
ok  	github.com/infercrane/infercrane/internal/metrics	2.665s
ok  	github.com/infercrane/infercrane/internal/modelapicatalog	2.590s
ok  	github.com/infercrane/infercrane/internal/modelapisupply	2.561s
ok  	github.com/infercrane/infercrane/internal/nodediscovery	2.542s
ok  	github.com/infercrane/infercrane/internal/openaicompat	2.312s
ok  	github.com/infercrane/infercrane/internal/operations	3.464s
ok  	github.com/infercrane/infercrane/internal/optimizationcampaign	2.467s
ok  	github.com/infercrane/infercrane/internal/optimizationcapability	2.462s
ok  	github.com/infercrane/infercrane/internal/optimizedartifact	2.467s
ok  	github.com/infercrane/infercrane/internal/optimizer	9.188s
ok  	github.com/infercrane/infercrane/internal/overflow	2.446s
ok  	github.com/infercrane/infercrane/internal/passport	2.474s
ok  	github.com/infercrane/infercrane/internal/performanceprofile	2.433s
ok  	github.com/infercrane/infercrane/internal/planning	2.447s
ok  	github.com/infercrane/infercrane/internal/priceingest	3.674s
ok  	github.com/infercrane/infercrane/internal/pricing	3.745s
ok  	github.com/infercrane/infercrane/internal/provideridentity	3.768s
ok  	github.com/infercrane/infercrane/internal/provision	7.942s
ok  	github.com/infercrane/infercrane/internal/qualityevidence	3.824s
ok  	github.com/infercrane/infercrane/internal/readiness	3.816s
ok  	github.com/infercrane/infercrane/internal/recipe	3.809s
ok  	github.com/infercrane/infercrane/internal/reconcile	3.861s
ok  	github.com/infercrane/infercrane/internal/releaseguard	3.916s
ok  	github.com/infercrane/infercrane/internal/replay	2.842s
ok  	github.com/infercrane/infercrane/internal/requestquota	2.787s
ok  	github.com/infercrane/infercrane/internal/router	2.790s
ok  	github.com/infercrane/infercrane/internal/routes	2.571s
ok  	github.com/infercrane/infercrane/internal/runtime	2.876s
ok  	github.com/infercrane/infercrane/internal/runtimecontract	2.956s
ok  	github.com/infercrane/infercrane/internal/safehttp	3.169s
ok  	github.com/infercrane/infercrane/internal/secrets	3.187s
ok  	github.com/infercrane/infercrane/internal/servingcontract	2.950s
ok  	github.com/infercrane/infercrane/internal/spec	2.674s
ok  	github.com/infercrane/infercrane/internal/store	2.516s
ok  	github.com/infercrane/infercrane/internal/support	2.614s
?   	github.com/infercrane/infercrane/internal/testtools/fake-router	[no test files]
?   	github.com/infercrane/infercrane/internal/testtools/fake-vllm	[no test files]
?   	github.com/infercrane/infercrane/internal/testtools/providerfixture	[no test files]
?   	github.com/infercrane/infercrane/internal/testtools/runpod-fault-proxy	[no test files]
ok  	github.com/infercrane/infercrane/internal/trainingartifact	2.547s
ok  	github.com/infercrane/infercrane/internal/workflows	2.511s
ok  	github.com/infercrane/infercrane/internal/workloadproject	2.506s
?   	github.com/infercrane/infercrane/tools/contract-qualifier	[no test files]
ok  	github.com/infercrane/infercrane/tools/kubernetes-manifest-check	2.410s
ok  	github.com/infercrane/infercrane/tools/openapi-codegen	2.460s
Processing ./sdk/python
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Building wheels for collected packages: infercrane
  Building wheel for infercrane (pyproject.toml): started
  Building wheel for infercrane (pyproject.toml): finished with status 'done'
  Created wheel for infercrane: filename=infercrane-1.0.0-py3-none-any.whl size=17024 sha256=393e858acf6bcb8493b799bd0205748c6ba7eb0a1996cffb66f0cb366bbc0974
  Stored in directory: /private/var/folders/ws/r7l6v9690k13mgtsw_3_4ms00000gn/T/pip-ephem-wheel-cache-0xq_uv9e/wheels/c5/fb/db/15e300a2ba3ab901e97aeeaa54f8a3e33bb81a945b4f405f13
Successfully built infercrane

added 3 packages in 344ms

> @infercrane/sdk@1.0.0 test
> npm run build && node --test test/*.test.mjs


> @infercrane/sdk@1.0.0 build
> tsc -p tsconfig.json

✔ deploy preserves explicit idempotency and wait reaches terminal state (11.798958ms)
✔ deploy preserves portable runtime workload intent (0.609042ms)
✔ wait timeout never sends cancellation (3.561833ms)
✔ terminal and API errors are typed (0.337166ms)
✔ control-plane membership exposes mixed-version protocol evidence (0.192166ms)
✔ recipe and lab helpers preserve immutable measured evidence (0.281833ms)
✔ streaming parses fragmented SSE without replay (0.381917ms)
✔ stream requires a terminal done event (0.115125ms)
✔ SLO and recommendation helpers preserve explicit evidence policy (0.375542ms)
ℹ tests 9
ℹ suites 0
ℹ pass 9
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 52.063125
infercrane-1.0.0-py3-none-any.whl: OK
infercrane-sdk-1.0.0.tgz: OK
SDK artifacts verified: Python 1.0.0 and npm 1.0.0, Apache-2.0 notices, and SHA-256 checksums.
✔ semantic Markdown is deterministic, ordered, and free of ANSI (0.407625ms)
✔ release checks require exact revision and convergence (0.099583ms)
✔ secret values and terminal escapes are removed (0.14ms)
✔ automatic CLI resolution requires an exact pinned release (0.25675ms)
✔ plan mode writes JSON and summary using an existing CLI (671.821625ms)
✔ apply is refused without explicit confirmation (30.571ms)
✔ apply records the stable endpoint and durable operation (665.165792ms)
✔ release check requires and records a verified passport (717.310166ms)
ℹ tests 8
ℹ suites 0
ℹ pass 8
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 2122.562958
?   	github.com/infercrane/infercrane/integrations/terraform	[no test files]
ok  	github.com/infercrane/infercrane/integrations/terraform/internal/provider	0.404s
runtime image publication contract passed
Fly control-plane profile passed
provider-neutral hosted control-plane contract passed
- repository hygiene, license, release, Go race suite, SDK, Terraform, image, and hosted control-plane contracts passed

## Safety

The catalog is read-only, bounded, last-good cached, and never promotes Hub metadata into a reviewed deployment recipe. Hosted and customer-owned delivery remain two modes of the same immutable model contract.