### PR TITLE
Add durable hosted Model API foundation

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -25,6 +25,8 @@ INFERCRANE_PORT=8080
 # must be readable only by the control plane; its internal fields are never
 # returned by the customer catalog API.
 # INFERCRANE_MODEL_API_CATALOG_FILE=/run/secrets/model-api-catalog.json
+# Operator-controlled supplier/adapter base URLs. Credentials remain tenant-scoped secret references.
+# INFERCRANE_HOSTED_MODEL_API_ENDPOINTS_JSON={"openrouter/openai":"https://openrouter.ai/api/v1"}
 # Set to 21600 for a six-hour refresh of bounded metadata for reviewed Hugging Face repositories.
 # Optional HF_TOKEN should be a fine-grained read token and is sent only to https://huggingface.co.
 # INFERCRANE_HF_CATALOG_REFRESH_SECONDS=21600

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,133 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Stack
+
+InferCrane's control plane and inference gateway are implemented in Go. The
+customer-facing landing site and authenticated console are a separately
+deployed Next.js/React application consuming the authenticated control API.
+
+## Users
+
+- Developers and AI-native teams that want production access to a curated set
+  of high-value open models without operating inference infrastructure.
+- Growing companies that need to move a workload from shared serverless APIs to
+  dedicated capacity without changing the application-facing API.
+- Enterprise platform and infrastructure teams that need governed deployment,
+  observability, release safety, private networking, residency, or customer-cloud
+  operation.
+
+## Product Purpose
+
+InferCrane is designed to give an application one stable OpenAI-compatible model
+API while qualified suppliers, runtimes, providers, revisions, and deployment
+modes can change underneath it. The initial hosted product is a curated
+pay-as-you-go model catalog. An exact model contract can later move to
+InferCrane-managed dedicated capacity or the customer's own cloud only when its
+model, revision, license, artifacts, and API behavior are legally and technically
+self-hostable.
+
+Success means a new user can select a model, create a key, run a streamed request,
+and see its usage and cost in minutes; a growing customer can later change the
+serving mode without rewriting their integration.
+
+## Positioning
+
+Target market position, after route-level performance qualification:
+
+**Fast model APIs. Complete inference infrastructure.**
+
+Start with qualified open-model APIs. When dedicated capacity becomes useful,
+InferCrane deploys, autoscales, routes, measures, and improves the serving stack
+behind the same stable API contract. Public use of `fast` or `optimized` must be
+supported by current evidence for the routes being offered.
+
+The catalog is the acquisition surface. The durable advantage is the continuous
+path from serverless to dedicated or customer-owned infrastructure, with shared
+policy, evidence, billing, and release controls.
+
+## Operating Context
+
+- The initial public catalog is planned around GLM-5.2, GLM-5.3, GLM-5.3-Flash,
+  Kimi-K3, Kimi-K2.6, and DeepSeek-V4-Flash-0731-Fast.
+- Customers use one InferCrane API key and OpenAI-compatible endpoint.
+- Public model identities and prices are supplier-neutral. Private supply
+  offers contain upstream identity, cost, health, region, policy, and capacity.
+- The MVP may use qualified external suppliers. LiteLLM can remain a replaceable
+  internal translation boundary; it is not the customer-facing product owner.
+- Customer usage is prepaid. Funds are reserved before supplier transmission,
+  settled from actual usage, and blocked when credit is insufficient.
+
+## Capabilities and Constraints
+
+- Curated model discovery, stable logical model identities, API keys, streaming,
+  usage, spend controls, prepaid billing, health-aware primary/fallback routing,
+  and supplier-neutral public contracts are core hosted-model capabilities.
+- Planning, deployment, adoption, observation, benchmarking, optimization,
+  Release Guard, rollback, and provider/runtime adapters are existing control-plane
+  capabilities; exact real-infrastructure support remains evidence-bound.
+- Exact model requests must never silently substitute a different model. Optional
+  outcome aliases may route across models only with explicit customer consent.
+- Hosted-to-dedicated migration under the same public model ID is allowed only
+  for the exact legally and technically self-hostable model/revision and a
+  qualified equivalent API contract. A different model requires a new public ID
+  and an explicit customer-approved quality migration.
+- Hugging Face can supply candidate metadata, immutable artifact identity, and
+  organization assets. InferCrane remains authoritative for customer price,
+  capabilities, availability, qualification, and performance evidence.
+- The hosted cloud service is not generally available yet. Real supplier
+  behavior, commercial resale rights, current rates, reconciliation, and each
+  model/runtime/provider/GPU tuple require qualification before public claims.
+- Public claims such as fastest, zero data retention, residency, or self-hosted
+  must be shown only when the complete selected route has current evidence.
+
+Open decisions include initial supplier contracts, final retail rate cards,
+which catalog entries launch as Recommended versus Available or Preview, and
+the first model whose traffic justifies InferCrane-managed warm capacity.
+
+## Brand Commitments
+
+- Product name: InferCrane.
+- Target lead after route-level qualification: **Fast model APIs. Complete
+  inference infrastructure.** Before then, use evidence-neutral hosted-model
+  language or scope performance claims to a named measured route.
+- Approved supporting idea: start serverless, then move to dedicated or the
+  customer's cloud without changing the application integration.
+- Product language must be concise, evidence-led, technically credible, and
+  suitable for both developers and enterprise buyers.
+
+## Evidence on Hand
+
+- `docs/product-capabilities.md` is the short product-truth map.
+- `docs/testing/feature-qualification-matrix.md` records implemented contracts,
+  qualification evidence, and real-infrastructure gaps.
+- `docs/architecture/system.mdx` defines the database-free request path and
+  replaceable provider/runtime boundaries.
+- The repository contains local contracts for the hosted catalog, prepaid
+  billing, supplier planning, routing, RunPod Serverless, OpenAI-compatible
+  providers, LiteLLM composition, and Hugging Face catalog ingestion.
+- No customer testimonial, production SLA, public benchmark for the six planned
+  models, or generally available hosted-cloud claim is currently established;
+  future surfaces must not fabricate them.
+
+## Product Principles
+
+1. Keep the customer contract stable while supply remains replaceable.
+2. Curate and qualify models rather than presenting an unbounded model dump.
+3. Measure price, availability, performance, quality, and compatibility as
+   separate claims; leave missing evidence unknown.
+4. Spend only after authority: prepaid hosted usage, reversible plans before
+   deployment, and customer or traffic commitments before warm GPU capacity.
+5. Let serverless adoption graduate into dedicated or customer-owned operation
+   without creating a second product model.
+
+## Accessibility & Inclusion
+
+The web experience must be responsive, keyboard operable, compatible with
+automated accessibility testing, and must not communicate availability,
+qualification, errors, or cost using color alone.

--- a/cmd/infercrane/main.go
+++ b/cmd/infercrane/main.go
@@ -50,6 +50,7 @@ import (
 	"github.com/infercrane/infercrane/internal/integration"
 	"github.com/infercrane/infercrane/internal/managedbilling"
 	"github.com/infercrane/infercrane/internal/modelapicatalog"
+	"github.com/infercrane/infercrane/internal/modelapirouting"
 	"github.com/infercrane/infercrane/internal/operations"
 	"github.com/infercrane/infercrane/internal/optimizationcampaign"
 	"github.com/infercrane/infercrane/internal/passport"
@@ -4336,7 +4337,24 @@ func serve(parent context.Context, cfg config.Config, s *store.Store) error {
 			launchProbers[provider.ID] = provision.ConfiguredLaunchProbe{Provider: provider.ID}
 		}
 	}
-	controlAPI := controlapi.API{Store: s, APIKey: cfg.APIKey, Authenticator: controlAuthenticator, BenchmarkRunner: benchmark.Runner{}, Diagnostics: diagnostics, Backends: benchmarkBackends, Integrations: integrationRegistry.Snapshot(), GatewayURL: cfg.ControlURL, AIPerfBinary: cfg.AIPerfBinary, PassportPrivateKey: passportKey, EndpointRefresh: rec.RefreshEndpoints, CredentialRefresh: credentialCache.Refresh, AlertDeliverer: alert.Deliverer{Store: s, Secrets: secrets.Environment{}}, ContextPassports: contextPassports, ArtifactCacheAdapters: artifactCacheAdapters, ProductVersion: version, GatewayInstanceID: cfg.InstanceID, AdmissionState: admissionPool, OptimizationCosts: optimizationCosts, ModelAPICatalog: modelAPICatalog, HFCatalog: hfCatalog, ComputeProviders: computeProviders, GPUPriceCatalog: priceCatalog, LaunchProbers: launchProbers, DefaultProviderAdapters: defaultProviderAdapters}
+	var hostedModels *modelapirouting.Runtime
+	if len(cfg.HostedModelAPIEndpoints) > 0 {
+		hostedRoutes := modelapirouting.NewDirectory()
+		targetResolver, resolverErr := modelapirouting.NewRegistryTargetResolver(cfg.HostedModelAPIEndpoints, s, secrets.Environment{})
+		if resolverErr != nil {
+			return fmt.Errorf("configure hosted Model API targets: %w", resolverErr)
+		}
+		publisher := &modelapirouting.Publisher{Store: s, Resolver: targetResolver, Directory: hostedRoutes, Interval: 15 * time.Second, Logger: logger}
+		publishCtx, publishCancel := context.WithTimeout(ctx, 15*time.Second)
+		publishErr := publisher.PublishOnce(publishCtx)
+		publishCancel()
+		if publishErr != nil {
+			return fmt.Errorf("load hosted Model API route snapshot: %w", publishErr)
+		}
+		go publisher.Run(ctx)
+		hostedModels = &modelapirouting.Runtime{Routes: hostedRoutes, Billing: store.ModelAPIBillingAdapter{Store: s}, Client: client, Logger: logger}
+	}
+	controlAPI := controlapi.API{Store: s, APIKey: cfg.APIKey, Authenticator: controlAuthenticator, BenchmarkRunner: benchmark.Runner{}, Diagnostics: diagnostics, Backends: benchmarkBackends, Integrations: integrationRegistry.Snapshot(), GatewayURL: cfg.ControlURL, AIPerfBinary: cfg.AIPerfBinary, PassportPrivateKey: passportKey, EndpointRefresh: rec.RefreshEndpoints, CredentialRefresh: credentialCache.Refresh, AlertDeliverer: alert.Deliverer{Store: s, Secrets: secrets.Environment{}}, ContextPassports: contextPassports, ArtifactCacheAdapters: artifactCacheAdapters, ProductVersion: version, GatewayInstanceID: cfg.InstanceID, AdmissionState: admissionPool, OptimizationCosts: optimizationCosts, ModelAPICatalog: modelAPICatalog, ModelAPIProducts: s, HFCatalog: hfCatalog, ComputeProviders: computeProviders, GPUPriceCatalog: priceCatalog, LaunchProbers: launchProbers, DefaultProviderAdapters: defaultProviderAdapters}
 	if cfg.StripeEnabled() {
 		stripeBilling, stripeErr := managedbilling.NewStripe(cfg.StripeSecretKey, cfg.StripeWebhookSecret, cfg.StripeBillingReturnURL, cfg.StripePriceIDs, cfg.StripeLivemode)
 		if stripeErr != nil {
@@ -4507,7 +4525,7 @@ func serve(parent context.Context, cfg config.Config, s *store.Store) error {
 		return err
 	}
 	databaseReadiness := &readiness.Gate{Probe: s.Ping, StaleAfter: 30 * time.Second}
-	server := &http.Server{Addr: fmt.Sprintf("%s:%d", cfg.Host, cfg.Port), Handler: (&gateway.Gateway{Routes: directory, APIKey: cfg.APIKey, Authenticator: credentialCache, Recorder: recorder, Logger: logger, Client: client, Ready: databaseReadiness.Check, Control: control, Telemetry: gatewayTelemetry, CapacityObservers: map[string]gateway.CapacityObserver{"runpod": serverless.ActiveWorkers}, ExternalAuthorizer: externalBudgets, ManagedBilling: s, RequestAuthorizer: requestQuotas, AdmissionAuthorizer: admissionPool, ContextPassports: contextPassports}).Handler(), ReadHeaderTimeout: 10 * time.Second, IdleTimeout: 2 * time.Minute, MaxHeaderBytes: 1 << 20, TLSConfig: serverTLS}
+	server := &http.Server{Addr: fmt.Sprintf("%s:%d", cfg.Host, cfg.Port), Handler: (&gateway.Gateway{Routes: directory, APIKey: cfg.APIKey, Authenticator: credentialCache, Recorder: recorder, Logger: logger, Client: client, Ready: databaseReadiness.Check, Control: control, Telemetry: gatewayTelemetry, CapacityObservers: map[string]gateway.CapacityObserver{"runpod": serverless.ActiveWorkers}, ExternalAuthorizer: externalBudgets, ManagedBilling: s, HostedModels: hostedModels, RequestAuthorizer: requestQuotas, AdmissionAuthorizer: admissionPool, ContextPassports: contextPassports}).Handler(), ReadHeaderTimeout: 10 * time.Second, IdleTimeout: 2 * time.Minute, MaxHeaderBytes: 1 << 20, TLSConfig: serverTLS}
 	go func() {
 		<-ctx.Done()
 		shutdown, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)

--- a/docs/model-api-implementation-plan.md
+++ b/docs/model-api-implementation-plan.md
@@ -1,0 +1,568 @@
+# Model APIs implementation plan
+
+Status: MVP contracts implemented; provider launch qualification remains gated
+Updated: 2026-09-02
+Repositories: `infercrane` control plane and gateway, `infercrane-web` site and console
+
+Production activation, payment qualification, supplier conformance, canary, and
+GPU-lane promotion are tracked in
+[Model API production rollout](model-api-production-rollout.md). Catalog presence
+is not evidence that a model is callable.
+
+## Outcome
+
+Ship a credible, capital-light Model APIs MVP toward this qualified market
+promise:
+
+> **Fast model APIs. Complete inference infrastructure.**
+>
+> Start with qualified open-model APIs. When you need dedicated capacity,
+> InferCrane deploys, autoscales, routes, measures, and continuously improves the
+> entire serving stack.
+
+`Fast` and `optimized` are launch claims only after the offered route has current
+performance evidence. Before then, investor and preview material presents this
+as the product target or scopes the claim to a named measured route.
+
+The MVP must let a user:
+
+1. Discover the six curated models.
+2. See a truthful, current price and capability contract.
+3. Prepay a small balance.
+4. Create a scoped API key.
+5. Make an OpenAI-compatible streamed request.
+6. See usage, cost, route status, and missing reconciliation clearly.
+7. Start a dedicated or own-cloud plan without changing the model/API contract.
+
+The MVP may buy inference from qualified upstream suppliers. Customers see
+InferCrane model identities, API keys, prices, usage, support, and migration
+path. They do not see or depend on the current supplier.
+
+## Launch catalog
+
+All six products appear in the catalog from the first UI release. An entry is
+callable only after its exact supplier route passes the launch gates below.
+Before then it is labeled `Catalog only`, `Private preview`, or `Unavailable`.
+
+| Public product | Primary use | Initial display state |
+| --- | --- | --- |
+| GLM-5.2 | Coding, reasoning, bilingual chat | Catalog only until qualified |
+| GLM-5.3 | Flagship reasoning and long context | Catalog only until qualified |
+| GLM-5.3-Flash | Low-cost, latency-sensitive work | Catalog only until qualified |
+| Kimi-K3 | Coding and agentic workflows | Catalog only until qualified |
+| Kimi-K2.6 | Coding, agents, long context | Catalog only until qualified |
+| DeepSeek-V4-Flash-0731-Fast | High-throughput workloads | Catalog only until qualified |
+
+The prices shown in competitor screenshots are research inputs, not InferCrane
+rate cards. A public price is published only after supplier cost, resale terms,
+usage semantics, failure charging, taxes/fees, and target margin are known.
+
+## Product and architecture contract
+
+The customer integration remains stable while supply changes underneath it:
+
+```text
+Application
+   |
+   | OpenAI-compatible request + InferCrane API key
+   v
+InferCrane Gateway
+   |-- auth, budgets, reservation, admission, request policy
+   |-- immutable serving plan from memory; no database in request path
+   |-- usage parsing, settlement, audit, metrics
+   v
+Qualified supplier route today
+   |
+   +--> InferCrane-managed or customer-cloud capacity later
+        using the same public model identity and API contract
+```
+
+Use three separate records. Never merge their responsibilities:
+
+- `ManagedProduct`: public, supplier-neutral identity, description,
+  capabilities, context, availability, retail price, and evidence freshness.
+- `SupplierOffer`: private supplier model ID, adapter, region, cost, limits,
+  health, qualification evidence, capacity, resale terms, and expiry.
+- `ServingPlan`: immutable compiled primary/fallback routes for one public model
+  and protocol. The data plane reads the active plan from memory.
+
+Hugging Face enriches discovery data, immutable artifact identity, licenses,
+tags, and organization assets. It is not authoritative for InferCrane pricing,
+availability, performance, supported API features, or qualification.
+
+### Shared hosted-supply tenancy
+
+Hosted supply is operator-owned and shared; customer policy and money remain
+customer-owned. Do not duplicate supplier targets or credentials into every
+customer tenant.
+
+- The InferCrane operator workspace owns supplier targets, credentials, private
+  offers, qualification evidence, and published serving plans.
+- A customer workspace owns API keys, wallet, budgets, usage, audit records, and
+  product entitlements.
+- A product entitlement maps an authorized customer workspace and public model
+  ID to the operator-published serving plan plus customer-specific limits. It
+  grants no read access to the operator target or secret.
+- The gateway snapshot contains the entitlement, public product/rate version,
+  and opaque active backend bindings needed for routing. Supplier credentials
+  are resolved only inside the trusted gateway boundary.
+- Retail settlement is written to the customer ledger. Supplier cost and invoice
+  reconciliation are written to a separate operator ledger and joined through
+  request and route IDs for margin reporting.
+- Existing tenant-scoped endpoint bindings remain the contract for customer-owned
+  dedicated/BYOC capacity. Shared hosted bindings use an explicit operator-owned
+  publication path instead of pretending to be customer resources.
+
+## Capital and margin strategy
+
+Use capital in this order:
+
+1. **BYOK/BYOC and paid qualification.** Customer pays the cloud or supplier;
+   InferCrane earns setup, platform, and support revenue without financing GPUs.
+2. **Prepaid hosted APIs.** InferCrane buys each request from qualified suppliers
+   and keeps a transparent margin. Spend is reserved before transmission.
+3. **Customer-funded dedicated capacity.** Use minimum-spend or annual
+   commitments to cover non-cancellable capacity.
+4. **InferCrane-owned warm capacity.** Only after stable demand and measured unit
+   economics show at least 30% fully-loaded cost advantage over the current
+   supplier route.
+
+MVP commercial rules:
+
+- Wallet funds are credited only by a verified paid webhook, never a browser
+  redirect.
+- Reserve the worst-case authorized request cost before calling a supplier.
+- Reject a request when balance, price, cost basis, margin, health, or evidence
+  is stale.
+- Set ceilings per request, key, workspace, model, supplier, and operator.
+- Settle known actual usage. Keep ambiguous usage `Pending reconciliation`; do
+  not silently release or invent a charge.
+- Launch without automatic top-up. Add it only after reconciliation and fraud
+  behavior are understood.
+- Target a minimum gross margin per route. Do not subsidize an unprofitable
+  route to make the catalog look larger.
+
+## Workstreams and ownership boundaries
+
+These lanes are designed for parallel agents without overlapping files.
+
+| Lane | Repository / owned paths | Responsibility |
+| --- | --- | --- |
+| A. Product contracts | `internal/modelapicatalog/**`, new `internal/modelapiproduct/**`, catalog API/schema files, assigned `*_model_api_catalog.sql` migrations | Managed products, rate cards, entitlements, public projection |
+| B. Supply and qualification | `internal/modelapisupply/**`, new `internal/supplieradapter/**`, assigned `*_model_api_supply.sql` migrations | Private offers, adapters, probes, planning, evidence |
+| C. Gateway and billing | `internal/gateway/**`, `internal/routes/**`, `internal/managedbilling/**`, named store files, assigned `*_model_api_billing.sql` migrations | Admission, shared-plan publication, reserve/settle, safe failover, metrics |
+| D. Design system and console | `infercrane-web/packages/ui`, `packages/design-tokens`, `apps/console` | Primitives, catalog, quickstart, onboarding, usage, dedicated |
+| E. Landing and messaging | `infercrane-web/apps/site` only | Positioning, interactive plan preview, enterprise conversion |
+| F. End-to-end verification | dedicated integration/browser fixture paths only | Cross-package, browser, accessibility, billing, and failure journeys |
+
+Only lane A changes shared API schemas. It lands those changes first. Each
+feature lane owns its migration and package tests; lane F owns only cross-package
+and browser suites. Other lanes consume generated or versioned contracts and do
+not redefine them. Lane D owns reusable UI primitives; lane E consumes them and
+does not edit the shared package during its page pass.
+
+## Implementation phases
+
+### Phase 0 — Freeze truth and the public contract
+
+Goal: make the six model products stable before designing around temporary data.
+
+Backend:
+
+- Define the six public model IDs, names, descriptions, context limits, and
+  capability fields.
+- Separate discovery entries, managed products, supplier offers, and active
+  serving plans.
+- Define availability states: `catalog_only`, `private_preview`, `available`,
+  `degraded`, and `unavailable`.
+- Define a versioned retail/cost rate-card contract with validity windows.
+- Define an anonymous, cacheable public projection and an authenticated
+  projection with account-specific limits.
+- Define the operator-owned hosted-supply workspace, customer product
+  entitlements, shared-plan publication, secret isolation, customer retail
+  ledger, and operator supplier-cost ledger.
+- Keep exact model requests exact. Cross-model outcome routing requires a
+  separate, explicit product and customer consent.
+
+Web:
+
+- Map all visible catalog labels to fields in the public contract.
+- Delete or hide unsupported switches such as ZDR and reasoning effort. Render
+  them only when the selected route proves support.
+
+Exit criteria:
+
+- One documented schema drives catalog, billing, gateway, and UI fixtures.
+- No UI value depends on supplier-private data.
+- Unknown values render as unknown, never zero or an implied promise.
+
+### Phase 1 — Design-system primitives
+
+Goal: a calm, simple visual grammar influenced by the supplied Wafer references,
+without copying its brand assets or introducing a second CSS system.
+
+- Keep the current Next.js/React design tokens and CSS architecture.
+- Use shadcn's accessible composition patterns, adapted to InferCrane tokens.
+- Do not add Tailwind only to install shadcn defaults.
+- Add only the missing primitives to `packages/ui`: `Button`, `Input`, `Tabs`,
+  `Accordion`, `Dialog`, mobile `Sheet`, `Select`/`Combobox`, `Skeleton`, and
+  `Toast`.
+- Reuse the existing badge, code, heading, status, empty-state, definition-list,
+  wizard, explorer, canvas, chart, and shell components.
+- Standardize focus rings, 44px touch targets, compact density, elevation,
+  empty/loading/error states, reduced motion, and responsive behavior.
+- Use one restrained signature motion: the route in Plan Preview resolves from
+  application to hosted, dedicated, or customer-cloud capacity.
+
+Exit criteria:
+
+- Primitives have keyboard and screen-reader tests.
+- No stock shadcn theme appears in the product.
+- Core screens work at 320px, 390px, and desktop widths.
+
+### Phase 2 — Public catalog and private supply
+
+Goal: turn static catalog data into an operated supply system.
+
+- Persist `ManagedProduct`, `SupplierOffer`, qualification, rate card, and
+  compiled-plan records. JSON remains bootstrap/fixture data, not production
+  state.
+- Create a private `SupplierAdapter` interface for:
+  - authentication and request construction;
+  - buffered and streaming protocols;
+  - tool/structured-output capabilities;
+  - health, inventory, and rate-limit signals;
+  - usage parsing and ambiguous billing;
+  - normalized errors, retry hints, and reconciliation.
+- Implement one exact supplier/model route first. An internal LiteLLM adapter is
+  allowed behind this interface, but LiteLLM does not own the public contract.
+- Import Hugging Face metadata on a schedule with manual review, immutable
+  revision pinning, license checks, and field-level provenance.
+- Wire the existing supply planner into persistence and the existing endpoint
+  materialization path. Store accepted routes and rejection reasons rather than
+  rebuilding plan publication.
+
+Exit criteria:
+
+- Operators can inspect why each offer was accepted or rejected.
+- Public responses never expose supplier identity, cost, or credentials.
+- Catalog display state and callable state are controlled independently.
+
+### Phase 3 — Gateway, prepaid billing, and safe routing
+
+Goal: make one qualified route safe enough for paid preview traffic.
+
+- Extend the existing scoped-key and tenant billing path with a product
+  entitlement that can reference an operator-owned shared serving plan without
+  exposing its target or secret.
+- Make one canonical immutable rate-card version feed public catalog projection,
+  supply-planner candidates, request reservation, and settlement policy.
+- Connect the existing reservation and append-only settlement contracts to the
+  canonical product/rate/offer records.
+- Add automated reconciliation plus the missing operator supplier-cost and
+  invoice ledger.
+- Add margin and cost-variance alarms.
+- Extend the existing in-memory route snapshot and publication flow for opaque
+  shared hosted bindings while preserving customer-owned endpoint bindings.
+- Implement circuit breaking and hysteresis.
+- Add same-request fallback only before response bytes are sent. Never replay a
+  stream after bytes have reached the client.
+- Mark uncertain supplier charges for reconciliation and prevent double spend.
+
+Exit criteria:
+
+- Insufficient credit fails before an upstream call.
+- Expired rates and stale evidence fail closed.
+- Every successful or ambiguous request has an auditable financial state.
+- A supplier outage does not silently change the requested public model.
+
+### Phase 4 — Model API catalog, quickstart, and API keys
+
+Goal: the shortest credible path from discovery to first request.
+
+Catalog:
+
+- Keep `/models` for deployable/self-hosted compatibility and `/model-apis` for
+  callable hosted products.
+- Add a compact `Hosted APIs / Deploy your own` surface switcher.
+- Render one accordion row per model. Collapsed rows show identity, concise use,
+  input/output/cache price, context, capabilities, and availability.
+- Expanded rows show cURL/Python/JavaScript quickstarts, the exact capability
+  contract, price validity, qualification freshness, and `Deploy this model`
+  migration action.
+- Support search and filters for task, price, context, capability, and status.
+- Avoid decorative scenery behind operational content. Let typography, spacing,
+  thin borders, and one subtle atmospheric field establish the brand.
+
+Quickstart and keys:
+
+- Use an environment variable in every snippet; never render the raw secret
+  after its one-time creation reveal.
+- Provide `Create key`, `Copy`, `Run in playground`, and a small funded-balance
+  prompt in context.
+- Show missing-key, insufficient-balance, unavailable-model, stale-price,
+  streaming, success, and copy-failure states.
+- Keep reasoning, ZDR, residency, and other options absent unless the route's
+  current contract supports them.
+
+Exit criteria:
+
+- A funded user can reach a successful streamed request in under five minutes.
+- A catalog-only model cannot be called accidentally.
+- Examples work against the real gateway contract in CI.
+
+### Phase 5 — Landing positioning and guided onboarding
+
+Goal: explain the two-stage business in seconds and reduce the current chat-like
+input burden.
+
+Landing:
+
+- Lead with the approved positioning and two actions: `Try model APIs` and
+  `Plan dedicated capacity`.
+- Show proof through the real product mechanism: one stable API contract moving
+  from serverless to dedicated or customer cloud.
+- Keep the planner compact: `Deploy`, `Improve`, or `Connect`; then model or
+  endpoint, workload, and priority.
+- Show a read-only Plan Preview before signup or spend.
+- Use concise sections for hosted APIs, the stable migration path, optimization
+  evidence, enterprise control, and final conversion.
+- Do not claim fastest, lowest cost, ZDR, or enterprise controls without current
+  evidence on the selected route.
+
+Onboarding:
+
+- Replace the long conversational questionnaire with two progressive screens:
+  1. intent, model/endpoint, workload, and priority;
+  2. Plan Canvas, unknowns, delivery choice, and explicit authorization.
+- Default a new developer toward hosted APIs; keep BYOK, dedicated, and own-cloud
+  visible as alternative delivery modes.
+- Keep provider, GPU, runtime, scaling, and networking under `Advanced` until
+  those choices materially affect the plan.
+- Never create resources or charge money during anonymous planning.
+
+Exit criteria:
+
+- A first-time user creates a useful plan in under three minutes.
+- The plan states what is known, modeled, measured, or missing.
+- Authorization is explicit before funding, provider connection, or deployment.
+
+### Phase 6 — Dedicated dashboard, usage, and billing
+
+Goal: make the expansion path and paid operation real without fake enterprise
+inventory.
+
+Dedicated:
+
+- Use the existing endpoint area with a dedicated view, not a disconnected
+  product shell.
+- Empty state: explain reserved/customer-cloud capacity and offer `Plan dedicated
+  capacity` plus `Talk to an engineer`.
+- Populated states show actual endpoint, model/revision, provider/region, runtime,
+  capacity, autoscaling, SLO, cost, health, operations, optimization candidates,
+  Release Guard, and rollback only when backed by authoritative APIs.
+- For early enterprise work, default to customer-owned provider billing and a
+  paid fixed-scope qualification engagement.
+
+Usage:
+
+- Show requests, input/output/cached tokens, TTFT, latency, errors, spend, route
+  status, and reconciliation status.
+- Offer graph/table views and content-free request inspection.
+- Make zero traffic, delayed metrics, partial data, and unavailable telemetry
+  explicit states.
+
+Billing:
+
+- Show available, reserved, spent, and pending-reconciliation balances.
+- Show the append-only ledger and prepaid funding action.
+- Do not add invoices, auto-reload, or per-key filtering until their backend
+  contracts exist and have been qualified.
+
+Exit criteria:
+
+- Financial totals reconcile with the ledger.
+- Missing metrics do not render as healthy zeros.
+- Dedicated empty and populated states are driven by the same endpoint model.
+
+### Phase 7 — Exact self-host migration and continuous optimization
+
+Goal: convert Model API adoption into the defensible infrastructure product.
+
+- Mark a hosted product migration-eligible only when its exact model, revision,
+  license, weights, tokenizer, protocol, and capability contract are legally and
+  technically self-hostable.
+- Pin that exact model repository, revision, tokenizer, protocol, and capability
+  contract used by the hosted product.
+- Build the candidate on InferCrane-managed or customer-cloud capacity.
+- Qualify and benchmark the exact runtime/provider/region/GPU configuration.
+- Replay representative, content-safe workload samples.
+- Extend Release Guard to accept a qualified external hosted route as the active
+  baseline, then compare it with a deployment-backed candidate. This is a new
+  backend dependency; the current deployment-only primary rule is insufficient.
+- Promote explicitly only when correctness, SLO, cost, and rollback gates pass.
+- Keep the hosted route as rollback until the new capacity is stable.
+- If exact migration is impossible, create a new public model ID and require an
+  explicit customer-approved quality migration. Never imply equivalence.
+- Continuously test bounded alternatives in engine configuration, batching,
+  quantization, caching, scaling, hardware, and routing; never mutate production
+  from an advisory result alone.
+
+Exit criteria:
+
+- For a migration-eligible exact model/revision, the public model ID and
+  application integration do not change.
+- Migration evidence is exact-tuple, current, and auditable.
+- Rollback is proven before promotion.
+
+## Model launch gates
+
+Each of the six models advances independently:
+
+| Gate | Required evidence | Public state |
+| --- | --- | --- |
+| G0 — Catalog | reviewed identity, description, license/source provenance | Catalog only |
+| G1 — Contract | retail rate, context, API capability contract, expiry | Private preview |
+| G2 — Supplier | real credentials, bounded load test, usage/error/retry semantics | Private preview |
+| G3 — Billing | reserve/settle/reconcile and invoice variance proven | Private preview |
+| G4 — Pilot | customer traffic or 30-day operated window meets SLO/margin | Available |
+| G5 — Redundancy | second qualified supplier or exact self-hosted fallback | Available + resilient |
+
+At G2, run buffered, streaming, tool use where supported, structured output
+where supported, cancellation, deadline, malformed request, rate limit, provider
+5xx, disconnect, and ambiguous-usage tests. Capture TTFT and throughput only as
+measured evidence, not universal model claims.
+
+## Verification matrix
+
+Backend and integration:
+
+- Catalog schema compatibility and private-field redaction.
+- Rate expiry, cost ceiling, minimum margin, stale health, and stale evidence.
+- Wallet concurrency, idempotent reservation/settlement, ambiguous usage, and
+  verified Stripe webhook behavior.
+- Exact model identity, no silent substitution, supplier failover before bytes,
+  no streamed replay, circuit breaker, and plan snapshot updates.
+- Supplier adapter conformance and reconciliation against upstream invoices.
+
+Web and experience:
+
+- Catalog loading, available, catalog-only, private-preview, degraded,
+  unavailable, no-results, and API-error states.
+- Missing key, one-time key reveal, copy failure, insufficient balance, price
+  expiry, successful streamed quickstart, and no raw key in code examples.
+- Anonymous plan causes no mutation; browser payment return grants no funds.
+- Empty and populated dedicated, usage, and billing views.
+- Keyboard-only flows, automated accessibility checks, reduced motion, and
+  responsive snapshots at 390px and 1440px.
+
+Success-path scenarios:
+
+1. New user -> GLM-5.3-Flash -> fund -> key -> streamed request -> usage row.
+2. Developer -> Kimi model -> inspect tools/context -> Python snippet -> success.
+3. Catalog-only model -> clear waitlist/private-preview path; no callable action.
+4. Existing endpoint -> connect -> inspect plan -> explicit authorization.
+5. Hosted customer -> plan exact dedicated candidate -> Release Guard -> promote
+   -> retain hosted rollback.
+6. Enterprise prospect -> dedicated empty state -> paid qualification scope ->
+   customer-cloud plan.
+
+## Delivery sequence
+
+This is a gate-based sequence, not a promise that every feature fits a fixed
+calendar.
+
+### Milestone 1 — Investor-quality operated demo
+
+- Product records and six-model public catalog fixtures.
+- Design primitives and finished catalog/quickstart/key flow.
+- One real qualified supplier/model route or an explicitly labeled sandbox.
+- Prepaid ledger and verified funding flow.
+- Real request, streaming response, usage, and cost trail.
+- Landing and two-screen onboarding tied to real destinations.
+
+### Milestone 2 — Paid private preview
+
+- One production supplier route, reconciliation, ceilings, margin alarms, and
+  operator runbook.
+- Two or three callable models; all six remain visible with honest states.
+- Usage/billing evidence and dedicated planning conversion.
+- Five design-partner conversations, three paid scopes, two qualified
+  candidates, and one recurring conversion as commercial learning targets.
+
+### Milestone 3 — Small self-serve catalog
+
+- All six independently pass G4.
+- At least one high-demand model has supplier redundancy.
+- Support, incident, rate-change, reconciliation, and catalog update operations
+  are exercised.
+- Self-serve limits remain conservative until traffic history supports changes.
+
+### Milestone 4 — Dedicated and self-host expansion
+
+- Exact migration pipeline through benchmark, Release Guard, promotion, and
+  rollback.
+- Customer-funded dedicated capacity first.
+- InferCrane-owned capacity only after the capital gate is met.
+
+## Metrics
+
+Activation:
+
+- Useful plan created in less than 3 minutes.
+- First funded hosted request in less than 5 minutes.
+- First BYOK request in less than 15 minutes.
+- Conversion from catalog view to successful request.
+
+Operation:
+
+- Success rate, TTFT, output throughput, p95 latency, cold starts, and error rate
+  per exact route.
+- Reconciliation age and supplier invoice variance.
+- Gross margin per model and route.
+- Percentage of requests served by qualified fallback.
+- Rate/evidence expiry incidents caught before traffic.
+
+Expansion:
+
+- Hosted customers starting a dedicated plan.
+- Paid qualification conversion and recurring platform revenue.
+- Cost improvement and SLO stability after an exact self-host migration.
+
+## Explicitly out of scope for the first MVP
+
+- Hosting all six models on InferCrane-funded GPUs.
+- A public claim that InferCrane is universally the fastest or cheapest.
+- Public `fast` or `optimized` positioning before route-level evidence exists.
+- Automatic cross-model substitution.
+- Unbounded Hugging Face catalog deployment.
+- Automatic provider price scraping as billing truth.
+- Fake dedicated inventory or unsupported enterprise feature claims.
+- Full autonomous optimization or promotion without approval.
+- Auto-reload, complex invoicing, or broad marketplace economics before ledger
+  and reconciliation behavior are proven.
+
+## First implementation tickets
+
+1. Land the six-product schema, fixtures, availability states, and public/private
+   projections.
+2. Land the operator hosted-supply tenancy, customer entitlement, secret
+   isolation, and dual retail/supplier-ledger contract.
+3. Land one canonical versioned rate-card contract and connect it to catalog,
+   planner candidates, reservation, and settlement.
+4. Add the minimal token-native UI primitives in `packages/ui`.
+5. Build the model API accordion and quickstart against generated fixtures.
+6. Implement one supplier adapter and one exact qualification record.
+7. Connect private offers through the existing supply planner and endpoint
+   materialization path, including persisted rejection reasons.
+8. Connect the canonical product/rate/offer records to existing reservation and
+   settlement; add automated reconciliation and supplier-cost accounting.
+9. Extend the route snapshot for operator-published shared bindings and add
+   cross-binding pre-response failover.
+10. Connect the console to the real catalog/key/wallet/request APIs.
+11. Refine the site hero and two-step planner around the stable API migration
+   story.
+12. Extend Release Guard for an external hosted baseline and enforce exact
+    migration eligibility.
+13. Run the six success-path scenarios, accessibility checks, financial
+    invariants, and failure tests before enabling paid preview.

--- a/docs/model-api-production-rollout.md
+++ b/docs/model-api-production-rollout.md
@@ -1,0 +1,483 @@
+# Model API production rollout
+
+Status: execution plan; callable routes remain gated
+Updated: 2026-09-02
+Owners: gateway/platform, supplier qualification, billing/finance, product operations
+
+## Decision
+
+Expose one stable InferCrane API implementing a versioned, documented subset of
+the OpenAI Chat Completions contract. “OpenAI-compatible” must mean the exact
+supported fields, streaming grammar, errors, limits, and deviations published
+for that API version; it must not imply every OpenAI extension is accepted.
+
+```text
+Developer
+   |
+   v
+api.infercrane.com/v1
+   |
+   v
+Auth -> prepaid admission -> entitlement -> immutable route snapshot
+   |
+   +-- Qualified upstream API
+   +-- Qualified serverless GPU
+   +-- Qualified dedicated or BYOC deployment
+```
+
+The public model name, API key, request contract, usage record, and retail rate
+belong to InferCrane. The active supplier is private and may change only when the
+replacement preserves the exact qualified model identity and behavioral
+contract. Never retry after response bytes have reached the customer. Before
+that point, failover is allowed only when transmission did not occur or the
+supplier proves that the attempt was not charged.
+
+This plan separates three truths:
+
+- a **catalog product** may exist without callable capacity;
+- a **qualified offer** proves one exact supplier/model/runtime contract;
+- a **published route** authorizes one tenant to spend against a current retail
+  rate and qualified offer.
+
+## Verified production baseline
+
+Read-only production checks on 2026-09-02 found:
+
+- `api.infercrane.com` resolves to the Fly application and has an active
+  certificate;
+- HTTP redirects to HTTPS and `/livez` and `/readyz` return `200`;
+- the Fly application has one 2 GB `shared-cpu-1x` Machine in `fra`;
+- the database-aware Fly service check is passing;
+- required Stripe, hosted-auth, database, RunPod, and API secret **names** exist;
+  values were not inspected;
+- `/metrics` is currently reachable through the public service;
+- the deployment is single-machine and therefore is not highly available.
+
+DNS and TLS are not the current blocker. Supplier qualification, money
+reconciliation, route publication, and operational safety are.
+
+## Launch scope
+
+The six requested product identities stay supplier-neutral. Competitor prices
+are research inputs, not InferCrane prices.
+
+| InferCrane product | Verified potential supplier identity | Launch state |
+| --- | --- | --- |
+| `glm-5.2` | Cloudflare Workers AI `@cf/zai-org/glm-5.2` | Catalog only until contract qualification |
+| `glm-5.3` | Cloudflare Workers AI `@cf/zai-org/glm-5.3` | Catalog only until contract qualification |
+| `glm-5.3-flash` | Cloudflare Workers AI `@cf/zai-org/glm-5.3-flash` | Catalog only until contract qualification |
+| `kimi-k2.6` | Cloudflare `@cf/moonshotai/kimi-k2.6`; Kimi `kimi-k2.6` | Catalog only until one offer is qualified |
+| `kimi-k3` | Kimi `kimi-k3` | Cloudflare-hosted offer unverified |
+| `deepseek-v4-flash-0731-fast` | Cloudflare `@cf/deepseek-ai/deepseek-v4-flash-0731`; direct DeepSeek family | `-fast` remains an InferCrane alias, never a supplier ID |
+
+Do not make all six callable merely to fill the shelf. Launch the first exact
+offer that passes every gate, then repeat the same qualification. A product
+without a current offer remains visible as `Catalog only` or `Private preview`.
+
+## Existing implementation to preserve
+
+InferCrane already has:
+
+- supplier-neutral products, private offers, qualifications, plans, rates, and
+  tenant entitlements;
+- append-only, versioned retail rate contracts with validity windows;
+- deterministic supply planning with a hard minimum 15% supplier-token margin
+  floor; a landed-COGS floor is still required before paid launch;
+- atomic in-memory route generations with last-known-good retention;
+- tenant-isolated prepaid reservation before supplier transmission;
+- explicit `reserved -> transmitted -> response_started -> settled` fencing;
+- `pending_reconciliation` for ambiguous usage instead of guessed charges;
+- initial buffered and SSE usage extraction, stable public model rewriting, and
+  an HTTPS-only configured endpoint registry; the strict streaming conformance
+  and cached/reasoning-token gates below remain launch blockers;
+- fixed $25, $50, $100, $250, and $500 Stripe Checkout top-ups;
+- signed raw-body Stripe webhook verification, atomic idempotent crediting,
+  partial cumulative refunds, wallet debt, and an append-only wallet ledger;
+- `/livez`, database-aware `/readyz`, Prometheus metrics, and durable operation
+  fencing.
+
+These are strong safety foundations. They are not yet proof of unattended paid
+production.
+
+## Phase 0 — Freeze public and private contracts
+
+Before buying traffic, create one versioned operator bundle containing:
+
+1. public product and public operation;
+2. exact supplier and supplier model ID;
+3. supplier endpoint, adapter, and credential reference;
+4. exact identity or documented mutable-alias policy;
+5. normalized streaming, usage, error, context, tool, and idempotency behavior;
+6. supplier cost schedule and commercial authorization;
+7. retail rate, target margin, hard floor, entitlement, and validity window;
+8. canary cohort, fallback predicates, rollback route, and qualification expiry.
+
+Build an authenticated operator API/CLI for offers, qualifications, plans,
+rates, entitlements, and publication. Operators must not edit production tables
+directly. Every mutation emits an audit event and produces a canonical digest.
+
+Acceptance:
+
+- a public catalog response never exposes supplier name, URL, offer, cost, or
+  credential;
+- a missing, expired, or inconsistent contract fails closed before a supplier
+  call;
+- changing an identity-bearing field requires a new qualification and route
+  generation;
+- durable route-generation history and a tested operator action can republish
+  the exact prior generation. This is planned work; in-memory
+  last-known-good retention alone is not a production rollback mechanism.
+
+## Phase 1 — Gateway and `api.infercrane.com`
+
+### Current launch posture
+
+Keep Fly.io as the control/gateway host for the MVP. It is inexpensive, already
+deployed, and does not need to host GPUs. Confirm the deployed
+`INFERCRANE_URL` value is exactly `https://api.infercrane.com` before publishing
+customer examples.
+
+### Required work
+
+1. Add a deploy runbook or GitHub workflow using an immutable image digest.
+2. Before a migration-bearing release, record the previous image digest, create
+   and restore-test a PostgreSQL backup, and prefer roll-forward migrations.
+3. Add an explicit Fly deploy strategy only after choosing between accepted
+   single-Machine interruption and qualified two-Machine rolling deployment.
+4. For rolling or canary deployments, add a deploy-only Machine check so a bad
+   candidate stops before replacement. For a single-Machine immediate deploy,
+   use an independently started pre-deploy candidate and run the same checks
+   before replacing production.
+5. Keep the existing service `/readyz` check because it correctly removes a
+   database-disconnected Machine from routing.
+6. Add Fly custom metrics scraping, long-term log export, alert contacts, and
+   dashboards. Move or protect the currently public `/metrics` surface.
+7. Benchmark the current `soft=100`, `hard=200` Fly concurrency settings with
+   long-lived streams. They are load-balancing signals, not customer rate
+   limits.
+8. Configure tenant quotas and verify `429` plus `Retry-After`; a missing tenant
+   quota is currently unlimited.
+9. Rotate secrets through staged Fly secret deployments. Separate staging and
+   production organizations and deploy credentials before live payments.
+10. Drill rollback by deploying the previous image digest. A database schema
+    incompatibility requires the database restore runbook, not only an image
+    rollback.
+
+Do not market the MVP as multi-region or highly available. Move to two Machines
+in distinct failure domains only after database failover, route reconstruction,
+unique instance identity, connection-budget, rolling-upgrade, and region-loss
+tests pass.
+
+Gateway acceptance:
+
+- DNS, certificate, HTTPS redirect, `/livez`, `/readyz`, authenticated control
+  read, and route reconstruction pass after deploy. A supplier-backed synthetic
+  Model API call is added only after that exact offer passes Phase 2;
+- a bad candidate never receives customer traffic;
+- a Machine or region failure demonstrates the documented service behavior;
+- no secret value appears in Fly configuration, logs, metrics, or audit output.
+
+## Phase 2 — Supplier qualification
+
+Introduce `infercrane.supplier-qualification/v1`. Its canonical digest must bind:
+
+- product, offer version, supplier, region, validity, and resale authority;
+- supplier model ID, revision/fingerprint, accepted response identities, and
+  drift policy;
+- adapter version, endpoint family, runtime/engine/image/model/tokenizer/chat
+  template/tool parser/reasoning parser/configuration digests;
+- operations, modalities, streaming grammar, terminal event, usage placement,
+  tool modes, structured output, and reasoning behavior;
+- effective context and output limits measured on the deployed route;
+- input, output, cached-input, and reasoning-token fields;
+- supplier request ID, authoritative usage source, reconciliation and explicit
+  no-charge methods;
+- supplier pricing revision, retry behavior, idempotency guarantee, queue/cold
+  start configuration, and safe failover predicates;
+- conformance suite version, sample counts, artifacts, completion time, and
+  expiry.
+
+### Qualification suite
+
+For each exact supplier/model tuple, run:
+
+1. buffered and streamed deterministic requests;
+2. valid SSE framing, multi-line events, comments, terminal event, premature EOF,
+   malformed JSON, cancellation, and errors inside a `200` stream;
+3. no-tools, automatic, required, named and parallel tool calls where claimed,
+   including streamed arguments and assistant/tool round trips;
+4. context tests immediately below, at, and above the effective limit, with
+   tools and multimodal overhead included;
+5. normal, cached, reasoning, tool-only, and zero-output usage;
+6. invalid auth/model/body/context, `429`, capacity failure, `5xx`, timeout,
+   disconnect before headers, and disconnect after output;
+7. warm and scale-to-zero samples for queue delay, headers, TTFT, output rate,
+   p50/p95/p99, initialization failures, and cold-start maximum;
+8. request-ID correlation and any documented supplier idempotency behavior;
+9. supplier usage/invoice sample reconciliation against the gateway record;
+10. mutable-alias drift detection and automatic quarantine.
+
+The current normalized `supplieradapter` contract should become the production
+runtime boundary. Do not keep the generic one-size-fits-all bearer/OpenAI
+transport as the only adapter. Normalize supplier errors, billing outcome,
+`Retry-After`, response model/fingerprint, cached and reasoning tokens, and
+supplier request ID before committing the public response.
+
+Do not enable supplier-internal retries or hidden fallbacks unless their exact
+behavior is part of the qualified tuple. A Cloudflare AI Gateway route is not
+the same offer as a Cloudflare Workers AI-hosted model.
+
+## Phase 3 — Prepaid Stripe production qualification
+
+The Stripe webhook is already connected in code. Production work is
+configuration and missing lifecycle hardening, not a new balance system.
+
+### Required configuration
+
+For separate test and live environments configure:
+
+- secret key and pinned Stripe account identity;
+- five one-time USD Price IDs for $25/$50/$100/$250/$500;
+- Checkout success/cancel return URL;
+- dedicated endpoint signing secret, with a rotation overlap strategy;
+- expected live/test mode.
+
+At startup, retrieve and reject a Price that is inactive, recurring, wrong
+currency, wrong amount, wrong mode, or owned by the wrong Stripe account.
+
+### Required hardening
+
+1. Persist a funding intent before creating Checkout.
+2. Use its immutable ID as the local and Stripe idempotency key. The durable
+   local funding intent is the source of truth: reuse a stored Session when it
+   exists and conflict on changed parameters. Stripe may prune an idempotency
+   key after 24 hours, so recovery must query/persist Session identity rather
+   than assuming Stripe will return the original forever. Define and test the
+   crash window between remote Session creation and local persistence.
+3. Copy tenant, environment, and funding-intent IDs onto both Checkout Session
+   and PaymentIntent metadata.
+4. Persist a verified event into a durable inbox, acknowledge quickly, and
+   process wallet mutation asynchronously and idempotently.
+5. Track refund IDs and pending/succeeded/failed/canceled states. Add disputes
+   and chargeback holds/debt.
+6. Recover undelivered events and reconcile Stripe Balance/Payout reports to
+   funding intents, wallet entries, refunds, disputes, and fees daily.
+
+### End-to-end tests
+
+Run the complete journey in Stripe test mode before supplier canary. Only after
+Phases 4 and 5 pass, repeat it with one capped pilot tenant and one small
+controlled live payment:
+
+1. create one funding intent and Checkout Session;
+2. complete payment and observe a signed event;
+3. verify exactly one append-only credit and correct wallet balance;
+4. retry browser return and webhook deliveries and verify no extra credit;
+5. after supplier qualification and admission gates exist, make one qualified
+   Model API request and settle usage;
+6. issue a partial refund and verify debit/debt behavior;
+7. issue the remaining refund and reconcile Stripe cash to the wallet ledger;
+8. export and archive redacted evidence; never put card or secret data in it.
+
+No browser redirect can grant credit. Test objects must never mutate live
+wallets and live events must never mutate test wallets.
+
+## Phase 4 — Admission, settlement, and reconciliation
+
+Before supplier transmission, one transaction must enforce:
+
+- API key and tenant;
+- product entitlement state;
+- RPM, TPM, monthly spend, maximum request cost, and wallet balance;
+- current retail rate, hard margin floor, and supplier/operator budget;
+- qualified route and unexpired commercial/evidence contract;
+- customer idempotency key plus canonical request hash.
+
+Configured RPM, TPM, monthly-spend, or other dimensions that are not yet
+atomically enforced must make the entitlement non-callable. Likewise, a retail
+rate containing cached-input or reasoning-token dimensions remains
+non-callable until those tokens are normalized, reserved, settled, and
+reconciled end to end. The gateway must never silently bill them as ordinary
+input or omit them.
+
+Add a durable settlement outbox and sweep every aging state:
+
+- stale `reserved`: release only after proving transmission never occurred;
+- stale `transmitted` or `response_started`: resolve with supplier evidence;
+- `pending_reconciliation`: bounded retries and age escalation.
+
+Persist gateway usage, supplier usage, cached/reasoning tokens, supplier request
+ID, supplier price revision, actual COGS, invoice reference, evidence digest,
+and variance independently. Retail settlement stays pinned to the customer rate
+contract; later supplier cost changes become COGS variance, not a retroactive
+customer price change.
+
+Reconcile all calls, not only ambiguous calls. Never release a reservation on a
+timer because usage is missing.
+
+## Phase 5 — Circuit breakers and canary
+
+Circuit-break per exact supplier/model/operation/region tuple. Initial policy:
+
+- require at least 20 observed attempts for a rate window;
+- open after five consecutive pre-response failures or more than 50% failure;
+- allow one half-open probe every 30 seconds;
+- close only after three successful probes;
+- open immediately on qualification/rate expiry, margin-floor breach, drift,
+  supplier-budget exhaustion, or commercial invalidation.
+
+Circuits affect future routing only. They do not replay a transmitted request.
+
+Canary stages:
+
+```text
+synthetic paid probes -> opted-in pilot 1% -> 5% -> 25% -> 50% -> 100%
+```
+
+Use a stable HMAC cohort. Before the first canary, implement durable route
+generation history and a tested republish action for the previous generation;
+the current in-memory retention is insufficient for operator rollback. Abort
+on semantic mismatch, missing or incorrect usage, SSE/tool/context failure,
+double billing, unresolved invoice variance, cost/margin breach, supplier drift,
+or SLO regression. Do not shadow customer prompts without explicit consent.
+
+A route becomes `callable` only when:
+
+- qualification and commercial evidence are current;
+- customer and supplier accounting reconcile;
+- the retail margin is above the hard floor and launch target;
+- canary gates and rollback drill pass;
+- support, alert, and incident ownership are assigned.
+
+## Phase 6 — Promote hot routes to InferCrane GPUs
+
+Use one target interface:
+
+```text
+Target = ExternalAPI | ServerlessGPU | DedicatedDeployment | CustomerCloud
+```
+
+Every target declares exact artifact/tokenizer/protocol identity, metering
+authority, idempotency/transmission semantics, cost model, lifecycle owner,
+credential boundary, qualification expiry, and rollback path.
+
+Promotion policy:
+
+1. start on token-priced external supply for near-zero fixed cost;
+2. when measured traffic makes it cheaper, qualify the same exact model on a
+   scale-to-zero RunPod vLLM/SGLang target;
+3. keep the upstream offer as cold-start/capacity fallback where its contract
+   makes pre-transmission failover safe;
+4. use `workersMin=0`, bounded `workersMax`, request-count autoscaling,
+   FlashBoot/cached models, explicit execution timeout, and measured idle
+   timeout for the first experiment;
+5. keep one worker warm only when latency value exceeds its idle cost;
+6. move sustained committed traffic to dedicated capacity only after measured
+   utilization beats elastic landed cost;
+7. use BYOC when the customer pays infrastructure directly; keep InferCrane
+   quota, audit, release, and platform-fee policy without supplier COGS reserve.
+
+Do not migrate under the same public model ID unless artifact, tokenizer,
+runtime behavior, context, tools, usage, and quality are exact. Otherwise issue
+a new product/version.
+
+Break-even is measured, not guessed:
+
+```text
+self-host landed cost per 1M tokens =
+  (GPU seconds + warm idle + storage + network + operations + failures) /
+  reconciled billable tokens
+```
+
+Promote only when the lower confidence bound of savings remains above the
+target margin after cold starts, headroom, payment fees, refunds, and incident
+reserve.
+
+## Alerts and operating limits
+
+Add alerts for:
+
+- customer spend at 50/75/90/100%;
+- supplier/operator budget at 70/85/95/100%;
+- low wallet balance and refund debt;
+- margin target or hard-floor breach;
+- missing usage, reconciliation age, invoice variance, and stale reservations;
+- circuit open/half-open duration and supplier capacity errors;
+- Stripe webhook/inbox lag, dead-letter events, disputes, and cash variance;
+- Fly readiness, CPU/memory, hard concurrency, 4xx/5xx/TLS, DB pressure, route
+  refresh failure, accounting drops, and operation backlog.
+
+The first paid launch should target a 30% landed gross-margin buffer. The
+existing 15% supplier-token rejection floor remains a preliminary guard, not a
+landed profitability guarantee. Add a separate landed-COGS publication gate
+that includes supplier usage,
+request/startup fees, warm idle, network/storage, payment fees, refund/fraud
+reserve, and reconciliation/incident reserve.
+
+## Release gates
+
+Track every gate in an append-only launch ledger with: gate ID, product/offer,
+owner, status (`planned`, `implemented`, `wired`, `deployed`,
+`production_verified`, or `failed`), evidence digest/URL, environment, and
+timestamp. “Implemented” is never treated as “production verified.”
+
+The launch order is strict:
+
+1. operator mutation API and versioned qualification contract;
+2. one supplier adapter and exact offer;
+3. payment idempotency, lifecycle, and reconciliation hardening;
+4. entitlement limit enforcement and durable settlement;
+5. supplier/accounting qualification fixtures;
+6. synthetic canary and rollback;
+7. test-mode payment/refund journey;
+8. private pilot with a low supplier and tenant spend ceiling, including
+   concurrent admission tests for wallet balance, request idempotency, RPM,
+   TPM, monthly spend, maximum request cost, and supplier budget;
+9. controlled live payment/refund/reconciliation for the pilot tenant;
+10. public callable status for that one model;
+11. repeat per model;
+12. only later add serverless GPU, dedicated, and BYOC targets.
+
+Any failed gate leaves the product catalog-visible but not callable.
+
+## Evidence sources
+
+Fly.io:
+
+- [Custom domains and certificates](https://fly.io/docs/networking/custom-domain/)
+- [Health checks](https://fly.io/docs/reference/health-checks/)
+- [Seamless deploys](https://fly.io/docs/blueprints/seamless-deployments/)
+- [Rollback](https://fly.io/docs/blueprints/rollback-guide/)
+- [Load balancing](https://fly.io/docs/reference/load-balancing/)
+- [Secrets](https://fly.io/docs/apps/secrets/)
+- [Metrics](https://fly.io/docs/monitoring/metrics/)
+- [Production checklist](https://fly.io/docs/apps/going-to-production/)
+
+Stripe:
+
+- [Checkout fulfillment](https://docs.stripe.com/checkout/fulfillment)
+- [Webhooks](https://docs.stripe.com/webhooks)
+- [Idempotent requests](https://docs.stripe.com/api/idempotent_requests)
+- [Refunds](https://docs.stripe.com/refunds)
+- [Testing environments](https://docs.stripe.com/testing-use-cases)
+- [Balance and payout reconciliation](https://docs.stripe.com/reports/payout-reconciliation)
+
+Suppliers and runtimes:
+
+- [Cloudflare Workers AI OpenAI compatibility](https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/)
+- [Cloudflare Workers AI pricing](https://developers.cloudflare.com/workers-ai/platform/pricing/)
+- [Cloudflare Workers AI limits](https://developers.cloudflare.com/workers-ai/platform/limits/)
+- [Cloudflare AI Gateway request handling](https://developers.cloudflare.com/ai-gateway/configuration/request-handling/)
+- [RunPod endpoint configuration](https://docs.runpod.io/serverless/endpoints/endpoint-configurations)
+- [RunPod load-balancer health](https://docs.runpod.io/serverless/load-balancing/overview)
+- [vLLM OpenAI-compatible server](https://docs.vllm.ai/en/latest/serving/openai_compatible_server/)
+- [vLLM production metrics](https://docs.vllm.ai/en/latest/usage/metrics/)
+- [SGLang server arguments](https://docs.sglang.io/docs/advanced_features/server_arguments)
+- [Z.ai chat completion](https://docs.z.ai/api-reference/llm/chat-completion)
+- [DeepSeek chat completion](https://api-docs.deepseek.com/api/create-chat-completion/)
+- [Kimi API models](https://platform.kimi.ai/docs/overview)
+
+Public compatibility references:
+
+- [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat)
+- [OpenAI streaming responses](https://platform.openai.com/docs/api-reference/chat-streaming)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	HostedAuthAutoProvision                                                                                            bool
 	StripeSecretKey, StripeWebhookSecret, StripeBillingReturnURL                                                       string
 	ModelAPICatalogFile                                                                                                string
+	HostedModelAPIEndpoints                                                                                            map[string]string
 	StripePriceIDs                                                                                                     map[int64]string
 	StripeLivemode                                                                                                     bool
 	RunPodAPIKey, RunPodServerlessTemplateID, RunPodRESTURL, RunPodArtifactCachePolicy, RunPodHFTokenSecret            string
@@ -359,6 +360,10 @@ func load(requireAPIKey bool) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	hostedModelAPIEndpoints, err := envStringMap("INFERCRANE_HOSTED_MODEL_API_ENDPOINTS_JSON")
+	if err != nil {
+		return Config{}, err
+	}
 	stripeLivemode, err := envBool("INFERCRANE_STRIPE_LIVEMODE", false)
 	if err != nil {
 		return Config{}, err
@@ -394,6 +399,7 @@ func load(requireAPIKey bool) (Config, error) {
 		StripePriceIDs:                      stripePriceIDs,
 		StripeLivemode:                      stripeLivemode,
 		ModelAPICatalogFile:                 env("INFERCRANE_MODEL_API_CATALOG_FILE", ""),
+		HostedModelAPIEndpoints:             hostedModelAPIEndpoints,
 		RunPodAPIKey:                        env("RUNPOD_API_KEY", ""),
 		RunPodServerlessTemplateID:          env("INFERCRANE_RUNPOD_SERVERLESS_TEMPLATE_ID", ""),
 		RunPodRESTURL:                       env("INFERCRANE_RUNPOD_REST_URL", "https://rest.runpod.io/v1"),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -117,6 +117,19 @@ func TestHFCatalogRefreshIntervalIsBoundedAndOptIn(t *testing.T) {
 	}
 }
 
+func TestHostedModelAPIEndpointsAreExplicitConfiguration(t *testing.T) {
+	t.Setenv("INFERCRANE_API_KEY", "test-key")
+	t.Setenv("INFERCRANE_HOSTED_MODEL_API_ENDPOINTS_JSON", `{"openrouter/openai":"https://openrouter.ai/api/v1"}`)
+	cfg, err := Load()
+	if err != nil || cfg.HostedModelAPIEndpoints["openrouter/openai"] != "https://openrouter.ai/api/v1" {
+		t.Fatalf("hosted model API endpoints=%#v err=%v", cfg.HostedModelAPIEndpoints, err)
+	}
+	t.Setenv("INFERCRANE_HOSTED_MODEL_API_ENDPOINTS_JSON", `{"openrouter/openai":42}`)
+	if _, err = Load(); err == nil || !strings.Contains(err.Error(), "INFERCRANE_HOSTED_MODEL_API_ENDPOINTS_JSON") {
+		t.Fatalf("non-string hosted endpoint accepted: %v", err)
+	}
+}
+
 func TestRunPodNetworkVolumesRequireImmutableExactMappings(t *testing.T) {
 	t.Setenv("INFERCRANE_API_KEY", "secret")
 	t.Setenv("INFERCRANE_RUNPOD_ARTIFACT_CACHE_POLICY", "required")

--- a/internal/controlapi/api.go
+++ b/internal/controlapi/api.go
@@ -38,6 +38,7 @@ import (
 	"github.com/infercrane/infercrane/internal/intentplan"
 	"github.com/infercrane/infercrane/internal/lab"
 	"github.com/infercrane/infercrane/internal/modelapicatalog"
+	"github.com/infercrane/infercrane/internal/modelapiproduct"
 	"github.com/infercrane/infercrane/internal/optimizationcampaign"
 	"github.com/infercrane/infercrane/internal/optimizedartifact"
 	"github.com/infercrane/infercrane/internal/optimizer"
@@ -48,6 +49,7 @@ import (
 	"github.com/infercrane/infercrane/internal/provision"
 	"github.com/infercrane/infercrane/internal/qualityevidence"
 	"github.com/infercrane/infercrane/internal/recipe"
+	"github.com/infercrane/infercrane/internal/store"
 	"github.com/infercrane/infercrane/internal/support"
 	"github.com/infercrane/infercrane/internal/trainingartifact"
 	"github.com/infercrane/infercrane/internal/workflows"
@@ -261,6 +263,17 @@ type externalWorkloadStore interface {
 	AttachTrainingArtifactHandoff(context.Context, string, string, domain.TrainingArtifactHandoff, domain.ModelArtifact) (domain.TrainingArtifactHandoff, domain.ModelArtifact, error)
 	TrainingArtifactHandoffs(context.Context, string, string) ([]domain.TrainingArtifactHandoff, error)
 }
+
+// modelAPIProductStore is deliberately separate from Store. The durable
+// customer product boundary is optional while older installations migrate,
+// and adding it here avoids forcing every control API test double to implement
+// catalog persistence.
+type modelAPIProductStore interface {
+	PublicModelAPIProducts(context.Context, time.Time) ([]modelapiproduct.PublicProjection, error)
+	PublicModelAPIProduct(context.Context, string, time.Time) (modelapiproduct.PublicProjection, error)
+	ModelAPIProductAccess(context.Context, string, string, time.Time) (store.ModelAPIProductAccess, error)
+}
+
 type API struct {
 	Store         Store
 	APIKey        string
@@ -295,6 +308,7 @@ type API struct {
 		ParseWebhook([]byte, string) (domain.ManagedPaymentEvent, error)
 	}
 	ModelAPICatalog  modelapicatalog.Catalog
+	ModelAPIProducts modelAPIProductStore
 	HFCatalog        *hfcatalog.Cache
 	ComputeProviders []ComputeProvider
 	GPUPrices        []GPUPriceObservation
@@ -691,6 +705,10 @@ func (a API) modelAPIModels(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	if a.ModelAPIProducts != nil {
+		a.durableModelAPIModels(w, r, offset, limit)
+		return
+	}
 	catalog := a.ModelAPICatalog
 	if len(catalog.Models) == 0 {
 		catalog = modelapicatalog.Default()
@@ -707,6 +725,10 @@ func (a API) modelAPIModels(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a API) modelAPIModel(w http.ResponseWriter, r *http.Request) {
+	if a.ModelAPIProducts != nil {
+		a.durableModelAPIModel(w, r)
+		return
+	}
 	catalog := a.ModelAPICatalog
 	if len(catalog.Models) == 0 {
 		catalog = modelapicatalog.Default()
@@ -716,7 +738,13 @@ func (a API) modelAPIModel(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "not_found", "Model API catalog entry was not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"model": modelAPIModelResponse(model)})
+	// The compatibility catalog is discovery-only. It cannot grant routing
+	// authority without a durable, tenant-scoped entitlement.
+	writeJSON(w, http.StatusOK, map[string]any{
+		"model":          modelAPIModelResponse(model),
+		"access":         map[string]any{"authorized": false},
+		"catalog_source": "compatibility_fallback",
+	})
 }
 
 func modelAPIModelResponse(model modelapicatalog.Model) map[string]any {

--- a/internal/controlapi/model_api_products.go
+++ b/internal/controlapi/model_api_products.go
@@ -1,0 +1,227 @@
+package controlapi
+
+import (
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/domain"
+	"github.com/infercrane/infercrane/internal/modelapiproduct"
+	"github.com/infercrane/infercrane/internal/store"
+)
+
+func (a API) durableModelAPIModels(w http.ResponseWriter, r *http.Request, offset, limit int) {
+	now := time.Now().UTC()
+	products, err := a.ModelAPIProducts.PublicModelAPIProducts(r.Context(), now)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "model_api_catalog_unavailable", "Model API catalog could not be read")
+		return
+	}
+	products = filterModelAPIProducts(products, r, now)
+	sort.SliceStable(products, func(i, j int) bool { return products[i].DisplayName < products[j].DisplayName })
+	total := len(products)
+	if offset > total {
+		offset = total
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	data := make([]map[string]any, 0, end-offset)
+	for _, product := range products[offset:end] {
+		data = append(data, modelAPIProductResponse(product, now))
+	}
+	var next *int
+	if end < total {
+		value := end
+		next = &value
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": data, "total": total, "next_offset": next,
+		"catalog_policy": "catalog-only products are discoverable; only a current qualified publication and an active exact entitlement authorize traffic",
+		"catalog_source": "durable_product_catalog",
+	})
+}
+
+func (a API) durableModelAPIModel(w http.ResponseWriter, r *http.Request) {
+	now := time.Now().UTC()
+	product, err := a.ModelAPIProducts.PublicModelAPIProduct(r.Context(), r.PathValue("id"), now)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "not_found", "Model API catalog entry was not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "model_api_catalog_unavailable", "Model API catalog entry could not be read")
+		return
+	}
+	actor := r.Context().Value(identityKey{}).(domain.Principal)
+	access, err := a.ModelAPIProducts.ModelAPIProductAccess(r.Context(), actor.TenantID, product.ID, now)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "not_found", "Model API catalog entry was not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "model_api_access_unavailable", "Model API access could not be verified")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"model":          modelAPIProductResponse(product, now),
+		"access":         modelAPIProductAccessResponse(access, now),
+		"catalog_source": "durable_product_catalog",
+	})
+}
+
+func filterModelAPIProducts(products []modelapiproduct.PublicProjection, r *http.Request, now time.Time) []modelapiproduct.PublicProjection {
+	query := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("query")))
+	task := r.URL.Query().Get("task")
+	capability := r.URL.Query().Get("capability")
+	publisher := r.URL.Query().Get("publisher")
+	access := r.URL.Query().Get("access")
+	filtered := make([]modelapiproduct.PublicProjection, 0, len(products))
+	for _, product := range products {
+		capabilities := modelAPIProductCapabilities(product)
+		if task != "" && !modelAPIStringContains(product.Tasks, task) ||
+			capability != "" && !modelAPIStringContains(capabilities, capability) ||
+			publisher != "" && modelAPIPublisherSlug(product.Publisher) != publisher ||
+			access != "" && modelAPIProductAccess(product, now) != access {
+			continue
+		}
+		if query != "" {
+			haystack := strings.ToLower(strings.Join(append([]string{product.ID, product.DisplayName, product.Publisher, product.Description}, product.Tasks...), " "))
+			if !strings.Contains(haystack, query) {
+				continue
+			}
+		}
+		filtered = append(filtered, product)
+	}
+	return filtered
+}
+
+func modelAPIProductResponse(product modelapiproduct.PublicProjection, now time.Time) map[string]any {
+	capabilities := modelAPIProductCapabilities(product)
+	callable := modelAPIProductCallableAt(product, now)
+	offers := make([]map[string]any, 0, 1)
+	if rate := product.RetailRate; rate != nil && rate.CachedInputMicrousdPerMillion == nil && rate.CurrentAt(now) {
+		pricing := map[string]any{
+			"currency": rate.Currency, "input_microusd_per_million": rate.InputMicrousdPerMillion,
+			"output_microusd_per_million": rate.OutputMicrousdPerMillion,
+			"provenance":                  rate.PublicProvenance, "observed_at": rate.PublishedAt,
+			"valid_until": rate.ValidUntil, "version": rate.Version,
+		}
+		availability := "unknown"
+		if callable {
+			availability = "available"
+		} else if product.Availability == modelapiproduct.AvailabilityUnavailable {
+			availability = "unavailable"
+		}
+		offers = append(offers, map[string]any{
+			"id": "infercrane-standard", "protocol": product.Protocol,
+			"access": modelAPIProductAccess(product, now), "availability": availability,
+			"capabilities": capabilities, "pricing": pricing,
+		})
+	}
+	qualification := modelAPIProductQualification(product, now)
+	response := map[string]any{
+		"schema_version": product.SchemaVersion, "id": product.ID,
+		"display_name": product.DisplayName, "publisher": product.Publisher,
+		"publisher_slug": modelAPIPublisherSlug(product.Publisher), "family": product.DisplayName,
+		"description": product.Description, "tasks": product.Tasks, "capabilities": capabilities,
+		"input_modalities": product.InputModalities, "output_modalities": product.OutputModalities,
+		"context_window_tokens": product.ContextWindowTokens, "access": modelAPIProductAccess(product, now),
+		"qualification": qualification, "qualification_note": modelAPIProductQualificationNote(product, now),
+		"availability": product.Availability, "self_host_eligibility": product.SelfHostEligibility,
+		"callable": callable, "offers": offers,
+	}
+	if product.EvidenceValidUntil != nil && product.EvidenceValidUntil.After(now) {
+		response["evidence_valid_until"] = product.EvidenceValidUntil
+	}
+	return response
+}
+
+func modelAPIProductAccessResponse(access store.ModelAPIProductAccess, now time.Time) map[string]any {
+	authorized := access.Authorized && modelAPIProductCallableAt(access.Product, now) && modelAPIEntitlementActiveAt(access.Entitlement, access.Product, now)
+	response := map[string]any{"authorized": authorized}
+	if access.Entitlement != nil {
+		response["entitlement"] = access.Entitlement
+	}
+	return response
+}
+
+func modelAPIEntitlementActiveAt(entitlement *modelapiproduct.CustomerEntitlementProjection, product modelapiproduct.PublicProjection, now time.Time) bool {
+	if entitlement == nil || entitlement.State != modelapiproduct.EntitlementActive || now.Before(entitlement.ValidFrom.UTC()) {
+		return false
+	}
+	if entitlement.ValidUntil != nil && !now.Before(entitlement.ValidUntil.UTC()) {
+		return false
+	}
+	return entitlement.Limits.SupportedForAdmission() && product.RetailRate != nil && entitlement.RetailRateVersion == product.RetailRate.Version
+}
+
+func modelAPIProductCallableAt(product modelapiproduct.PublicProjection, now time.Time) bool {
+	return product.Callable && product.HasCurrentCallableCapabilityAt(now) && product.RetailRate != nil && product.RetailRate.CachedInputMicrousdPerMillion == nil && product.RetailRate.CurrentAt(now) &&
+		product.Qualification == modelapiproduct.QualificationQualified && product.EvidenceValidUntil != nil && product.EvidenceValidUntil.After(now)
+}
+
+func modelAPIProductAccess(product modelapiproduct.PublicProjection, now time.Time) string {
+	if modelAPIProductCallableAt(product, now) {
+		return "ready"
+	}
+	if product.Availability == modelapiproduct.AvailabilityPrivatePreview || product.Availability == modelapiproduct.AvailabilityUnavailable {
+		return "request-access"
+	}
+	return "managed-preview"
+}
+
+func modelAPIProductQualification(product modelapiproduct.PublicProjection, now time.Time) string {
+	if modelAPIProductCallableAt(product, now) {
+		return "measured"
+	}
+	return "cataloged"
+}
+
+func modelAPIProductQualificationNote(product modelapiproduct.PublicProjection, now time.Time) string {
+	if modelAPIProductCallableAt(product, now) {
+		return "Current route qualification and an InferCrane retail rate are attached to this product."
+	}
+	if product.Qualification == modelapiproduct.QualificationStale || product.EvidenceValidUntil != nil && !product.EvidenceValidUntil.After(now) {
+		return "The prior route qualification is stale; traffic admission and performance claims remain disabled."
+	}
+	return "Model identity is cataloged; managed availability, rate, performance, and production qualification are not attached."
+}
+
+func modelAPIProductCapabilities(product modelapiproduct.PublicProjection) []string {
+	capabilities := make([]string, 0, len(product.Capabilities))
+	for _, capability := range product.Capabilities {
+		capabilities = append(capabilities, capability.Name)
+	}
+	return capabilities
+}
+
+func modelAPIStringContains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func modelAPIPublisherSlug(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var slug strings.Builder
+	separator := false
+	for _, char := range value {
+		if char >= 'a' && char <= 'z' || char >= '0' && char <= '9' {
+			if separator && slug.Len() > 0 {
+				slug.WriteByte('-')
+			}
+			slug.WriteRune(char)
+			separator = false
+		} else {
+			separator = true
+		}
+	}
+	return strings.Trim(slug.String(), "-")
+}

--- a/internal/controlapi/model_api_products_test.go
+++ b/internal/controlapi/model_api_products_test.go
@@ -1,0 +1,254 @@
+package controlapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/authz"
+	"github.com/infercrane/infercrane/internal/domain"
+	"github.com/infercrane/infercrane/internal/modelapiproduct"
+	"github.com/infercrane/infercrane/internal/store"
+)
+
+type fakeModelAPIProductStore struct {
+	products       []modelapiproduct.PublicProjection
+	accessByTenant map[string]store.ModelAPIProductAccess
+	err            error
+	accessTenants  []string
+}
+
+func (f *fakeModelAPIProductStore) PublicModelAPIProducts(context.Context, time.Time) ([]modelapiproduct.PublicProjection, error) {
+	return append([]modelapiproduct.PublicProjection(nil), f.products...), f.err
+}
+
+func (f *fakeModelAPIProductStore) PublicModelAPIProduct(_ context.Context, productID string, _ time.Time) (modelapiproduct.PublicProjection, error) {
+	if f.err != nil {
+		return modelapiproduct.PublicProjection{}, f.err
+	}
+	for _, product := range f.products {
+		if product.ID == productID {
+			return product, nil
+		}
+	}
+	return modelapiproduct.PublicProjection{}, store.ErrNotFound
+}
+
+func (f *fakeModelAPIProductStore) ModelAPIProductAccess(_ context.Context, tenant, productID string, _ time.Time) (store.ModelAPIProductAccess, error) {
+	f.accessTenants = append(f.accessTenants, tenant)
+	if f.err != nil {
+		return store.ModelAPIProductAccess{}, f.err
+	}
+	if access, ok := f.accessByTenant[tenant]; ok && access.Product.ID == productID {
+		return access, nil
+	}
+	for _, product := range f.products {
+		if product.ID == productID {
+			return store.ModelAPIProductAccess{Product: product}, nil
+		}
+	}
+	return store.ModelAPIProductAccess{}, store.ErrNotFound
+}
+
+func TestDurableModelAPICatalogPreservesPublicContractAndRedactsInternals(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	product := callableModelAPIProduct(t, now)
+	durable := &fakeModelAPIProductStore{products: []modelapiproduct.PublicProjection{product}}
+	handler := (API{Store: &fakeStore{}, APIKey: "secret", ModelAPIProducts: durable}).Handler()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/model-api-catalog?task=coding&limit=1", nil)
+	request.Header.Set("Authorization", "Bearer secret")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	body := response.Body.String()
+	for _, expected := range []string{`"catalog_source":"durable_product_catalog"`, `"display_name":"GLM-5.2"`, `"access":"ready"`, `"callable":true`, `"id":"infercrane-standard"`, `"version":1`} {
+		if response.Code != http.StatusOK || !strings.Contains(body, expected) {
+			t.Fatalf("status=%d missing=%q body=%s", response.Code, expected, body)
+		}
+	}
+	for _, secret := range []string{"operator_workspace_id", "serving_plan_id", "supply_plan_id", "contract_digest", "rate-glm-1", "supplier_model_id", "credential"} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("durable catalog leaked private field %q: %s", secret, body)
+		}
+	}
+}
+
+func TestDurableModelAPICatalogHidesExpiredRateAndFailsClosed(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	product := callableModelAPIProduct(t, now.Add(-48*time.Hour))
+	// Deliberately retain the stale projection's prior callable bit. The HTTP
+	// boundary must independently reject expired rate and evidence windows.
+	product.Callable = true
+	durable := &fakeModelAPIProductStore{products: []modelapiproduct.PublicProjection{product}}
+	handler := (API{Store: &fakeStore{}, APIKey: "secret", ModelAPIProducts: durable}).Handler()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/model-api-catalog", nil)
+	request.Header.Set("Authorization", "Bearer secret")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	body := response.Body.String()
+	if response.Code != http.StatusOK || !strings.Contains(body, `"callable":false`) || !strings.Contains(body, `"offers":[]`) || strings.Contains(body, `"pricing"`) {
+		t.Fatalf("expired durable product was not closed: status=%d body=%s", response.Code, body)
+	}
+}
+
+func TestDurableModelAPIAccessIsTenantScopedAndRequiresExactActiveEntitlement(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	product := callableModelAPIProduct(t, now)
+	validUntil := now.Add(time.Hour)
+	maxRequest := int64(100_000)
+	entitlement := &modelapiproduct.CustomerEntitlementProjection{
+		SchemaVersion: modelapiproduct.CustomerEntitlementSchemaVersion,
+		ID:            "entitlement-1", ProductID: product.ID, RetailRateVersion: product.RetailRate.Version,
+		State: modelapiproduct.EntitlementActive, Limits: modelapiproduct.CustomerLimits{MaxRequestMicrousd: &maxRequest}, ValidFrom: now.Add(-time.Hour), ValidUntil: &validUntil,
+	}
+	durable := &fakeModelAPIProductStore{
+		products: []modelapiproduct.PublicProjection{product},
+		accessByTenant: map[string]store.ModelAPIProductAccess{
+			"tenant-a": {Product: product, Entitlement: entitlement, Authorized: true},
+		},
+	}
+	principalStore := &fakeStore{principal: domain.Principal{ID: "reader", TenantID: "tenant-a", Name: "reader", Role: string(authz.Viewer), Scopes: []string{"read"}}}
+	handler := (API{Store: principalStore, Authenticator: principalStore, ModelAPIProducts: durable}).Handler()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/model-api-catalog/glm-5.2", nil)
+	request.Header.Set("Authorization", "Bearer tenant-token")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	body := response.Body.String()
+	if response.Code != http.StatusOK || !strings.Contains(body, `"authorized":true`) || len(durable.accessTenants) != 1 || durable.accessTenants[0] != "tenant-a" {
+		t.Fatalf("tenant access status=%d tenants=%v body=%s", response.Code, durable.accessTenants, body)
+	}
+	for _, secret := range []string{"operator_workspace_id", "serving_plan_id", "supply_plan_id", "retail_rate_id", "customer_workspace_id"} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("tenant access leaked private field %q: %s", secret, body)
+		}
+	}
+
+	wrongVersion := *entitlement
+	wrongVersion.RetailRateVersion++
+	durable.accessByTenant["tenant-a"] = store.ModelAPIProductAccess{Product: product, Entitlement: &wrongVersion, Authorized: true}
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"authorized":false`) {
+		t.Fatalf("mismatched entitlement authorized: status=%d body=%s", response.Code, response.Body.String())
+	}
+
+	unsupported := *entitlement
+	rpm := int64(60)
+	unsupported.Limits.RequestsPerMinute = &rpm
+	durable.accessByTenant["tenant-a"] = store.ModelAPIProductAccess{Product: product, Entitlement: &unsupported, Authorized: true}
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"authorized":false`) {
+		t.Fatalf("unenforced entitlement limit authorized: status=%d body=%s", response.Code, response.Body.String())
+	}
+
+	expired := *entitlement
+	past := now.Add(-time.Minute)
+	expired.ValidUntil = &past
+	durable.accessByTenant["tenant-a"] = store.ModelAPIProductAccess{Product: product, Entitlement: &expired, Authorized: true}
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"authorized":false`) {
+		t.Fatalf("expired entitlement authorized: status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestDurableModelAPICatalogSuppressesUnsupportedCachedInputPricing(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	product := callableModelAPIProduct(t, now)
+	cached := int64(100_000)
+	product.RetailRate.CachedInputMicrousdPerMillion = &cached
+	// Simulate a stale or independently produced projection. The HTTP boundary
+	// must not trust its previous callable bit or expose unsupported pricing.
+	product.Callable = true
+	durable := &fakeModelAPIProductStore{products: []modelapiproduct.PublicProjection{product}}
+	handler := (API{Store: &fakeStore{}, APIKey: "secret", ModelAPIProducts: durable}).Handler()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/model-api-catalog", nil)
+	request.Header.Set("Authorization", "Bearer secret")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"callable":false`) || !strings.Contains(response.Body.String(), `"offers":[]`) || strings.Contains(response.Body.String(), "cached_input_microusd_per_million") {
+		t.Fatalf("unsupported cached-input price was published: status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestDurableModelAPIAccessDoesNotCrossTenants(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	product := callableModelAPIProduct(t, now)
+	durable := &fakeModelAPIProductStore{products: []modelapiproduct.PublicProjection{product}, accessByTenant: map[string]store.ModelAPIProductAccess{}}
+	principalStore := &fakeStore{principal: domain.Principal{ID: "reader-b", TenantID: "tenant-b", Name: "reader", Role: string(authz.Viewer), Scopes: []string{"read"}}}
+	handler := (API{Store: principalStore, Authenticator: principalStore, ModelAPIProducts: durable}).Handler()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/model-api-catalog/glm-5.2", nil)
+	request.Header.Set("Authorization", "Bearer tenant-b-token")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"authorized":false`) || len(durable.accessTenants) != 1 || durable.accessTenants[0] != "tenant-b" {
+		t.Fatalf("tenant isolation status=%d tenants=%v body=%s", response.Code, durable.accessTenants, response.Body.String())
+	}
+}
+
+func TestModelAPIAccessCompatibilityFallbackNeverAuthorizes(t *testing.T) {
+	handler := (API{Store: &fakeStore{}, APIKey: "secret"}).Handler()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/model-api-catalog/qwen3-8b", nil)
+	request.Header.Set("Authorization", "Bearer secret")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"catalog_source":"compatibility_fallback"`) || !strings.Contains(response.Body.String(), `"authorized":false`) {
+		t.Fatalf("fallback access status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestDurableModelAPICatalogDoesNotFallBackOnReadFailure(t *testing.T) {
+	durable := &fakeModelAPIProductStore{err: errors.New("database offline")}
+	handler := (API{Store: &fakeStore{}, APIKey: "secret", ModelAPIProducts: durable}).Handler()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/model-api-catalog", nil)
+	request.Header.Set("Authorization", "Bearer secret")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusInternalServerError || !strings.Contains(response.Body.String(), `"code":"model_api_catalog_unavailable"`) || strings.Contains(response.Body.String(), "qwen3-8b") {
+		t.Fatalf("durable failure did not fail closed: status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func callableModelAPIProduct(t *testing.T, now time.Time) modelapiproduct.PublicProjection {
+	t.Helper()
+	var product modelapiproduct.Product
+	for _, candidate := range modelapiproduct.DefaultCatalog() {
+		if candidate.ID == "glm-5.2" {
+			product = candidate
+			break
+		}
+	}
+	product.Availability = modelapiproduct.AvailabilityAvailable
+	for index := range product.Capabilities {
+		if product.Capabilities[index].Name == "chat-completions" || product.Capabilities[index].Name == "streaming" {
+			evidenceUntil := now.Add(24 * time.Hour)
+			name := product.Capabilities[index].Name
+			product.Capabilities[index] = modelapiproduct.CapabilityClaim{Name: name, State: modelapiproduct.ClaimQualified, EvidenceID: name + "-evidence-private", EvidenceUntil: &evidenceUntil}
+		}
+	}
+	rate, err := modelapiproduct.NewRetailRate(modelapiproduct.RetailRateDraft{
+		ID: "rate-glm-1", ProductID: product.ID, Version: 1,
+		InputMicrousdPerMillion: 1_260_000, OutputMicrousdPerMillion: 3_960_000,
+		ValidFrom: now.Add(-time.Hour), ValidUntil: now.Add(24 * time.Hour),
+		PublishedAt: now.Add(-2 * time.Hour), PublicProvenance: "InferCrane rate card",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidenceUntil := now.Add(24 * time.Hour)
+	publication := modelapiproduct.OperatorPublication{
+		SchemaVersion: modelapiproduct.OperatorProjectionSchemaVersion, ProductID: product.ID,
+		OperatorWorkspaceID: "operator-private", ServingPlanID: "serving-private", SupplyPlanID: "supply-private",
+		Qualification: modelapiproduct.RouteQualification{State: modelapiproduct.QualificationQualified, EvidenceID: "evidence-private", EvidenceUntil: &evidenceUntil},
+		RetailRate:    &rate, UpdatedAt: now,
+	}
+	projection, err := modelapiproduct.PublicProjectionAt(product, &publication, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return projection
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -24,6 +24,7 @@ import (
 	"github.com/infercrane/infercrane/internal/authz"
 	"github.com/infercrane/infercrane/internal/contextpassport"
 	"github.com/infercrane/infercrane/internal/domain"
+	"github.com/infercrane/infercrane/internal/modelapirouting"
 	"github.com/infercrane/infercrane/internal/openaicompat"
 	"github.com/infercrane/infercrane/internal/routes"
 	"github.com/infercrane/infercrane/internal/runtimecontract"
@@ -67,6 +68,7 @@ type Gateway struct {
 	CapacityObservers   map[string]CapacityObserver
 	ExternalAuthorizer  ExternalAuthorizer
 	ManagedBilling      ManagedBillingAuthorizer
+	HostedModels        *modelapirouting.Runtime
 	RequestAuthorizer   RequestAuthorizer
 	AdmissionAuthorizer AdmissionAuthorizer
 	ContextPassports    ContextPassportResolver
@@ -138,6 +140,7 @@ func (g *Gateway) health(w http.ResponseWriter, _ *http.Request) {
 func (g *Gateway) models(w http.ResponseWriter, r *http.Request) {
 	data := make([]map[string]any, 0)
 	principal := r.Context().Value(principalKey{}).(domain.Principal)
+	seen := make(map[string]struct{})
 	for _, route := range g.Routes.ListForTenant(principal.TenantID) {
 		if !principalAllowsEndpoint(principal, route.Alias) {
 			continue
@@ -147,6 +150,15 @@ func (g *Gateway) models(w http.ResponseWriter, r *http.Request) {
 			owner = "endpoint"
 		}
 		data = append(data, map[string]any{"id": route.Alias, "object": "model", "owned_by": owner, "infercrane_capabilities": route.ProtocolCapabilities})
+		seen[route.Alias] = struct{}{}
+	}
+	if g.HostedModels != nil && g.HostedModels.Routes != nil {
+		for _, productID := range g.HostedModels.Routes.ListForTenant(principal.TenantID) {
+			if _, exists := seen[productID]; exists || !principalAllowsEndpoint(principal, productID) {
+				continue
+			}
+			data = append(data, map[string]any{"id": productID, "object": "model", "owned_by": "infercrane"})
+		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"object": "list", "data": data})
 }
@@ -212,6 +224,13 @@ func (g *Gateway) proxyInference(w http.ResponseWriter, r *http.Request, operati
 	}
 	route, releaseRoute, ok := g.Routes.AcquirePreferredForTenant(principal.TenantID, alias, preferredBinding, preferredTarget)
 	if !ok {
+		if g.HostedModels != nil {
+			g.HostedModels.ServeHTTP(w, r, modelapirouting.ProxyRequest{
+				TenantID: principal.TenantID, ProductID: alias, Operation: operation, Resource: resource,
+				RequestID: requestID, TraceParent: traceParent, Payload: payload,
+			})
+			return
+		}
 		openAIError(w, "Unknown model alias: "+alias, http.StatusNotFound, "invalid_request_error")
 		return
 	}

--- a/internal/modelapiproduct/entitlement.go
+++ b/internal/modelapiproduct/entitlement.go
@@ -1,0 +1,145 @@
+package modelapiproduct
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+type EntitlementState string
+
+const (
+	EntitlementPending   EntitlementState = "pending"
+	EntitlementActive    EntitlementState = "active"
+	EntitlementSuspended EntitlementState = "suspended"
+	EntitlementRevoked   EntitlementState = "revoked"
+)
+
+func (s EntitlementState) Valid() bool {
+	switch s {
+	case EntitlementPending, EntitlementActive, EntitlementSuspended, EntitlementRevoked:
+		return true
+	default:
+		return false
+	}
+}
+
+type CustomerLimits struct {
+	RequestsPerMinute    *int64 `json:"requests_per_minute,omitempty"`
+	TokensPerMinute      *int64 `json:"tokens_per_minute,omitempty"`
+	MonthlySpendMicrousd *int64 `json:"monthly_spend_microusd,omitempty"`
+	MaxRequestMicrousd   *int64 `json:"max_request_microusd,omitempty"`
+}
+
+func (l CustomerLimits) Validate() error {
+	for name, value := range map[string]*int64{
+		"requests_per_minute":    l.RequestsPerMinute,
+		"tokens_per_minute":      l.TokensPerMinute,
+		"monthly_spend_microusd": l.MonthlySpendMicrousd,
+		"max_request_microusd":   l.MaxRequestMicrousd,
+	} {
+		if value != nil && *value <= 0 {
+			return fmt.Errorf("customer limit %s must be positive when set", name)
+		}
+	}
+	if l.MaxRequestMicrousd != nil && l.MonthlySpendMicrousd != nil && *l.MaxRequestMicrousd > *l.MonthlySpendMicrousd {
+		return errors.New("maximum request cost cannot exceed the monthly spend limit")
+	}
+	return nil
+}
+
+// SupportedForAdmission is deliberately narrower than Validate. These limit
+// shapes remain representable for future control-plane work, but an active
+// hosted entitlement cannot promise enforcement the request path does not yet
+// implement.
+func (l CustomerLimits) SupportedForAdmission() bool {
+	return l.RequestsPerMinute == nil && l.TokensPerMinute == nil && l.MonthlySpendMicrousd == nil && l.MaxRequestMicrousd != nil
+}
+
+// ProductEntitlement is the trusted mapping from a customer workspace to
+// shared operator supply. It grants routing authority, not read access to the
+// operator's targets, supplier offers, or credentials.
+type ProductEntitlement struct {
+	SchemaVersion       string           `json:"schema_version"`
+	ID                  string           `json:"id"`
+	CustomerWorkspaceID string           `json:"customer_workspace_id"`
+	ProductID           string           `json:"product_id"`
+	OperatorWorkspaceID string           `json:"operator_workspace_id"`
+	ServingPlanID       string           `json:"serving_plan_id"`
+	RetailRateID        string           `json:"retail_rate_id"`
+	RetailRateVersion   int              `json:"retail_rate_version"`
+	State               EntitlementState `json:"state"`
+	Limits              CustomerLimits   `json:"limits"`
+	ValidFrom           time.Time        `json:"valid_from"`
+	ValidUntil          *time.Time       `json:"valid_until,omitempty"`
+	CreatedAt           time.Time        `json:"created_at"`
+	UpdatedAt           time.Time        `json:"updated_at"`
+}
+
+func (e ProductEntitlement) Validate() error {
+	if e.SchemaVersion != EntitlementSchemaVersion {
+		return fmt.Errorf("product entitlement schema_version must be %q", EntitlementSchemaVersion)
+	}
+	if !validID(e.ID) || !validID(e.ProductID) || e.CustomerWorkspaceID == "" || e.OperatorWorkspaceID == "" || e.ServingPlanID == "" || !validID(e.RetailRateID) || e.RetailRateVersion <= 0 {
+		return errors.New("entitlement identity, workspaces, serving plan, and retail rate are required")
+	}
+	if e.CustomerWorkspaceID == e.OperatorWorkspaceID {
+		return errors.New("shared hosted entitlement must separate customer and operator workspaces")
+	}
+	if !e.State.Valid() {
+		return errors.New("entitlement state is invalid")
+	}
+	if err := e.Limits.Validate(); err != nil {
+		return err
+	}
+	if e.ValidFrom.IsZero() || e.CreatedAt.IsZero() || e.UpdatedAt.IsZero() || e.UpdatedAt.Before(e.CreatedAt) {
+		return errors.New("entitlement needs ordered lifecycle timestamps")
+	}
+	if e.ValidUntil != nil && !e.ValidUntil.After(e.ValidFrom) {
+		return errors.New("entitlement valid_until must follow valid_from")
+	}
+	return nil
+}
+
+func (e ProductEntitlement) ActiveAt(at time.Time) bool {
+	if e.Validate() != nil || e.State != EntitlementActive || at.UTC().Before(e.ValidFrom.UTC()) {
+		return false
+	}
+	return e.ValidUntil == nil || at.UTC().Before(e.ValidUntil.UTC())
+}
+
+type CustomerEntitlementProjection struct {
+	SchemaVersion     string           `json:"schema_version"`
+	ID                string           `json:"id"`
+	ProductID         string           `json:"product_id"`
+	RetailRateVersion int              `json:"retail_rate_version"`
+	State             EntitlementState `json:"state"`
+	Limits            CustomerLimits   `json:"limits"`
+	ValidFrom         time.Time        `json:"valid_from"`
+	ValidUntil        *time.Time       `json:"valid_until,omitempty"`
+}
+
+func (e ProductEntitlement) CustomerProjection() (CustomerEntitlementProjection, error) {
+	if err := e.Validate(); err != nil {
+		return CustomerEntitlementProjection{}, err
+	}
+	projection := CustomerEntitlementProjection{
+		SchemaVersion: CustomerEntitlementSchemaVersion,
+		ID:            e.ID, ProductID: e.ProductID, RetailRateVersion: e.RetailRateVersion,
+		State: e.State, Limits: copyLimits(e.Limits), ValidFrom: e.ValidFrom.UTC(),
+	}
+	if e.ValidUntil != nil {
+		value := e.ValidUntil.UTC()
+		projection.ValidUntil = &value
+	}
+	return projection, nil
+}
+
+func copyLimits(limits CustomerLimits) CustomerLimits {
+	return CustomerLimits{
+		RequestsPerMinute:    copyInt64(limits.RequestsPerMinute),
+		TokensPerMinute:      copyInt64(limits.TokensPerMinute),
+		MonthlySpendMicrousd: copyInt64(limits.MonthlySpendMicrousd),
+		MaxRequestMicrousd:   copyInt64(limits.MaxRequestMicrousd),
+	}
+}

--- a/internal/modelapiproduct/product.go
+++ b/internal/modelapiproduct/product.go
@@ -1,0 +1,257 @@
+// Package modelapiproduct defines the supplier-neutral public Model API
+// product contract and the operator-private publication that can make a
+// product callable. Discovery metadata alone never makes a product callable.
+package modelapiproduct
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"time"
+)
+
+const (
+	ProductSchemaVersion             = "model-api-product/v1"
+	PublicProjectionSchemaVersion    = "model-api-public-projection/v1"
+	OperatorProjectionSchemaVersion  = "model-api-operator-projection/v1"
+	EntitlementSchemaVersion         = "model-api-product-entitlement/v1"
+	CustomerEntitlementSchemaVersion = "model-api-customer-entitlement/v1"
+)
+
+type Availability string
+
+const (
+	AvailabilityCatalogOnly    Availability = "catalog_only"
+	AvailabilityPrivatePreview Availability = "private_preview"
+	AvailabilityAvailable      Availability = "available"
+	AvailabilityDegraded       Availability = "degraded"
+	AvailabilityUnavailable    Availability = "unavailable"
+)
+
+func (a Availability) Valid() bool {
+	switch a {
+	case AvailabilityCatalogOnly, AvailabilityPrivatePreview, AvailabilityAvailable, AvailabilityDegraded, AvailabilityUnavailable:
+		return true
+	default:
+		return false
+	}
+}
+
+type ClaimState string
+
+const (
+	ClaimCataloged        ClaimState = "cataloged"
+	ClaimSupplierReported ClaimState = "supplier_reported"
+	ClaimQualified        ClaimState = "qualified"
+)
+
+func (s ClaimState) Valid() bool {
+	switch s {
+	case ClaimCataloged, ClaimSupplierReported, ClaimQualified:
+		return true
+	default:
+		return false
+	}
+}
+
+type SelfHostEligibility string
+
+const (
+	SelfHostUnknown    SelfHostEligibility = "unknown"
+	SelfHostEligible   SelfHostEligibility = "eligible"
+	SelfHostIneligible SelfHostEligibility = "ineligible"
+)
+
+func (e SelfHostEligibility) Valid() bool {
+	switch e {
+	case SelfHostUnknown, SelfHostEligible, SelfHostIneligible:
+		return true
+	default:
+		return false
+	}
+}
+
+// CapabilityClaim keeps catalog metadata distinct from current qualification.
+// Qualified claims need time-bounded evidence before they may be used to admit
+// traffic or make a public support claim.
+type CapabilityClaim struct {
+	Name          string     `json:"name"`
+	State         ClaimState `json:"state"`
+	EvidenceID    string     `json:"evidence_id,omitempty"`
+	EvidenceUntil *time.Time `json:"evidence_until,omitempty"`
+}
+
+func (c CapabilityClaim) Validate() error {
+	if !validName(c.Name) || !c.State.Valid() {
+		return errors.New("capability claim needs a valid name and state")
+	}
+	if c.State == ClaimQualified {
+		if c.EvidenceID == "" || c.EvidenceUntil == nil || c.EvidenceUntil.IsZero() {
+			return errors.New("qualified capability claim needs evidence and an expiry")
+		}
+	} else if c.EvidenceID != "" || c.EvidenceUntil != nil {
+		return errors.New("unqualified capability claim cannot carry qualification evidence")
+	}
+	return nil
+}
+
+func (c CapabilityClaim) CurrentAt(at time.Time) bool {
+	return c.State == ClaimQualified && c.EvidenceID != "" && c.EvidenceUntil != nil && c.EvidenceUntil.After(at.UTC())
+}
+
+// CallableOperation reports whether the claim is evidence for a request-path
+// operation. Streaming is a modifier of several operations, not an operation
+// on its own, and is checked separately when launchability is evaluated.
+func (c CapabilityClaim) CallableOperation() (string, bool) {
+	operation, ok := map[string]string{
+		"chat-completions": "chat",
+		"completions":      "completions",
+		"responses":        "responses",
+		"embeddings":       "embeddings",
+	}[c.Name]
+	return operation, ok
+}
+
+func (p Product) HasCurrentCallableCapabilityAt(at time.Time) bool {
+	hasCallable, requiresStreaming, hasStreaming := false, false, false
+	for _, claim := range p.Capabilities {
+		if !claim.CurrentAt(at) {
+			continue
+		}
+		if claim.Name == "streaming" {
+			hasStreaming = true
+			continue
+		}
+		operation, callable := claim.CallableOperation()
+		hasCallable = hasCallable || callable
+		requiresStreaming = requiresStreaming || callable && (operation == "chat" || operation == "completions" || operation == "responses")
+	}
+	return hasCallable && (!requiresStreaming || hasStreaming)
+}
+
+// Product is the stable, supplier-neutral identity shown to customers. Unknown
+// context and support data remain absent rather than being represented as zero.
+type Product struct {
+	SchemaVersion       string              `json:"schema_version"`
+	ID                  string              `json:"id"`
+	DisplayName         string              `json:"display_name"`
+	Publisher           string              `json:"publisher"`
+	Description         string              `json:"description"`
+	Protocol            string              `json:"protocol"`
+	Tasks               []string            `json:"tasks"`
+	Capabilities        []CapabilityClaim   `json:"capabilities"`
+	InputModalities     []string            `json:"input_modalities"`
+	OutputModalities    []string            `json:"output_modalities"`
+	ContextWindowTokens *int64              `json:"context_window_tokens,omitempty"`
+	Availability        Availability        `json:"availability"`
+	SelfHostEligibility SelfHostEligibility `json:"self_host_eligibility"`
+}
+
+func (p Product) Validate() error {
+	if p.SchemaVersion != ProductSchemaVersion {
+		return fmt.Errorf("product schema_version must be %q", ProductSchemaVersion)
+	}
+	if !validID(p.ID) || p.DisplayName == "" || p.Publisher == "" || p.Description == "" || p.Protocol != "openai" {
+		return errors.New("product identity and OpenAI-compatible protocol are required")
+	}
+	if !p.Availability.Valid() || !p.SelfHostEligibility.Valid() {
+		return errors.New("product availability and self-host eligibility must be explicit")
+	}
+	if len(p.Tasks) == 0 || len(p.Capabilities) == 0 || len(p.InputModalities) == 0 || len(p.OutputModalities) == 0 {
+		return errors.New("product tasks, capabilities, and modalities are required")
+	}
+	if err := uniqueNames(p.Tasks, "task"); err != nil {
+		return err
+	}
+	if err := uniqueNames(p.InputModalities, "input modality"); err != nil {
+		return err
+	}
+	if err := uniqueNames(p.OutputModalities, "output modality"); err != nil {
+		return err
+	}
+	seen := make(map[string]struct{}, len(p.Capabilities))
+	for _, capability := range p.Capabilities {
+		if err := capability.Validate(); err != nil {
+			return fmt.Errorf("product %q capability %q: %w", p.ID, capability.Name, err)
+		}
+		if _, exists := seen[capability.Name]; exists {
+			return fmt.Errorf("product %q capability %q is duplicated", p.ID, capability.Name)
+		}
+		seen[capability.Name] = struct{}{}
+	}
+	if p.ContextWindowTokens != nil && *p.ContextWindowTokens <= 0 {
+		return errors.New("known context window must be positive")
+	}
+	return nil
+}
+
+// DefaultCatalog returns the fixed public launch shelf. Every entry starts as
+// catalog-only with cataloged (not qualified) capability claims and no invented
+// context, price, availability, or performance evidence.
+func DefaultCatalog() []Product {
+	products := []Product{
+		newCatalogProduct("glm-5.2", "GLM-5.2", "Z.ai", "Planned for coding, reasoning, and bilingual chat workloads.", []string{"coding", "reasoning", "chat"}),
+		newCatalogProduct("glm-5.3", "GLM-5.3", "Z.ai", "Planned for reasoning and long-context workloads.", []string{"reasoning", "long-context", "chat"}),
+		newCatalogProduct("glm-5.3-flash", "GLM-5.3-Flash", "Z.ai", "Planned for cost-sensitive and latency-sensitive workloads.", []string{"chat", "coding"}),
+		newCatalogProduct("kimi-k3", "Kimi-K3", "Moonshot AI", "Planned for coding and agentic workflows.", []string{"coding", "agents", "chat"}),
+		newCatalogProduct("kimi-k2.6", "Kimi-K2.6", "Moonshot AI", "Planned for coding, agentic, and long-context workloads.", []string{"coding", "agents", "long-context", "chat"}),
+		newCatalogProduct("deepseek-v4-flash-0731-fast", "DeepSeek-V4-Flash-0731-Fast", "DeepSeek", "Planned for high-throughput workloads after route qualification.", []string{"chat", "coding", "throughput"}),
+	}
+	sort.Slice(products, func(i, j int) bool { return products[i].ID < products[j].ID })
+	return products
+}
+
+func ValidateCatalog(products []Product) error {
+	if len(products) == 0 {
+		return errors.New("product catalog cannot be empty")
+	}
+	seen := make(map[string]struct{}, len(products))
+	for _, product := range products {
+		if err := product.Validate(); err != nil {
+			return fmt.Errorf("product %q: %w", product.ID, err)
+		}
+		if _, exists := seen[product.ID]; exists {
+			return fmt.Errorf("product id %q is duplicated", product.ID)
+		}
+		seen[product.ID] = struct{}{}
+	}
+	return nil
+}
+
+func newCatalogProduct(id, name, publisher, description string, tasks []string) Product {
+	return Product{
+		SchemaVersion:       ProductSchemaVersion,
+		ID:                  id,
+		DisplayName:         name,
+		Publisher:           publisher,
+		Description:         description,
+		Protocol:            "openai",
+		Tasks:               append([]string(nil), tasks...),
+		Capabilities:        []CapabilityClaim{{Name: "chat-completions", State: ClaimCataloged}, {Name: "streaming", State: ClaimCataloged}},
+		InputModalities:     []string{"text"},
+		OutputModalities:    []string{"text"},
+		Availability:        AvailabilityCatalogOnly,
+		SelfHostEligibility: SelfHostUnknown,
+	}
+}
+
+var idPattern = regexp.MustCompile(`^[a-z0-9]+(?:[.-][a-z0-9]+)*$`)
+var namePattern = regexp.MustCompile(`^[a-z0-9]+(?:[-_.][a-z0-9]+)*$`)
+
+func validID(value string) bool   { return len(value) <= 128 && idPattern.MatchString(value) }
+func validName(value string) bool { return len(value) <= 128 && namePattern.MatchString(value) }
+
+func uniqueNames(values []string, field string) error {
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if !validName(value) {
+			return fmt.Errorf("%s %q is invalid", field, value)
+		}
+		if _, exists := seen[value]; exists {
+			return fmt.Errorf("%s %q is duplicated", field, value)
+		}
+		seen[value] = struct{}{}
+	}
+	return nil
+}

--- a/internal/modelapiproduct/product_test.go
+++ b/internal/modelapiproduct/product_test.go
@@ -1,0 +1,266 @@
+package modelapiproduct
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDefaultCatalogIsExactlyTheStableSixAndMakesNoServiceClaim(t *testing.T) {
+	products := DefaultCatalog()
+	if err := ValidateCatalog(products); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"deepseek-v4-flash-0731-fast",
+		"glm-5.2",
+		"glm-5.3",
+		"glm-5.3-flash",
+		"kimi-k2.6",
+		"kimi-k3",
+	}
+	got := make([]string, 0, len(products))
+	for _, product := range products {
+		got = append(got, product.ID)
+		if product.Availability != AvailabilityCatalogOnly || product.ContextWindowTokens != nil || product.SelfHostEligibility != SelfHostUnknown {
+			t.Fatalf("default product fabricated operational evidence: %+v", product)
+		}
+		for _, claim := range product.Capabilities {
+			if claim.State != ClaimCataloged || claim.EvidenceID != "" || claim.EvidenceUntil != nil {
+				t.Fatalf("default product fabricated qualified capability evidence: %+v", claim)
+			}
+		}
+		projection, err := PublicProjectionAt(product, nil, time.Now())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if projection.Callable || projection.RetailRate != nil {
+			t.Fatalf("catalog-only product became callable: %+v", projection)
+		}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("stable public product ids changed: got %v want %v", got, want)
+	}
+}
+
+func TestRetailRateIsVersionedCurrentAndTamperEvident(t *testing.T) {
+	published := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	validFrom := published.Add(time.Hour)
+	validUntil := validFrom.Add(24 * time.Hour)
+	rate, err := NewRetailRate(RetailRateDraft{
+		ID: "glm-5.3-rate-1", ProductID: "glm-5.3", Version: 1,
+		InputMicrousdPerMillion:  250_000,
+		OutputMicrousdPerMillion: 750_000, ValidFrom: validFrom, ValidUntil: validUntil,
+		PublishedAt: published, PublicProvenance: "InferCrane retail rate card",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rate.ContractDigest == "" || !rate.CurrentAt(validFrom) || rate.CurrentAt(validUntil) {
+		t.Fatalf("unexpected rate validity: %+v", rate)
+	}
+	duplicate, err := NewRetailRate(RetailRateDraft{
+		ID: "glm-5.3-rate-1", ProductID: "glm-5.3", Version: 1,
+		InputMicrousdPerMillion:  250_000,
+		OutputMicrousdPerMillion: 750_000, ValidFrom: validFrom, ValidUntil: validUntil,
+		PublishedAt: published, PublicProvenance: "InferCrane retail rate card",
+	})
+	if err != nil || duplicate.ContractDigest != rate.ContractDigest {
+		t.Fatalf("rate digest must be deterministic: %v %+v", err, duplicate)
+	}
+	tampered := rate
+	tampered.OutputMicrousdPerMillion++
+	if err := tampered.Validate(); err == nil || tampered.CurrentAt(validFrom) {
+		t.Fatal("mutated rate contract must fail closed")
+	}
+}
+
+func TestRetailRateRejectsUnknownOrInvalidPublicPricing(t *testing.T) {
+	now := time.Now().UTC()
+	cached := int64(1)
+	for name, draft := range map[string]RetailRateDraft{
+		"missing input":                          {ID: "rate-1", ProductID: "glm-5.3", Version: 1, OutputMicrousdPerMillion: 1, ValidFrom: now, ValidUntil: now.Add(time.Hour), PublishedAt: now, PublicProvenance: "retail"},
+		"unordered validity":                     {ID: "rate-1", ProductID: "glm-5.3", Version: 1, InputMicrousdPerMillion: 1, OutputMicrousdPerMillion: 1, ValidFrom: now, ValidUntil: now, PublishedAt: now, PublicProvenance: "retail"},
+		"late publication":                       {ID: "rate-1", ProductID: "glm-5.3", Version: 1, InputMicrousdPerMillion: 1, OutputMicrousdPerMillion: 1, ValidFrom: now, ValidUntil: now.Add(time.Hour), PublishedAt: now.Add(time.Minute), PublicProvenance: "retail"},
+		"cached input before settlement support": {ID: "rate-1", ProductID: "glm-5.3", Version: 1, InputMicrousdPerMillion: 1, CachedInputMicrousdPerMillion: &cached, OutputMicrousdPerMillion: 1, ValidFrom: now, ValidUntil: now.Add(time.Hour), PublishedAt: now, PublicProvenance: "retail"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := NewRetailRate(draft); err == nil {
+				t.Fatal("expected invalid public pricing to be rejected")
+			}
+		})
+	}
+}
+
+func TestPublicProjectionRequiresCurrentRateAndEvidenceAndRedactsOperatorData(t *testing.T) {
+	now := time.Date(2030, 2, 1, 0, 0, 0, 0, time.UTC)
+	product := productByID(t, "glm-5.3-flash")
+	product.Availability = AvailabilityAvailable
+	qualifyCapability(t, &product, "chat-completions", now.Add(time.Hour))
+	qualifyCapability(t, &product, "streaming", now.Add(time.Hour))
+	rate := testRate(t, product.ID, now.Add(-time.Hour), now.Add(time.Hour))
+	evidenceUntil := now.Add(time.Hour)
+	publication := OperatorPublication{
+		SchemaVersion:       OperatorProjectionSchemaVersion,
+		ProductID:           product.ID,
+		OperatorWorkspaceID: "operator-secret-workspace",
+		ServingPlanID:       "operator-secret-serving-plan",
+		SupplyPlanID:        "operator-secret-supply-plan",
+		Qualification:       RouteQualification{State: QualificationQualified, EvidenceID: "operator-secret-evidence", EvidenceUntil: &evidenceUntil},
+		RetailRate:          &rate,
+		UpdatedAt:           now,
+	}
+	unqualified := product
+	unqualified.Capabilities = append([]CapabilityClaim(nil), product.Capabilities...)
+	for index := range unqualified.Capabilities {
+		unqualified.Capabilities[index].State = ClaimCataloged
+		unqualified.Capabilities[index].EvidenceID = ""
+		unqualified.Capabilities[index].EvidenceUntil = nil
+	}
+	if err := publication.ValidateAt(unqualified, now); err == nil {
+		t.Fatal("route-level qualification made a product callable without per-operation evidence")
+	}
+	unqualifiedProjection, err := PublicProjectionAt(unqualified, &publication, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unqualifiedProjection.Callable {
+		t.Fatal("public projection became callable without per-operation evidence")
+	}
+	missingStreaming := product
+	missingStreaming.Capabilities = append([]CapabilityClaim(nil), product.Capabilities...)
+	for index := range missingStreaming.Capabilities {
+		if missingStreaming.Capabilities[index].Name == "streaming" {
+			missingStreaming.Capabilities[index] = CapabilityClaim{Name: "streaming", State: ClaimCataloged}
+		}
+	}
+	if err := publication.ValidateAt(missingStreaming, now); err == nil {
+		t.Fatal("stream-capable product launched without streaming evidence")
+	}
+	missingStreamingProjection, err := PublicProjectionAt(missingStreaming, &publication, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if missingStreamingProjection.Callable {
+		t.Fatal("public projection became callable without streaming evidence")
+	}
+	if err := publication.ValidateAt(product, now); err != nil {
+		t.Fatal(err)
+	}
+	projection, err := PublicProjectionAt(product, &publication, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !projection.Callable || projection.RetailRate == nil || projection.Qualification != QualificationQualified {
+		t.Fatalf("qualified publication should be callable: %+v", projection)
+	}
+	body, err := json.Marshal(projection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, secret := range []string{"operator-secret-workspace", "operator-secret-serving-plan", "operator-secret-supply-plan", "operator-secret-evidence"} {
+		if strings.Contains(string(body), secret) {
+			t.Fatalf("public projection leaked operator-private value %q: %s", secret, body)
+		}
+	}
+
+	expiredEvidence := now
+	publication.Qualification.EvidenceUntil = &expiredEvidence
+	projection, err = PublicProjectionAt(product, &publication, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projection.Callable || projection.Availability != AvailabilityUnavailable || projection.Qualification != QualificationStale || projection.EvidenceValidUntil != nil {
+		t.Fatalf("expired evidence must fail closed: %+v", projection)
+	}
+}
+
+func TestProductEntitlementIsSharedSupplyContractWithSafeCustomerProjection(t *testing.T) {
+	now := time.Date(2030, 3, 1, 0, 0, 0, 0, time.UTC)
+	rpm, monthly, maximum := int64(60), int64(10_000_000), int64(100_000)
+	entitlement := ProductEntitlement{
+		SchemaVersion: EntitlementSchemaVersion,
+		ID:            "entitlement-1", CustomerWorkspaceID: "customer-workspace", ProductID: "kimi-k3",
+		OperatorWorkspaceID: "operator-private-workspace", ServingPlanID: "operator-private-plan",
+		RetailRateID: "kimi-k3-rate-4", RetailRateVersion: 4, State: EntitlementActive,
+		Limits:    CustomerLimits{MaxRequestMicrousd: &maximum},
+		ValidFrom: now.Add(-time.Hour), CreatedAt: now.Add(-2 * time.Hour), UpdatedAt: now.Add(-time.Hour),
+	}
+	if !entitlement.ActiveAt(now) {
+		t.Fatal("valid active entitlement should authorize its product")
+	}
+	projection, err := entitlement.CustomerProjection()
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(projection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, private := range []string{"operator-private-workspace", "operator-private-plan", "kimi-k3-rate-4", "customer-workspace"} {
+		if strings.Contains(string(body), private) {
+			t.Fatalf("customer projection leaked private binding %q: %s", private, body)
+		}
+	}
+	if projection.ProductID != entitlement.ProductID || projection.RetailRateVersion != entitlement.RetailRateVersion {
+		t.Fatalf("customer projection lost public entitlement contract: %+v", projection)
+	}
+	entitlement.Limits.RequestsPerMinute = &rpm
+	entitlement.Limits.MonthlySpendMicrousd = &monthly
+	if entitlement.Limits.SupportedForAdmission() {
+		t.Fatal("unsupported entitlement limits were marked enforceable")
+	}
+	projection, err = entitlement.CustomerProjection()
+	if err != nil {
+		t.Fatal(err)
+	}
+	*projection.Limits.RequestsPerMinute = 999
+	if *entitlement.Limits.RequestsPerMinute == 999 {
+		t.Fatal("customer projection shares mutable limit storage with trusted entitlement")
+	}
+
+	entitlement.OperatorWorkspaceID = entitlement.CustomerWorkspaceID
+	if err := entitlement.Validate(); err == nil {
+		t.Fatal("shared hosted entitlement must not collapse operator and customer tenancy")
+	}
+}
+
+func qualifyCapability(t *testing.T, product *Product, name string, until time.Time) {
+	t.Helper()
+	for index := range product.Capabilities {
+		if product.Capabilities[index].Name == name {
+			product.Capabilities[index].State = ClaimQualified
+			product.Capabilities[index].EvidenceID = "evidence-" + name
+			product.Capabilities[index].EvidenceUntil = &until
+			return
+		}
+	}
+	t.Fatalf("missing capability %q", name)
+}
+
+func productByID(t *testing.T, id string) Product {
+	t.Helper()
+	for _, product := range DefaultCatalog() {
+		if product.ID == id {
+			return product
+		}
+	}
+	t.Fatalf("missing default product %q", id)
+	return Product{}
+}
+
+func testRate(t *testing.T, productID string, from, until time.Time) RetailRate {
+	t.Helper()
+	rate, err := NewRetailRate(RetailRateDraft{
+		ID: productID + "-rate-1", ProductID: productID, Version: 1,
+		InputMicrousdPerMillion: 100_000, OutputMicrousdPerMillion: 400_000,
+		ValidFrom: from, ValidUntil: until, PublishedAt: from.Add(-time.Hour),
+		PublicProvenance: "InferCrane retail rate card",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rate
+}

--- a/internal/modelapiproduct/publication.go
+++ b/internal/modelapiproduct/publication.go
@@ -1,0 +1,201 @@
+package modelapiproduct
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+type QualificationState string
+
+const (
+	QualificationPending   QualificationState = "pending"
+	QualificationQualified QualificationState = "qualified"
+	QualificationStale     QualificationState = "stale"
+)
+
+func (s QualificationState) Valid() bool {
+	switch s {
+	case QualificationPending, QualificationQualified, QualificationStale:
+		return true
+	default:
+		return false
+	}
+}
+
+type RouteQualification struct {
+	State         QualificationState `json:"state"`
+	EvidenceID    string             `json:"evidence_id,omitempty"`
+	EvidenceUntil *time.Time         `json:"evidence_until,omitempty"`
+}
+
+func (q RouteQualification) Validate() error {
+	if !q.State.Valid() {
+		return errors.New("route qualification state is invalid")
+	}
+	if q.State == QualificationQualified {
+		if q.EvidenceID == "" || q.EvidenceUntil == nil || q.EvidenceUntil.IsZero() {
+			return errors.New("qualified route needs evidence and an expiry")
+		}
+	} else if q.EvidenceID != "" || q.EvidenceUntil != nil {
+		return errors.New("non-qualified route cannot carry active evidence")
+	}
+	return nil
+}
+
+func (q RouteQualification) CurrentAt(at time.Time) bool {
+	return q.State == QualificationQualified && q.EvidenceID != "" && q.EvidenceUntil != nil && q.EvidenceUntil.After(at.UTC())
+}
+
+// OperatorPublication contains trusted control-plane references. It must never
+// be serialized through the anonymous or customer projection.
+type OperatorPublication struct {
+	SchemaVersion       string             `json:"schema_version"`
+	ProductID           string             `json:"product_id"`
+	OperatorWorkspaceID string             `json:"operator_workspace_id"`
+	ServingPlanID       string             `json:"serving_plan_id"`
+	SupplyPlanID        string             `json:"supply_plan_id"`
+	Qualification       RouteQualification `json:"qualification"`
+	RetailRate          *RetailRate        `json:"retail_rate,omitempty"`
+	UpdatedAt           time.Time          `json:"updated_at"`
+}
+
+func (p OperatorPublication) validateStructure(product Product) error {
+	if p.SchemaVersion != OperatorProjectionSchemaVersion {
+		return fmt.Errorf("operator publication schema_version must be %q", OperatorProjectionSchemaVersion)
+	}
+	if err := product.Validate(); err != nil {
+		return err
+	}
+	if p.ProductID != product.ID {
+		return errors.New("publication product does not match public product")
+	}
+	if err := p.Qualification.Validate(); err != nil {
+		return err
+	}
+	if p.OperatorWorkspaceID == "" || p.ServingPlanID == "" || p.SupplyPlanID == "" || p.UpdatedAt.IsZero() {
+		return errors.New("operator publication needs workspace, serving plan, supply plan, and update time")
+	}
+	if p.RetailRate != nil {
+		if err := p.RetailRate.Validate(); err != nil {
+			return err
+		}
+		if p.RetailRate.ProductID != product.ID {
+			return errors.New("retail rate product does not match publication product")
+		}
+	}
+	return nil
+}
+
+func (p OperatorPublication) ValidateAt(product Product, at time.Time) error {
+	if err := p.validateStructure(product); err != nil {
+		return err
+	}
+	if product.Availability == AvailabilityAvailable || product.Availability == AvailabilityDegraded {
+		if p.RetailRate == nil || !p.RetailRate.CurrentAt(at) || !p.Qualification.CurrentAt(at) || !product.HasCurrentCallableCapabilityAt(at) {
+			return errors.New("callable availability needs a current retail rate, route qualification, and per-operation capability evidence")
+		}
+	}
+	return nil
+}
+
+type PublicCapabilityClaim struct {
+	Name               string     `json:"name"`
+	State              ClaimState `json:"state"`
+	EvidenceValidUntil *time.Time `json:"evidence_valid_until,omitempty"`
+}
+
+type PublicProjection struct {
+	SchemaVersion       string                  `json:"schema_version"`
+	ID                  string                  `json:"id"`
+	DisplayName         string                  `json:"display_name"`
+	Publisher           string                  `json:"publisher"`
+	Description         string                  `json:"description"`
+	Protocol            string                  `json:"protocol"`
+	Tasks               []string                `json:"tasks"`
+	Capabilities        []PublicCapabilityClaim `json:"capabilities"`
+	InputModalities     []string                `json:"input_modalities"`
+	OutputModalities    []string                `json:"output_modalities"`
+	ContextWindowTokens *int64                  `json:"context_window_tokens,omitempty"`
+	Availability        Availability            `json:"availability"`
+	SelfHostEligibility SelfHostEligibility     `json:"self_host_eligibility"`
+	RetailRate          *RetailRate             `json:"retail_rate,omitempty"`
+	Qualification       QualificationState      `json:"qualification"`
+	EvidenceValidUntil  *time.Time              `json:"evidence_valid_until,omitempty"`
+	Callable            bool                    `json:"callable"`
+}
+
+func (p PublicProjection) HasCurrentCallableCapabilityAt(at time.Time) bool {
+	hasCallable, requiresStreaming, hasStreaming := false, false, false
+	for _, claim := range p.Capabilities {
+		if claim.State != ClaimQualified || claim.EvidenceValidUntil == nil || !claim.EvidenceValidUntil.After(at.UTC()) {
+			continue
+		}
+		if claim.Name == "streaming" {
+			hasStreaming = true
+			continue
+		}
+		operation, callable := (CapabilityClaim{Name: claim.Name}).CallableOperation()
+		hasCallable = hasCallable || callable
+		requiresStreaming = requiresStreaming || callable && (operation == "chat" || operation == "completions" || operation == "responses")
+	}
+	return hasCallable && (!requiresStreaming || hasStreaming)
+}
+
+// PublicProjectionAt explicitly strips operator workspace, plan, supplier, and
+// evidence identifiers. Expired rates and evidence fail closed.
+func PublicProjectionAt(product Product, publication *OperatorPublication, at time.Time) (PublicProjection, error) {
+	if err := product.Validate(); err != nil {
+		return PublicProjection{}, err
+	}
+	projection := PublicProjection{
+		SchemaVersion: PublicProjectionSchemaVersion,
+		ID:            product.ID, DisplayName: product.DisplayName, Publisher: product.Publisher,
+		Description: product.Description, Protocol: product.Protocol,
+		Tasks: append([]string(nil), product.Tasks...), Capabilities: publicCapabilitiesAt(product.Capabilities, at),
+		InputModalities: append([]string(nil), product.InputModalities...), OutputModalities: append([]string(nil), product.OutputModalities...),
+		ContextWindowTokens: copyInt64(product.ContextWindowTokens), Availability: product.Availability,
+		SelfHostEligibility: product.SelfHostEligibility, Qualification: QualificationPending,
+	}
+	if publication == nil {
+		return projection, nil
+	}
+	if err := publication.validateStructure(product); err != nil {
+		return PublicProjection{}, err
+	}
+	projection.Qualification = publication.Qualification.State
+	if publication.Qualification.CurrentAt(at) {
+		value := publication.Qualification.EvidenceUntil.UTC()
+		projection.EvidenceValidUntil = &value
+	} else if publication.Qualification.State == QualificationQualified {
+		projection.Qualification = QualificationStale
+	}
+	if publication.RetailRate != nil && publication.RetailRate.ProductID == product.ID && publication.RetailRate.CurrentAt(at) {
+		copy := *publication.RetailRate
+		copy.CachedInputMicrousdPerMillion = copyInt64(publication.RetailRate.CachedInputMicrousdPerMillion)
+		projection.RetailRate = &copy
+	}
+	callableState := product.Availability == AvailabilityAvailable || product.Availability == AvailabilityDegraded
+	projection.Callable = callableState && publication.OperatorWorkspaceID != "" && publication.ServingPlanID != "" && publication.SupplyPlanID != "" && projection.RetailRate != nil && publication.Qualification.CurrentAt(at) && projection.HasCurrentCallableCapabilityAt(at)
+	if callableState && !projection.Callable {
+		// Never leave an externally visible product labelled available when a
+		// stale price or qualification means admission must fail closed.
+		projection.Availability = AvailabilityUnavailable
+	}
+	return projection, nil
+}
+
+func publicCapabilitiesAt(claims []CapabilityClaim, at time.Time) []PublicCapabilityClaim {
+	public := make([]PublicCapabilityClaim, 0, len(claims))
+	for _, claim := range claims {
+		item := PublicCapabilityClaim{Name: claim.Name, State: claim.State}
+		if claim.CurrentAt(at) {
+			value := claim.EvidenceUntil.UTC()
+			item.EvidenceValidUntil = &value
+		} else if claim.State == ClaimQualified {
+			item.State = ClaimCataloged
+		}
+		public = append(public, item)
+	}
+	return public
+}

--- a/internal/modelapiproduct/rate.go
+++ b/internal/modelapiproduct/rate.go
@@ -1,0 +1,134 @@
+package modelapiproduct
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// RetailRate is an append-only, versioned public price contract. Supplier cost
+// and supplier identity intentionally do not belong in this record.
+type RetailRate struct {
+	ID                            string    `json:"id"`
+	ProductID                     string    `json:"product_id"`
+	Version                       int       `json:"version"`
+	Currency                      string    `json:"currency"`
+	InputMicrousdPerMillion       int64     `json:"input_microusd_per_million"`
+	CachedInputMicrousdPerMillion *int64    `json:"cached_input_microusd_per_million,omitempty"`
+	OutputMicrousdPerMillion      int64     `json:"output_microusd_per_million"`
+	ValidFrom                     time.Time `json:"valid_from"`
+	ValidUntil                    time.Time `json:"valid_until"`
+	PublishedAt                   time.Time `json:"published_at"`
+	PublicProvenance              string    `json:"public_provenance"`
+	ContractDigest                string    `json:"contract_digest"`
+}
+
+type RetailRateDraft struct {
+	ID                            string
+	ProductID                     string
+	Version                       int
+	InputMicrousdPerMillion       int64
+	CachedInputMicrousdPerMillion *int64
+	OutputMicrousdPerMillion      int64
+	ValidFrom                     time.Time
+	ValidUntil                    time.Time
+	PublishedAt                   time.Time
+	PublicProvenance              string
+}
+
+func NewRetailRate(draft RetailRateDraft) (RetailRate, error) {
+	rate := RetailRate{
+		ID:                            draft.ID,
+		ProductID:                     draft.ProductID,
+		Version:                       draft.Version,
+		Currency:                      "USD",
+		InputMicrousdPerMillion:       draft.InputMicrousdPerMillion,
+		CachedInputMicrousdPerMillion: copyInt64(draft.CachedInputMicrousdPerMillion),
+		OutputMicrousdPerMillion:      draft.OutputMicrousdPerMillion,
+		ValidFrom:                     draft.ValidFrom.UTC(),
+		ValidUntil:                    draft.ValidUntil.UTC(),
+		PublishedAt:                   draft.PublishedAt.UTC(),
+		PublicProvenance:              draft.PublicProvenance,
+	}
+	if err := rate.validateFields(); err != nil {
+		return RetailRate{}, err
+	}
+	digest, err := rate.computeDigest()
+	if err != nil {
+		return RetailRate{}, err
+	}
+	rate.ContractDigest = digest
+	return rate, nil
+}
+
+func (r RetailRate) Validate() error {
+	if err := r.validateFields(); err != nil {
+		return err
+	}
+	expected, err := r.computeDigest()
+	if err != nil {
+		return err
+	}
+	if r.ContractDigest != expected {
+		return errors.New("retail rate contract digest does not match its immutable fields")
+	}
+	return nil
+}
+
+func (r RetailRate) CurrentAt(at time.Time) bool {
+	return r.Validate() == nil && !at.UTC().Before(r.ValidFrom) && at.UTC().Before(r.ValidUntil)
+}
+
+func (r RetailRate) validateFields() error {
+	if !validID(r.ID) || !validID(r.ProductID) || r.Version <= 0 || r.Currency != "USD" || r.PublicProvenance == "" {
+		return errors.New("retail rate identity, positive version, USD currency, and public provenance are required")
+	}
+	if r.InputMicrousdPerMillion <= 0 || r.OutputMicrousdPerMillion <= 0 {
+		return errors.New("published input and output rates must be positive")
+	}
+	if r.CachedInputMicrousdPerMillion != nil {
+		return errors.New("cached-input pricing cannot be published until cached-token settlement is supported")
+	}
+	if r.ValidFrom.IsZero() || r.ValidUntil.IsZero() || r.PublishedAt.IsZero() || !r.ValidUntil.After(r.ValidFrom) || r.PublishedAt.After(r.ValidFrom) {
+		return errors.New("retail rate needs ordered published_at, valid_from, and valid_until timestamps")
+	}
+	return nil
+}
+
+func (r RetailRate) computeDigest() (string, error) {
+	contract := struct {
+		ID                            string    `json:"id"`
+		ProductID                     string    `json:"product_id"`
+		Version                       int       `json:"version"`
+		Currency                      string    `json:"currency"`
+		InputMicrousdPerMillion       int64     `json:"input_microusd_per_million"`
+		CachedInputMicrousdPerMillion *int64    `json:"cached_input_microusd_per_million,omitempty"`
+		OutputMicrousdPerMillion      int64     `json:"output_microusd_per_million"`
+		ValidFrom                     time.Time `json:"valid_from"`
+		ValidUntil                    time.Time `json:"valid_until"`
+		PublishedAt                   time.Time `json:"published_at"`
+		PublicProvenance              string    `json:"public_provenance"`
+	}{
+		ID: r.ID, ProductID: r.ProductID, Version: r.Version, Currency: r.Currency,
+		InputMicrousdPerMillion: r.InputMicrousdPerMillion, CachedInputMicrousdPerMillion: r.CachedInputMicrousdPerMillion,
+		OutputMicrousdPerMillion: r.OutputMicrousdPerMillion, ValidFrom: r.ValidFrom.UTC(), ValidUntil: r.ValidUntil.UTC(),
+		PublishedAt: r.PublishedAt.UTC(), PublicProvenance: r.PublicProvenance,
+	}
+	body, err := json.Marshal(contract)
+	if err != nil {
+		return "", fmt.Errorf("encode retail rate contract: %w", err)
+	}
+	sum := sha256.Sum256(body)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func copyInt64(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}

--- a/internal/modelapirouting/billing.go
+++ b/internal/modelapirouting/billing.go
@@ -1,0 +1,56 @@
+package modelapirouting
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var ErrInsufficientPrepaidBalance = errors.New("prepaid Model API balance is insufficient")
+
+type ReservationRequest struct {
+	ID, TenantID, ProductID, EntitlementID          string
+	OperatorTenantID, ServingPlanID, SupplyPlanID   string
+	RetailRate                                      RetailRate
+	MaxRequestMicrousd                              int64
+	CandidateID, OfferID, Supplier, SupplierModelID string
+	OfferVersion                                    int64
+	CreatedAt                                       time.Time
+}
+
+func (r ReservationRequest) Validate() error {
+	if r.ID == "" || r.TenantID == "" || r.ProductID == "" || r.EntitlementID == "" || r.OperatorTenantID == "" ||
+		r.ServingPlanID == "" || r.SupplyPlanID == "" || r.CandidateID == "" || r.OfferID == "" || r.Supplier == "" ||
+		r.SupplierModelID == "" || r.OfferVersion <= 0 || r.MaxRequestMicrousd <= 0 || r.CreatedAt.IsZero() {
+		return errors.New("hosted reservation identity, route, supplier, limit, and timestamp are required")
+	}
+	if r.RetailRate.ProductID != r.ProductID || !r.RetailRate.currentAt(r.CreatedAt.UTC()) {
+		return errors.New("hosted reservation requires the exact current immutable retail rate")
+	}
+	return nil
+}
+
+type Reservation struct {
+	ID, TenantID, ProductID, EntitlementID            string
+	RetailRateID, RetailRateDigest                    string
+	RetailRateVersion                                 int
+	InputMicrousdPerMillion, OutputMicrousdPerMillion int64
+	ReservedMicrousd, ActualMicrousd                  int64
+	InputTokens, OutputTokens                         *int
+	State, Resolution                                 string
+	TransmittedAt, ResponseStartedAt                  *time.Time
+	CreatedAt, UpdatedAt                              time.Time
+}
+
+type Usage struct {
+	StatusCode                int
+	InputTokens, OutputTokens *int
+}
+
+type Billing interface {
+	Reserve(context.Context, ReservationRequest) (Reservation, error)
+	MarkTransmitted(context.Context, string, string, time.Time) error
+	MarkResponseStarted(context.Context, string, string, time.Time) error
+	Settle(context.Context, string, string, Usage) (Reservation, error)
+	ReleaseUnsent(context.Context, string, string, string) error
+}

--- a/internal/modelapirouting/directory.go
+++ b/internal/modelapirouting/directory.go
@@ -1,0 +1,255 @@
+// Package modelapirouting owns the request-path snapshot for InferCrane's
+// shared hosted Model API catalog. Control-plane code publishes immutable
+// snapshots; request-path reads never query the database.
+package modelapirouting
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	ErrRouteUnavailable = errors.New("hosted model API route is unavailable")
+	ErrUnauthorized     = errors.New("hosted model API entitlement is not active")
+)
+
+// RetailRate is the immutable customer price captured by a request lease.
+// Supplier prices and identities never belong in this contract.
+type RetailRate struct {
+	ID, ProductID, ContractDigest                     string
+	Version                                           int
+	InputMicrousdPerMillion, OutputMicrousdPerMillion int64
+	CachedInputMicrousdPerMillion                     *int64
+	ValidFrom, ValidUntil                             time.Time
+}
+
+func (r RetailRate) currentAt(at time.Time) bool {
+	return r.ID != "" && r.ProductID != "" && r.Version > 0 && strings.HasPrefix(r.ContractDigest, "sha256:") &&
+		r.InputMicrousdPerMillion > 0 && r.OutputMicrousdPerMillion > 0 &&
+		!at.Before(r.ValidFrom) && at.Before(r.ValidUntil)
+}
+
+// Entitlement is customer-owned policy that authorizes one public product to
+// one operator publication. It contains no supplier or credential details.
+type Entitlement struct {
+	ID, CustomerTenantID, ProductID, OperatorTenantID string
+	ServingPlanID, RetailRateID                       string
+	RetailRateVersion                                 int
+	State                                             string
+	MaxRequestMicrousd                                int64
+	ValidFrom                                         time.Time
+	ValidUntil                                        *time.Time
+}
+
+func (e Entitlement) activeAt(at time.Time) bool {
+	return e.ID != "" && e.CustomerTenantID != "" && e.ProductID != "" && e.OperatorTenantID != "" &&
+		e.CustomerTenantID != e.OperatorTenantID && e.ServingPlanID != "" && e.RetailRateID != "" &&
+		e.RetailRateVersion > 0 && e.State == "active" && e.MaxRequestMicrousd > 0 &&
+		!at.Before(e.ValidFrom) && (e.ValidUntil == nil || at.Before(*e.ValidUntil))
+}
+
+// Publication is the operator-owned current route contract.
+type Publication struct {
+	ProductID, OperatorTenantID, ServingPlanID, SupplyPlanID string
+	CompatibilityKey                                         string
+	EvidenceID                                               string
+	EvidenceValidUntil                                       time.Time
+	ValidUntil                                               time.Time
+}
+
+func (p Publication) currentAt(at time.Time) bool {
+	return p.ProductID != "" && p.OperatorTenantID != "" && p.ServingPlanID != "" && p.SupplyPlanID != "" && p.CompatibilityKey != "" &&
+		p.EvidenceID != "" && at.Before(p.EvidenceValidUntil) && at.Before(p.ValidUntil)
+}
+
+// Candidate is operator-private. Endpoint and credential are deliberately
+// hidden from JSON so customer projections cannot leak supply details.
+type Candidate struct {
+	ID, ProductID, OperatorTenantID, ServingPlanID, SupplyPlanID string
+	OfferID, QualificationEvidenceID, CompatibilityKey           string
+	OfferVersion                                                 int64
+	Protocol, Supplier, SupplierModelID                          string
+	Operations                                                   []string
+	Endpoint, Credential                                         string `json:"-"`
+	Qualified, Available                                         bool
+	ValidUntil                                                   time.Time
+}
+
+func (c Candidate) supports(operation string) bool {
+	for _, supported := range c.Operations {
+		if supported == operation {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Candidate) validFor(p Publication, at time.Time) bool {
+	if c.ID == "" || c.ProductID != p.ProductID || c.OperatorTenantID != p.OperatorTenantID ||
+		c.ServingPlanID != p.ServingPlanID || c.SupplyPlanID != p.SupplyPlanID || c.OfferID == "" || c.OfferVersion <= 0 ||
+		c.QualificationEvidenceID == "" || c.CompatibilityKey == "" || c.Protocol != "openai" ||
+		c.Supplier == "" || c.SupplierModelID == "" || !c.Qualified || !c.Available || !at.Before(c.ValidUntil) {
+		return false
+	}
+	parsed, err := url.Parse(c.Endpoint)
+	return err == nil && parsed.Scheme == "https" && parsed.Host != ""
+}
+
+// PublishedRoute is built by the control plane from durable catalog, supply,
+// publication, rate, and entitlement records.
+type PublishedRoute struct {
+	Entitlement Entitlement
+	Publication Publication
+	Rate        RetailRate
+	Candidates  []Candidate
+}
+
+// RouteSource is the durable, secret-free control-plane projection compiled by
+// Store. Credential references cross into plaintext only inside Publisher.
+type RouteSource struct {
+	Entitlement Entitlement
+	Publication Publication
+	Rate        RetailRate
+	Candidates  []CandidateSource
+}
+
+type CandidateSource struct {
+	Candidate           Candidate
+	Adapter             string `json:"-"`
+	CredentialReference string `json:"-"`
+}
+
+// Lease pins an immutable route generation and retail contract for one
+// request. Later publications cannot change its settlement price.
+type Lease struct {
+	Entitlement Entitlement
+	Publication Publication
+	Rate        RetailRate
+	Candidates  []Candidate
+}
+
+type snapshot struct{ routes map[string]PublishedRoute }
+
+// Directory publishes complete immutable generations with atomic pointer
+// replacement. Reads are lock-free and cannot observe a partially compiled
+// product route.
+type Directory struct {
+	state atomic.Pointer[snapshot]
+	now   func() time.Time
+}
+
+func NewDirectory() *Directory {
+	d := &Directory{now: time.Now}
+	d.state.Store(&snapshot{routes: map[string]PublishedRoute{}})
+	return d
+}
+
+func key(tenant, product string) string { return tenant + "\x00" + product }
+
+// Publish replaces the full hosted routing generation. Invalid entries fail
+// the publication; the previous known-good generation remains active.
+func (d *Directory) Publish(routes []PublishedRoute) error {
+	next := make(map[string]PublishedRoute, len(routes))
+	for index, route := range routes {
+		if err := validatePublishedRoute(route); err != nil {
+			return fmt.Errorf("route %d: %w", index, err)
+		}
+		entryKey := key(route.Entitlement.CustomerTenantID, route.Entitlement.ProductID)
+		if _, exists := next[entryKey]; exists {
+			return fmt.Errorf("route %d duplicates customer product", index)
+		}
+		next[entryKey] = cloneRoute(route)
+	}
+	d.state.Store(&snapshot{routes: next})
+	return nil
+}
+
+func validatePublishedRoute(route PublishedRoute) error {
+	e, p, rate := route.Entitlement, route.Publication, route.Rate
+	if e.ProductID != p.ProductID || e.ProductID != rate.ProductID || e.OperatorTenantID != p.OperatorTenantID ||
+		e.ServingPlanID != p.ServingPlanID || e.RetailRateID != rate.ID || e.RetailRateVersion != rate.Version {
+		return errors.New("entitlement, publication, and immutable retail rate do not match")
+	}
+	if len(route.Candidates) == 0 {
+		return errors.New("route requires at least one candidate")
+	}
+	seen := make(map[string]struct{}, len(route.Candidates))
+	for _, candidate := range route.Candidates {
+		if _, duplicate := seen[candidate.ID]; duplicate {
+			return errors.New("candidate identity is duplicated")
+		}
+		seen[candidate.ID] = struct{}{}
+	}
+	return nil
+}
+
+// Acquire performs all time-dependent checks at request admission. Expired
+// publication, price, entitlement, or evidence fails closed.
+func (d *Directory) Acquire(customerTenant, productID string) (Lease, error) {
+	if customerTenant == "" || productID == "" {
+		return Lease{}, ErrUnauthorized
+	}
+	entry, exists := d.state.Load().routes[key(customerTenant, productID)]
+	if !exists {
+		return Lease{}, ErrUnauthorized
+	}
+	at := d.now().UTC()
+	if !entry.Entitlement.activeAt(at) {
+		return Lease{}, ErrUnauthorized
+	}
+	if !entry.Publication.currentAt(at) || !entry.Rate.currentAt(at) {
+		return Lease{}, ErrRouteUnavailable
+	}
+	valid := make([]Candidate, 0, len(entry.Candidates))
+	for _, candidate := range entry.Candidates {
+		if !candidate.validFor(entry.Publication, at) {
+			continue
+		}
+		if candidate.CompatibilityKey == entry.Publication.CompatibilityKey {
+			valid = append(valid, candidate)
+		}
+	}
+	if len(valid) == 0 {
+		return Lease{}, ErrRouteUnavailable
+	}
+	return Lease{Entitlement: entry.Entitlement, Publication: entry.Publication, Rate: cloneRate(entry.Rate), Candidates: append([]Candidate(nil), valid...)}, nil
+}
+
+// ListForTenant returns product IDs only; it never returns private candidate
+// or operator route details.
+func (d *Directory) ListForTenant(tenant string) []string {
+	at := d.now().UTC()
+	state := d.state.Load()
+	products := make([]string, 0)
+	for _, route := range state.routes {
+		if route.Entitlement.CustomerTenantID == tenant && route.Entitlement.activeAt(at) && route.Publication.currentAt(at) && route.Rate.currentAt(at) {
+			products = append(products, route.Entitlement.ProductID)
+		}
+	}
+	sort.Strings(products)
+	return products
+}
+
+func cloneRoute(route PublishedRoute) PublishedRoute {
+	copy := route
+	copy.Rate = cloneRate(route.Rate)
+	copy.Candidates = append([]Candidate(nil), route.Candidates...)
+	for index := range copy.Candidates {
+		copy.Candidates[index].Operations = append([]string(nil), route.Candidates[index].Operations...)
+	}
+	return copy
+}
+
+func cloneRate(rate RetailRate) RetailRate {
+	copy := rate
+	if rate.CachedInputMicrousdPerMillion != nil {
+		value := *rate.CachedInputMicrousdPerMillion
+		copy.CachedInputMicrousdPerMillion = &value
+	}
+	return copy
+}

--- a/internal/modelapirouting/directory_test.go
+++ b/internal/modelapirouting/directory_test.go
@@ -1,0 +1,111 @@
+package modelapirouting
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHostedCandidateNeverSerializesCredentialOrEndpoint(t *testing.T) {
+	body, err := json.Marshal(CandidateSource{
+		Candidate:           Candidate{ID: "candidate", Endpoint: "https://private.example", Credential: "supplier-secret"},
+		Adapter:             "private-adapter",
+		CredentialReference: "private-reference",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "private.example") || strings.Contains(string(body), "supplier-secret") || strings.Contains(string(body), "private-adapter") || strings.Contains(string(body), "private-reference") {
+		t.Fatalf("private supply leaked through JSON: %s", body)
+	}
+}
+
+func routeFixture(now time.Time, tenant string) PublishedRoute {
+	until := now.Add(time.Hour)
+	return PublishedRoute{
+		Entitlement: Entitlement{
+			ID: "entitlement", CustomerTenantID: tenant, ProductID: "glm-5.3", OperatorTenantID: "operator",
+			ServingPlanID: "serving-plan", RetailRateID: "rate", RetailRateVersion: 1, State: "active",
+			MaxRequestMicrousd: 10_000, ValidFrom: now.Add(-time.Hour), ValidUntil: &until,
+		},
+		Publication: Publication{
+			ProductID: "glm-5.3", OperatorTenantID: "operator", ServingPlanID: "serving-plan", SupplyPlanID: "supply-plan",
+			CompatibilityKey: "glm-5.3/revision/openai", EvidenceID: "evidence", EvidenceValidUntil: until, ValidUntil: until,
+		},
+		Rate: RetailRate{
+			ID: "rate", ProductID: "glm-5.3", Version: 1, ContractDigest: "sha256:rate-one",
+			InputMicrousdPerMillion: 1_400_000, OutputMicrousdPerMillion: 4_400_000,
+			ValidFrom: now.Add(-time.Hour), ValidUntil: until,
+		},
+		Candidates: []Candidate{{
+			ID: "primary", ProductID: "glm-5.3", OperatorTenantID: "operator", ServingPlanID: "serving-plan", SupplyPlanID: "supply-plan",
+			OfferID: "offer", OfferVersion: 1, QualificationEvidenceID: "evidence", CompatibilityKey: "glm-5.3/revision/openai",
+			Protocol: "openai", Operations: []string{"chat"}, Supplier: "supplier", SupplierModelID: "supplier/glm",
+			Endpoint: "https://supplier.example/v1", Credential: "secret", Qualified: true, Available: true, ValidUntil: until,
+		}},
+	}
+}
+
+func TestDirectoryIsolatesTenantAndFailsClosedOnExpiry(t *testing.T) {
+	now := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
+	directory := NewDirectory()
+	directory.now = func() time.Time { return now }
+	if err := directory.Publish([]PublishedRoute{routeFixture(now, "customer-a")}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := directory.Acquire("customer-b", "glm-5.3"); !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("cross-tenant acquire error = %v", err)
+	}
+	if _, err := directory.Acquire("customer-a", "glm-5.3"); err != nil {
+		t.Fatalf("current route unavailable: %v", err)
+	}
+	directory.now = func() time.Time { return now.Add(2 * time.Hour) }
+	if _, err := directory.Acquire("customer-a", "glm-5.3"); !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("expired entitlement error = %v", err)
+	}
+}
+
+func TestDirectoryRejectsServingPlanMismatchWithoutReplacingGeneration(t *testing.T) {
+	now := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
+	directory := NewDirectory()
+	directory.now = func() time.Time { return now }
+	good := routeFixture(now, "customer")
+	if err := directory.Publish([]PublishedRoute{good}); err != nil {
+		t.Fatal(err)
+	}
+	bad := routeFixture(now, "customer")
+	bad.Publication.ServingPlanID = "other-plan"
+	if err := directory.Publish([]PublishedRoute{bad}); err == nil {
+		t.Fatal("mismatched serving plan was published")
+	}
+	lease, err := directory.Acquire("customer", "glm-5.3")
+	if err != nil || lease.Publication.ServingPlanID != "serving-plan" {
+		t.Fatalf("known-good generation was lost: lease=%#v err=%v", lease, err)
+	}
+}
+
+func TestDirectoryAllowsOnlyExactQualifiedFallbacks(t *testing.T) {
+	now := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
+	directory := NewDirectory()
+	directory.now = func() time.Time { return now }
+	route := routeFixture(now, "customer")
+	exact := route.Candidates[0]
+	exact.ID, exact.OfferID = "exact-fallback", "offer-two"
+	unsafe := exact
+	unsafe.ID, unsafe.OfferID, unsafe.CompatibilityKey = "unsafe-fallback", "offer-three", "other-revision"
+	unqualified := exact
+	unqualified.ID, unqualified.OfferID, unqualified.Qualified = "unqualified", "offer-four", false
+	route.Candidates = append(route.Candidates, exact, unsafe, unqualified)
+	if err := directory.Publish([]PublishedRoute{route}); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := directory.Acquire("customer", "glm-5.3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lease.Candidates) != 2 || lease.Candidates[0].ID != "primary" || lease.Candidates[1].ID != "exact-fallback" {
+		t.Fatalf("safe candidates = %#v", lease.Candidates)
+	}
+}

--- a/internal/modelapirouting/publisher.go
+++ b/internal/modelapirouting/publisher.go
@@ -1,0 +1,163 @@
+package modelapirouting
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/domain"
+)
+
+// RouteSourceStore returns one fully validated, secret-free generation. A
+// malformed durable generation is an error, never a partially usable result.
+type RouteSourceStore interface {
+	PublishedModelAPIRoutes(context.Context, time.Time) ([]RouteSource, error)
+}
+
+// TargetResolver is the narrow trusted boundary that maps an operator-owned
+// adapter and secret reference to a callable target. Store never sees secret
+// values and Directory never sees secret references.
+type TargetResolver interface {
+	ResolveHostedModelTarget(ctx context.Context, operatorTenantID, supplier, adapter, credentialReference string) (ResolvedTarget, error)
+}
+
+type ResolvedTarget struct {
+	Endpoint   string
+	Credential string
+}
+
+type SecretReferenceStore interface {
+	SecretReferenceForTenant(context.Context, string, string) (domain.SecretReference, error)
+}
+
+type SecretValueResolver interface {
+	Resolve(context.Context, domain.SecretReference) (string, error)
+}
+
+// RegistryTargetResolver is the production trusted-boundary implementation.
+// Adapter base URLs come from operator configuration; a database row cannot
+// inject an arbitrary upstream URL. Secret IDs are resolved tenant-scoped.
+type RegistryTargetResolver struct {
+	endpoints  map[string]string
+	references SecretReferenceStore
+	secrets    SecretValueResolver
+}
+
+func NewRegistryTargetResolver(endpoints map[string]string, references SecretReferenceStore, secrets SecretValueResolver) (*RegistryTargetResolver, error) {
+	if references == nil || secrets == nil || len(endpoints) == 0 {
+		return nil, errors.New("hosted target resolver requires endpoints, reference store, and secret resolver")
+	}
+	validated := make(map[string]string, len(endpoints))
+	for supplierAdapter, endpoint := range endpoints {
+		supplierAdapter = strings.TrimSpace(supplierAdapter)
+		parsed, err := url.Parse(strings.TrimSpace(endpoint))
+		if supplierAdapter == "" || !strings.Contains(supplierAdapter, "/") || err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+			return nil, errors.New("hosted adapter endpoints must be named absolute HTTPS URLs without query or fragment")
+		}
+		validated[supplierAdapter] = strings.TrimRight(parsed.String(), "/")
+	}
+	return &RegistryTargetResolver{endpoints: validated, references: references, secrets: secrets}, nil
+}
+
+func (r *RegistryTargetResolver) ResolveHostedModelTarget(ctx context.Context, operatorTenantID, supplier, adapter, credentialReference string) (ResolvedTarget, error) {
+	if r == nil || operatorTenantID == "" || supplier == "" || adapter == "" || credentialReference == "" {
+		return ResolvedTarget{}, errors.New("operator, supplier, adapter, and credential reference are required")
+	}
+	endpoint, exists := r.endpoints[supplier+"/"+adapter]
+	if !exists {
+		return ResolvedTarget{}, errors.New("hosted supplier adapter is not configured")
+	}
+	reference, err := r.references.SecretReferenceForTenant(ctx, operatorTenantID, credentialReference)
+	if err != nil {
+		return ResolvedTarget{}, err
+	}
+	credential, err := r.secrets.Resolve(ctx, reference)
+	if err != nil {
+		return ResolvedTarget{}, err
+	}
+	if strings.TrimSpace(credential) == "" {
+		return ResolvedTarget{}, errors.New("hosted supplier credential resolved empty")
+	}
+	return ResolvedTarget{Endpoint: endpoint, Credential: credential}, nil
+}
+
+// Publisher periodically compiles a complete generation and swaps it into the
+// request-path Directory atomically. Any source, secret, or validation failure
+// retains the previous known-good snapshot.
+type Publisher struct {
+	Store     RouteSourceStore
+	Resolver  TargetResolver
+	Directory *Directory
+	Interval  time.Duration
+	Logger    *slog.Logger
+	Now       func() time.Time
+}
+
+func (p *Publisher) PublishOnce(ctx context.Context) error {
+	if p == nil || p.Store == nil || p.Resolver == nil || p.Directory == nil {
+		return errors.New("hosted route publisher requires store, target resolver, and directory")
+	}
+	now := time.Now
+	if p.Now != nil {
+		now = p.Now
+	}
+	at := now().UTC()
+	sources, err := p.Store.PublishedModelAPIRoutes(ctx, at)
+	if err != nil {
+		return err
+	}
+	routes := make([]PublishedRoute, 0, len(sources))
+	for _, source := range sources {
+		if !source.Entitlement.activeAt(at) || !source.Publication.currentAt(at) || !source.Rate.currentAt(at) {
+			return errors.New("hosted route source is expired or inactive")
+		}
+		route := PublishedRoute{Entitlement: source.Entitlement, Publication: source.Publication, Rate: source.Rate}
+		for _, candidateSource := range source.Candidates {
+			if strings.TrimSpace(candidateSource.Adapter) == "" || strings.TrimSpace(candidateSource.CredentialReference) == "" {
+				return errors.New("published hosted candidate lacks adapter or credential reference")
+			}
+			target, resolveErr := p.Resolver.ResolveHostedModelTarget(ctx, source.Publication.OperatorTenantID, candidateSource.Candidate.Supplier, candidateSource.Adapter, candidateSource.CredentialReference)
+			if resolveErr != nil {
+				return resolveErr
+			}
+			candidate := candidateSource.Candidate
+			candidate.Endpoint, candidate.Credential = target.Endpoint, target.Credential
+			if strings.TrimSpace(candidate.Credential) == "" {
+				return errors.New("resolved hosted candidate credential is empty")
+			}
+			if !candidate.validFor(source.Publication, at) || candidate.CompatibilityKey != source.Publication.CompatibilityKey {
+				return errors.New("resolved hosted candidate is expired or incompatible")
+			}
+			route.Candidates = append(route.Candidates, candidate)
+		}
+		routes = append(routes, route)
+	}
+	return p.Directory.Publish(routes)
+}
+
+func (p *Publisher) Run(ctx context.Context) {
+	interval := p.Interval
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+	p.publishAndLog(ctx)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.publishAndLog(ctx)
+		}
+	}
+}
+
+func (p *Publisher) publishAndLog(ctx context.Context) {
+	if err := p.PublishOnce(ctx); err != nil && p.Logger != nil {
+		p.Logger.Error("retain previous hosted model API route generation", "error", err)
+	}
+}

--- a/internal/modelapirouting/publisher_test.go
+++ b/internal/modelapirouting/publisher_test.go
@@ -1,0 +1,142 @@
+package modelapirouting
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/domain"
+)
+
+type sourceStoreFake struct {
+	sources []RouteSource
+	err     error
+}
+
+type referenceStoreFake struct{ tenant, id string }
+
+func (s *referenceStoreFake) SecretReferenceForTenant(_ context.Context, tenant, id string) (domain.SecretReference, error) {
+	s.tenant, s.id = tenant, id
+	return domain.SecretReference{ID: id, TenantID: tenant, Resolver: "env", Reference: "SUPPLIER_KEY"}, nil
+}
+
+type secretValueFake struct{}
+
+func (secretValueFake) Resolve(context.Context, domain.SecretReference) (string, error) {
+	return "secret", nil
+}
+
+func (s *sourceStoreFake) PublishedModelAPIRoutes(context.Context, time.Time) ([]RouteSource, error) {
+	return s.sources, s.err
+}
+
+type targetResolverFake struct {
+	target ResolvedTarget
+	err    error
+	seen   []string
+}
+
+func (r *targetResolverFake) ResolveHostedModelTarget(_ context.Context, operator, supplier, adapter, reference string) (ResolvedTarget, error) {
+	r.seen = append(r.seen, operator+"/"+supplier+"/"+adapter+"/"+reference)
+	return r.target, r.err
+}
+
+func sourceFixture(now time.Time, tenant string) RouteSource {
+	route := routeFixture(now, tenant)
+	candidate := route.Candidates[0]
+	candidate.Endpoint, candidate.Credential = "", ""
+	return RouteSource{
+		Entitlement: route.Entitlement,
+		Publication: route.Publication,
+		Rate:        route.Rate,
+		Candidates:  []CandidateSource{{Candidate: candidate, Adapter: "openai", CredentialReference: "vault://hosted/glm"}},
+	}
+}
+
+func TestPublisherResolvesSecretsOnlyAtTrustedBoundaryAndPublishesAtomically(t *testing.T) {
+	now := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
+	directory := NewDirectory()
+	directory.now = func() time.Time { return now }
+	store := &sourceStoreFake{sources: []RouteSource{sourceFixture(now, "customer")}}
+	resolver := &targetResolverFake{target: ResolvedTarget{Endpoint: "https://supplier.example/v1", Credential: "resolved-secret"}}
+	publisher := &Publisher{Store: store, Resolver: resolver, Directory: directory, Now: func() time.Time { return now }}
+	if err := publisher.PublishOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := directory.Acquire("customer", "glm-5.3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resolver.seen) != 1 || resolver.seen[0] != "operator/supplier/openai/vault://hosted/glm" || lease.Candidates[0].Credential != "resolved-secret" {
+		t.Fatalf("resolver=%#v lease=%#v", resolver.seen, lease)
+	}
+}
+
+func TestRegistryTargetResolverUsesConfiguredHTTPSAndTenantScopedSecretID(t *testing.T) {
+	references := &referenceStoreFake{}
+	resolver, err := NewRegistryTargetResolver(map[string]string{"supplier/openrouter": "https://openrouter.example/v1/"}, references, secretValueFake{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := resolver.ResolveHostedModelTarget(context.Background(), "operator", "supplier", "openrouter", "secret-id")
+	if err != nil || target.Endpoint != "https://openrouter.example/v1" || target.Credential != "secret" || references.tenant != "operator" || references.id != "secret-id" {
+		t.Fatalf("target=%#v reference=%s/%s err=%v", target, references.tenant, references.id, err)
+	}
+	if _, err = NewRegistryTargetResolver(map[string]string{"supplier/bad": "http://plain.example/v1"}, references, secretValueFake{}); err == nil {
+		t.Fatal("plaintext hosted endpoint was accepted")
+	}
+	if _, err = NewRegistryTargetResolver(map[string]string{"supplier/bad": ":// malformed"}, references, secretValueFake{}); err == nil {
+		t.Fatal("malformed hosted endpoint was accepted")
+	}
+	if _, err = resolver.ResolveHostedModelTarget(context.Background(), "operator", "other-supplier", "openrouter", "secret-id"); err == nil {
+		t.Fatal("supplier/adapter endpoint mismatch was accepted")
+	}
+}
+
+func TestPublisherRetainsPreviousGenerationOnSourceOrSecretFailure(t *testing.T) {
+	now := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
+	directory := NewDirectory()
+	directory.now = func() time.Time { return now }
+	store := &sourceStoreFake{sources: []RouteSource{sourceFixture(now, "customer")}}
+	resolver := &targetResolverFake{target: ResolvedTarget{Endpoint: "https://supplier.example/v1", Credential: "first-secret"}}
+	publisher := &Publisher{Store: store, Resolver: resolver, Directory: directory, Now: func() time.Time { return now }}
+	if err := publisher.PublishOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	store.err = errors.New("invalid durable generation")
+	if err := publisher.PublishOnce(context.Background()); err == nil {
+		t.Fatal("invalid source generation was accepted")
+	}
+	lease, err := directory.Acquire("customer", "glm-5.3")
+	if err != nil || lease.Candidates[0].Credential != "first-secret" {
+		t.Fatalf("known-good route lost after source failure: lease=%#v err=%v", lease, err)
+	}
+	store.err = nil
+	resolver.err = errors.New("secret unavailable")
+	if err := publisher.PublishOnce(context.Background()); err == nil {
+		t.Fatal("unresolved secret generation was accepted")
+	}
+	lease, err = directory.Acquire("customer", "glm-5.3")
+	if err != nil || lease.Candidates[0].Credential != "first-secret" {
+		t.Fatalf("known-good route lost after resolver failure: lease=%#v err=%v", lease, err)
+	}
+	resolver.err = nil
+	resolver.target.Endpoint = "http://plaintext.example/v1"
+	if err := publisher.PublishOnce(context.Background()); err == nil {
+		t.Fatal("non-HTTPS resolved endpoint was accepted")
+	}
+	lease, err = directory.Acquire("customer", "glm-5.3")
+	if err != nil || lease.Candidates[0].Endpoint != "https://supplier.example/v1" {
+		t.Fatalf("known-good route lost after endpoint validation failure: lease=%#v err=%v", lease, err)
+	}
+	resolver.target.Endpoint = "https://supplier.example/v1"
+	store.sources = []RouteSource{sourceFixture(now.Add(-2*time.Hour), "customer")}
+	if err := publisher.PublishOnce(context.Background()); err == nil {
+		t.Fatal("expired generation was accepted")
+	}
+	lease, err = directory.Acquire("customer", "glm-5.3")
+	if err != nil || lease.Candidates[0].Credential != "first-secret" {
+		t.Fatalf("known-good route lost after expiry failure: lease=%#v err=%v", lease, err)
+	}
+}

--- a/internal/modelapirouting/runtime.go
+++ b/internal/modelapirouting/runtime.go
@@ -1,0 +1,490 @@
+package modelapirouting
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/openaicompat"
+)
+
+type ProxyRequest struct {
+	TenantID, ProductID, Operation, Resource, RequestID, TraceParent string
+	Payload                                                          map[string]any
+}
+
+// Runtime is the supplier-neutral hosted request boundary. It receives a
+// tenant already authenticated by Gateway, resolves an in-memory product
+// lease, reserves prepaid balance, then makes at most one supplier attempt.
+type Runtime struct {
+	Routes  *Directory
+	Billing Billing
+	Client  *http.Client
+	Logger  *slog.Logger
+	now     func() time.Time
+}
+
+func (rt *Runtime) ServeHTTP(w http.ResponseWriter, r *http.Request, request ProxyRequest) {
+	if rt == nil || rt.Routes == nil || rt.Billing == nil {
+		writeError(w, http.StatusServiceUnavailable, "Hosted Model API routing is unavailable", "server_error")
+		return
+	}
+	lease, err := rt.Routes.Acquire(request.TenantID, request.ProductID)
+	if err != nil {
+		status, errorType, message := http.StatusNotFound, "invalid_request_error", "Unknown or unavailable model: "+request.ProductID
+		if errors.Is(err, ErrUnauthorized) {
+			status, errorType, message = http.StatusForbidden, "permission_error", "API key is not entitled to this model"
+		}
+		writeError(w, status, message, errorType)
+		return
+	}
+	var candidate *Candidate
+	for index := range lease.Candidates {
+		if lease.Candidates[index].supports(request.Operation) {
+			candidate = &lease.Candidates[index]
+			break
+		}
+	}
+	if candidate == nil {
+		writeError(w, http.StatusUnprocessableEntity, "Model does not support this API operation", "unsupported_protocol")
+		return
+	}
+
+	now := time.Now
+	if rt.now != nil {
+		now = rt.now
+	}
+	reservationRequest := ReservationRequest{
+		ID: randomReservationID(), TenantID: request.TenantID, ProductID: request.ProductID,
+		EntitlementID: lease.Entitlement.ID, OperatorTenantID: lease.Entitlement.OperatorTenantID,
+		ServingPlanID: lease.Entitlement.ServingPlanID, SupplyPlanID: lease.Publication.SupplyPlanID,
+		RetailRate: lease.Rate, MaxRequestMicrousd: lease.Entitlement.MaxRequestMicrousd,
+		CandidateID: candidate.ID, OfferID: candidate.OfferID, OfferVersion: candidate.OfferVersion, Supplier: candidate.Supplier,
+		SupplierModelID: candidate.SupplierModelID, CreatedAt: now().UTC(),
+	}
+	reservation, err := rt.Billing.Reserve(r.Context(), reservationRequest)
+	if err != nil {
+		if errors.Is(err, ErrInsufficientPrepaidBalance) {
+			writeError(w, http.StatusPaymentRequired, "Prepaid Model API balance is insufficient", "billing_error")
+			return
+		}
+		if rt.Logger != nil {
+			rt.Logger.Error("reserve hosted Model API usage", "request_id", request.RequestID, "error", err)
+		}
+		writeError(w, http.StatusServiceUnavailable, "Usage authorization is temporarily unavailable", "billing_error")
+		return
+	}
+
+	payload := make(map[string]any, len(request.Payload))
+	for key, value := range request.Payload {
+		payload[key] = value
+	}
+	payload["model"] = candidate.SupplierModelID
+	forceStreamUsage(payload)
+	body, err := json.Marshal(payload)
+	if err != nil {
+		_ = rt.Billing.ReleaseUnsent(context.WithoutCancel(r.Context()), request.TenantID, reservation.ID, "request encoding failed before supplier transmission")
+		writeError(w, http.StatusBadRequest, "Invalid JSON body", "invalid_request_error")
+		return
+	}
+	target, err := openaicompat.Endpoint(candidate.Endpoint, request.Resource)
+	if err != nil {
+		_ = rt.Billing.ReleaseUnsent(context.WithoutCancel(r.Context()), request.TenantID, reservation.ID, "qualified endpoint became invalid before supplier transmission")
+		writeError(w, http.StatusServiceUnavailable, "Inference upstream is unavailable", "server_error")
+		return
+	}
+	upstream, err := http.NewRequestWithContext(r.Context(), http.MethodPost, target, bytes.NewReader(body))
+	if err != nil {
+		_ = rt.Billing.ReleaseUnsent(context.WithoutCancel(r.Context()), request.TenantID, reservation.ID, "request construction failed before supplier transmission")
+		writeError(w, http.StatusServiceUnavailable, "Inference upstream is unavailable", "server_error")
+		return
+	}
+	copyRequestHeaders(upstream.Header, r.Header)
+	upstream.Header.Set("Accept-Encoding", "identity")
+	upstream.Header.Set("Authorization", "Bearer "+candidate.Credential)
+	upstream.Header.Set("Content-Type", "application/json")
+	upstream.Header.Set("X-Request-ID", request.RequestID)
+	upstream.Header.Set("traceparent", request.TraceParent)
+	upstream.Header.Set("X-InferCrane-Attempt", "1")
+
+	// Mark first, then transmit. Any error after this point is ambiguous and
+	// must retain the reservation for reconciliation; it is never retried.
+	transmittedAt := now().UTC()
+	if err = rt.Billing.MarkTransmitted(r.Context(), request.TenantID, reservation.ID, transmittedAt); err != nil {
+		_ = rt.Billing.ReleaseUnsent(context.WithoutCancel(r.Context()), request.TenantID, reservation.ID, "billing transmission fence failed")
+		writeError(w, http.StatusServiceUnavailable, "Usage authorization could not be fenced", "billing_error")
+		return
+	}
+	client := rt.Client
+	if client == nil {
+		client = &http.Client{Transport: &http.Transport{MaxIdleConns: 512, MaxIdleConnsPerHost: 128, IdleConnTimeout: 90 * time.Second, ResponseHeaderTimeout: 5 * time.Minute}}
+	}
+	response, err := client.Do(upstream)
+	if err != nil {
+		settlementContext, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 5*time.Second)
+		_, _ = rt.Billing.Settle(settlementContext, request.TenantID, reservation.ID, Usage{})
+		cancel()
+		if rt.Logger != nil {
+			rt.Logger.Error("hosted model API supplier result is ambiguous", "request_id", request.RequestID, "reservation_id", reservation.ID, "error", err)
+		}
+		writeError(w, http.StatusServiceUnavailable, "Inference upstream is unavailable", "server_error")
+		return
+	}
+	defer response.Body.Close()
+	responseStartedAt := now().UTC()
+	if err = rt.Billing.MarkResponseStarted(context.WithoutCancel(r.Context()), request.TenantID, reservation.ID, responseStartedAt); err != nil && rt.Logger != nil {
+		rt.Logger.Error("mark hosted response start", "request_id", request.RequestID, "reservation_id", reservation.ID, "error", err)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
+		settlementContext, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 5*time.Second)
+		_, settleErr := rt.Billing.Settle(settlementContext, request.TenantID, reservation.ID, Usage{StatusCode: response.StatusCode})
+		cancel()
+		if settleErr != nil && rt.Logger != nil {
+			rt.Logger.Error("retain failed hosted supplier request for reconciliation", "request_id", request.RequestID, "reservation_id", reservation.ID, "error", settleErr)
+		}
+		writeError(w, response.StatusCode, "Inference supplier could not serve the request", "upstream_error")
+		return
+	}
+	copyResponseHeaders(w.Header(), response.Header)
+	w.Header().Set("X-Request-ID", request.RequestID)
+	w.Header().Set("traceparent", request.TraceParent)
+	w.WriteHeader(response.StatusCode)
+	input, output, copyErr := copyPublicResponse(w, response, request.ProductID)
+	settlementContext, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 5*time.Second)
+	_, settleErr := rt.Billing.Settle(settlementContext, request.TenantID, reservation.ID, Usage{StatusCode: response.StatusCode, InputTokens: input, OutputTokens: output})
+	cancel()
+	if (copyErr != nil || settleErr != nil) && rt.Logger != nil {
+		rt.Logger.Error("hosted model API response incomplete", "request_id", request.RequestID, "reservation_id", reservation.ID, "copy_error", copyErr, "settle_error", settleErr)
+	}
+	// An upstream response or partial body is terminal. Never fail over after
+	// response start, even when the supplier status is retryable.
+}
+
+func forceStreamUsage(payload map[string]any) {
+	stream, _ := payload["stream"].(bool)
+	if !stream {
+		return
+	}
+	options := map[string]any{}
+	if supplied, ok := payload["stream_options"].(map[string]any); ok {
+		for key, value := range supplied {
+			options[key] = value
+		}
+	}
+	options["include_usage"] = true
+	payload["stream_options"] = options
+}
+
+func randomReservationID() string {
+	value := make([]byte, 16)
+	if _, err := rand.Read(value); err != nil {
+		return "model_usage_" + strconv.FormatInt(time.Now().UnixNano(), 16)
+	}
+	return "model_usage_" + hex.EncodeToString(value)
+}
+
+var requestHeaderAllowlist = []string{"Accept", "OpenAI-Beta"}
+
+var responseHeaderAllowlist = []string{"Cache-Control"}
+
+func copyRequestHeaders(destination, source http.Header) {
+	copyAllowedHeaders(destination, source, requestHeaderAllowlist)
+}
+
+func copyResponseHeaders(destination, source http.Header) {
+	copyAllowedHeaders(destination, source, responseHeaderAllowlist)
+	// Supplier and proxy fingerprints (Server, Via, X-*), cookies, redirects,
+	// and transport-specific headers are deliberately private. Content-Type is
+	// normalized because the public response body is parsed and rewritten here.
+	if isEventStream(source.Get("Content-Type")) {
+		destination.Set("Content-Type", "text/event-stream; charset=utf-8")
+	} else {
+		destination.Set("Content-Type", "application/json")
+	}
+}
+
+func copyAllowedHeaders(destination, source http.Header, allowlist []string) {
+	const maxForwardedHeaderBytes = 8 << 10
+	forwarded := 0
+	for _, name := range allowlist {
+		for _, value := range source.Values(name) {
+			value = strings.TrimSpace(value)
+			if value == "" || !safeHeaderValue(value) || forwarded+len(name)+len(value) > maxForwardedHeaderBytes {
+				continue
+			}
+			destination.Add(name, value)
+			forwarded += len(name) + len(value)
+		}
+	}
+}
+
+func safeHeaderValue(value string) bool {
+	for _, character := range value {
+		if (character < 0x20 && character != '\t') || character == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
+func isEventStream(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	return err == nil && strings.EqualFold(mediaType, "text/event-stream")
+}
+
+type usageObserver struct {
+	input, output *int
+}
+
+type tokenUsage struct {
+	PromptTokens     *int `json:"prompt_tokens"`
+	CompletionTokens *int `json:"completion_tokens"`
+	InputTokens      *int `json:"input_tokens"`
+	OutputTokens     *int `json:"output_tokens"`
+}
+
+func (o *usageObserver) observeJSON(body []byte) {
+	var raw struct {
+		Usage    *tokenUsage `json:"usage"`
+		Response *struct {
+			Usage *tokenUsage `json:"usage"`
+		} `json:"response"`
+	}
+	if json.Unmarshal(body, &raw) != nil {
+		return
+	}
+	usage := raw.Usage
+	if usage == nil && raw.Response != nil {
+		usage = raw.Response.Usage
+	}
+	if usage == nil {
+		return
+	}
+	input, output := usage.InputTokens, usage.OutputTokens
+	if input == nil {
+		input = usage.PromptTokens
+	}
+	if output == nil {
+		output = usage.CompletionTokens
+	}
+	if input != nil {
+		value := *input
+		o.input = &value
+	}
+	if output != nil {
+		value := *output
+		o.output = &value
+	}
+}
+
+func (o usageObserver) usage() (*int, *int) { return o.input, o.output }
+
+const (
+	maxSSELineBytes  = 256 << 10
+	maxSSEEventBytes = 2 << 20
+	maxBufferedBytes = 32 << 20
+)
+
+func copyPublicResponse(w http.ResponseWriter, response *http.Response, publicModelID string) (*int, *int, error) {
+	observer := &usageObserver{}
+	if isEventStream(response.Header.Get("Content-Type")) {
+		return copyPublicSSE(w, response.Body, publicModelID, observer)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxBufferedBytes+1))
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(body) > maxBufferedBytes {
+		return nil, nil, errors.New("supplier response exceeds the 32 MiB limit")
+	}
+	observer.observeJSON(body)
+	body, err = rewriteJSONModel(body, publicModelID)
+	if err != nil {
+		input, output := observer.usage()
+		return input, output, fmt.Errorf("malformed supplier JSON response: %w", err)
+	}
+	_, err = w.Write(body)
+	input, output := observer.usage()
+	return input, output, err
+}
+
+func copyPublicSSE(w http.ResponseWriter, body io.Reader, publicModelID string, observer *usageObserver) (*int, *int, error) {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 64<<10), maxSSELineBytes+1)
+	scanner.Split(splitSSELines)
+	controller := http.NewResponseController(w)
+	var event [][]byte
+	eventBytes := 0
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) > maxSSELineBytes {
+			input, output := observer.usage()
+			return input, output, errors.New("supplier SSE line exceeds limit")
+		}
+		if len(line) != 0 {
+			if bytes.IndexByte(line, 0) >= 0 {
+				input, output := observer.usage()
+				return input, output, errors.New("supplier SSE line contains NUL")
+			}
+			eventBytes += len(line) + 1
+			if eventBytes > maxSSEEventBytes {
+				input, output := observer.usage()
+				return input, output, errors.New("supplier SSE event exceeds limit")
+			}
+			event = append(event, bytes.Clone(line))
+			continue
+		}
+		if len(event) == 0 {
+			continue
+		}
+		rewritten, terminal, data, err := rewriteSSEEvent(event, publicModelID)
+		if err != nil {
+			input, output := observer.usage()
+			return input, output, err
+		}
+		if len(data) != 0 {
+			observer.observeJSON(data)
+		}
+		if _, err = w.Write(rewritten); err != nil {
+			input, output := observer.usage()
+			return input, output, err
+		}
+		if err = controller.Flush(); err != nil {
+			input, output := observer.usage()
+			return input, output, err
+		}
+		if terminal {
+			input, output := observer.usage()
+			return input, output, nil
+		}
+		event, eventBytes = event[:0], 0
+	}
+	input, output := observer.usage()
+	if err := scanner.Err(); err != nil {
+		return input, output, fmt.Errorf("read supplier SSE stream: %w", err)
+	}
+	if len(event) != 0 {
+		return input, output, errors.New("supplier SSE stream ended with an unterminated event")
+	}
+	return input, output, nil
+}
+
+func splitSSELines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	for index, character := range data {
+		switch character {
+		case '\n':
+			return index + 1, data[:index], nil
+		case '\r':
+			if index+1 == len(data) && !atEOF {
+				return 0, nil, nil
+			}
+			advance = index + 1
+			if index+1 < len(data) && data[index+1] == '\n' {
+				advance++
+			}
+			return advance, data[:index], nil
+		}
+	}
+	if atEOF && len(data) != 0 {
+		return len(data), data, nil
+	}
+	return 0, nil, nil
+}
+
+func rewriteSSEEvent(lines [][]byte, publicModelID string) (rewritten []byte, terminal bool, observedData []byte, err error) {
+	dataValues := make([][]byte, 0, len(lines))
+	firstDataLine := -1
+	for index, line := range lines {
+		field, value := sseField(line)
+		if bytes.Equal(field, []byte("data")) {
+			if firstDataLine < 0 {
+				firstDataLine = index
+			}
+			dataValues = append(dataValues, value)
+		}
+	}
+	if firstDataLine < 0 {
+		for _, line := range lines {
+			rewritten = append(rewritten, line...)
+			rewritten = append(rewritten, '\n')
+		}
+		return append(rewritten, '\n'), false, nil, nil
+	}
+	data := bytes.Join(dataValues, []byte{'\n'})
+	if bytes.Equal(bytes.TrimSpace(data), []byte("[DONE]")) {
+		terminal = true
+	} else {
+		if len(bytes.TrimSpace(data)) == 0 {
+			return nil, false, nil, errors.New("supplier SSE event has empty data")
+		}
+		observedData = bytes.Clone(data)
+		data, err = rewriteJSONModel(data, publicModelID)
+		if err != nil {
+			return nil, false, nil, fmt.Errorf("malformed supplier SSE data: %w", err)
+		}
+	}
+	for index, line := range lines {
+		field, _ := sseField(line)
+		if bytes.Equal(field, []byte("data")) {
+			if index == firstDataLine {
+				rewritten = append(rewritten, "data: "...)
+				rewritten = append(rewritten, data...)
+				rewritten = append(rewritten, '\n')
+			}
+			continue
+		}
+		rewritten = append(rewritten, line...)
+		rewritten = append(rewritten, '\n')
+	}
+	return append(rewritten, '\n'), terminal, observedData, nil
+}
+
+func sseField(line []byte) (field, value []byte) {
+	if len(line) == 0 || line[0] == ':' {
+		return nil, nil
+	}
+	separator := bytes.IndexByte(line, ':')
+	if separator < 0 {
+		return line, nil
+	}
+	field, value = line[:separator], line[separator+1:]
+	if len(value) != 0 && value[0] == ' ' {
+		value = value[1:]
+	}
+	return field, value
+}
+
+func rewriteJSONModel(body []byte, publicModelID string) ([]byte, error) {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(body, &object); err != nil {
+		return nil, err
+	}
+	if object == nil {
+		return nil, errors.New("expected a JSON object")
+	}
+	model, err := json.Marshal(publicModelID)
+	if err != nil {
+		return nil, err
+	}
+	object["model"] = model
+	return json.Marshal(object)
+}
+
+func writeError(w http.ResponseWriter, status int, message, errorType string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": message, "type": errorType, "param": nil, "code": nil}})
+}

--- a/internal/modelapirouting/runtime_test.go
+++ b/internal/modelapirouting/runtime_test.go
@@ -1,0 +1,337 @@
+package modelapirouting
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type flushingRecorder struct {
+	*httptest.ResponseRecorder
+	flushes int
+}
+
+func (r *flushingRecorder) Flush() {
+	r.flushes++
+	r.ResponseRecorder.Flush()
+}
+
+type billingFake struct {
+	mu              sync.Mutex
+	reserveErr      error
+	requests        []ReservationRequest
+	transmitted     int
+	responseStarted int
+	settlements     []Usage
+	released        int
+}
+
+func (b *billingFake) Reserve(_ context.Context, request ReservationRequest) (Reservation, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.requests = append(b.requests, request)
+	if b.reserveErr != nil {
+		return Reservation{}, b.reserveErr
+	}
+	return Reservation{ID: request.ID, TenantID: request.TenantID, ProductID: request.ProductID, EntitlementID: request.EntitlementID, State: "reserved"}, nil
+}
+func (b *billingFake) MarkTransmitted(context.Context, string, string, time.Time) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.transmitted++
+	return nil
+}
+func (b *billingFake) MarkResponseStarted(context.Context, string, string, time.Time) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.responseStarted++
+	return nil
+}
+func (b *billingFake) Settle(_ context.Context, _, _ string, usage Usage) (Reservation, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.settlements = append(b.settlements, usage)
+	return Reservation{State: "settled"}, nil
+}
+func (b *billingFake) ReleaseUnsent(context.Context, string, string, string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.released++
+	return nil
+}
+
+func runtimeFixture(t *testing.T, server *httptest.Server, billing *billingFake) (*Runtime, time.Time) {
+	t.Helper()
+	now := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
+	route := routeFixture(now, "customer")
+	route.Candidates[0].Endpoint = server.URL + "/v1"
+	directory := NewDirectory()
+	directory.now = func() time.Time { return now }
+	if err := directory.Publish([]PublishedRoute{route}); err != nil {
+		t.Fatal(err)
+	}
+	return &Runtime{Routes: directory, Billing: billing, Client: server.Client(), now: func() time.Time { return now }}, now
+}
+
+func TestRuntimeInsufficientBalanceDoesNotSend(t *testing.T) {
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { requests++ }))
+	defer server.Close()
+	billing := &billingFake{reserveErr: ErrInsufficientPrepaidBalance}
+	runtime, _ := runtimeFixture(t, server, billing)
+	recorder := httptest.NewRecorder()
+	runtime.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil), ProxyRequest{
+		TenantID: "customer", ProductID: "glm-5.3", Operation: "chat", Resource: "chat/completions",
+		RequestID: "request", TraceParent: "trace", Payload: map[string]any{"model": "glm-5.3"},
+	})
+	if recorder.Code != http.StatusPaymentRequired || requests != 0 || billing.transmitted != 0 {
+		t.Fatalf("status=%d requests=%d transmitted=%d", recorder.Code, requests, billing.transmitted)
+	}
+}
+
+func TestRuntimeDoesNotMisreportBillingInfrastructureFailureAsInsufficientCredit(t *testing.T) {
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { requests++ }))
+	defer server.Close()
+	billing := &billingFake{reserveErr: errors.New("database unavailable")}
+	runtime, _ := runtimeFixture(t, server, billing)
+	recorder := httptest.NewRecorder()
+	runtime.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil), ProxyRequest{
+		TenantID: "customer", ProductID: "glm-5.3", Operation: "chat", Resource: "chat/completions",
+		RequestID: "request", TraceParent: "trace", Payload: map[string]any{"model": "glm-5.3"},
+	})
+	if recorder.Code != http.StatusServiceUnavailable || requests != 0 || billing.transmitted != 0 {
+		t.Fatalf("status=%d requests=%d transmitted=%d", recorder.Code, requests, billing.transmitted)
+	}
+}
+
+func TestRuntimePinsRetailRateAndSettlesObservedUsage(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"usage":{"prompt_tokens":100,"completion_tokens":20}}`))
+	}))
+	defer server.Close()
+	billing := &billingFake{}
+	runtime, now := runtimeFixture(t, server, billing)
+	updated := routeFixture(now, "customer")
+	updated.Rate.ID, updated.Rate.Version, updated.Rate.ContractDigest = "rate-two", 2, "sha256:rate-two"
+	updated.Entitlement.RetailRateID, updated.Entitlement.RetailRateVersion = "rate-two", 2
+	recorder := httptest.NewRecorder()
+	runtime.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil), ProxyRequest{
+		TenantID: "customer", ProductID: "glm-5.3", Operation: "chat", Resource: "chat/completions",
+		RequestID: "request", TraceParent: "trace", Payload: map[string]any{"model": "glm-5.3"},
+	})
+	if err := runtime.Routes.Publish([]PublishedRoute{updated}); err != nil {
+		t.Fatal(err)
+	}
+	if recorder.Code != http.StatusOK || len(billing.requests) != 1 || billing.requests[0].RetailRate.ID != "rate" {
+		t.Fatalf("response=%d reservations=%#v", recorder.Code, billing.requests)
+	}
+	if len(billing.settlements) != 1 || billing.settlements[0].InputTokens == nil || *billing.settlements[0].InputTokens != 100 || billing.settlements[0].OutputTokens == nil || *billing.settlements[0].OutputTokens != 20 {
+		t.Fatalf("settlement=%#v", billing.settlements)
+	}
+}
+
+func TestRuntimeNeverRetriesAfterSupplierResponseStarts(t *testing.T) {
+	firstCalls, fallbackCalls := 0, 0
+	primary := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		firstCalls++
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":"unavailable"}`))
+	}))
+	defer primary.Close()
+	fallback := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fallbackCalls++
+		_, _ = w.Write([]byte(`{"usage":{"prompt_tokens":1,"completion_tokens":1}}`))
+	}))
+	defer fallback.Close()
+	billing := &billingFake{}
+	runtime, now := runtimeFixture(t, primary, billing)
+	route := routeFixture(now, "customer")
+	route.Candidates[0].Endpoint = primary.URL + "/v1"
+	second := route.Candidates[0]
+	second.ID, second.OfferID, second.Endpoint = "fallback", "fallback-offer", fallback.URL+"/v1"
+	route.Candidates = append(route.Candidates, second)
+	if err := runtime.Routes.Publish([]PublishedRoute{route}); err != nil {
+		t.Fatal(err)
+	}
+	// The TLS trust pools differ. A client that trusts both is unnecessary for
+	// this assertion because the selected primary has its own trusted client.
+	runtime.Client = primary.Client()
+	recorder := httptest.NewRecorder()
+	runtime.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil), ProxyRequest{
+		TenantID: "customer", ProductID: "glm-5.3", Operation: "chat", Resource: "chat/completions",
+		RequestID: "request", TraceParent: "trace", Payload: map[string]any{"model": "glm-5.3"},
+	})
+	if recorder.Code != http.StatusServiceUnavailable || firstCalls != 1 || fallbackCalls != 0 || len(billing.settlements) != 1 {
+		t.Fatalf("status=%d primary=%d fallback=%d settlements=%d", recorder.Code, firstCalls, fallbackCalls, len(billing.settlements))
+	}
+	if billing.settlements[0].InputTokens != nil || billing.settlements[0].OutputTokens != nil {
+		t.Fatalf("missing usage was not sent to reconciliation: %#v", billing.settlements[0])
+	}
+}
+
+func TestHostedSSEFlushesStopsAtDoneRetainsUsageAndSettlesOnce(t *testing.T) {
+	stream := "data: {\"model\":\"supplier/glm\",\"choices\":[]}\n\n" +
+		"data: {\"model\":\"supplier/glm\",\"usage\":{\"prompt_tokens\":17,\"completion_tokens\":5}}\n\n" +
+		"data: [DONE]\n\n" +
+		"data: {\"usage\":{\"prompt_tokens\":999,\"completion_tokens\":999}}\n\n"
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode supplier request: %v", err)
+		}
+		streamOptions, _ := payload["stream_options"].(map[string]any)
+		if streamOptions["include_usage"] != true {
+			t.Fatalf("stream usage was not requested from supplier: %#v", payload)
+		}
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		_, _ = io.WriteString(w, stream)
+	}))
+	defer server.Close()
+	billing := &billingFake{}
+	runtime, _ := runtimeFixture(t, server, billing)
+	recorder := &flushingRecorder{ResponseRecorder: httptest.NewRecorder()}
+	runtime.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil), ProxyRequest{
+		TenantID: "customer", ProductID: "glm-5.3", Operation: "chat", Resource: "chat/completions",
+		RequestID: "request", TraceParent: "trace", Payload: map[string]any{"model": "glm-5.3", "stream": true},
+	})
+	if recorder.Code != http.StatusOK || recorder.flushes < 3 {
+		t.Fatalf("status=%d flushes=%d body=%q", recorder.Code, recorder.flushes, recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), "999") || !strings.Contains(recorder.Body.String(), "data: [DONE]") || strings.Contains(recorder.Body.String(), "supplier/glm") || !strings.Contains(recorder.Body.String(), `"model":"glm-5.3"`) {
+		t.Fatalf("hosted public stream=%q", recorder.Body.String())
+	}
+	if len(billing.settlements) != 1 {
+		t.Fatalf("settlements=%#v", billing.settlements)
+	}
+	settlement := billing.settlements[0]
+	if settlement.InputTokens == nil || *settlement.InputTokens != 17 || settlement.OutputTokens == nil || *settlement.OutputTokens != 5 {
+		t.Fatalf("terminal usage settlement=%#v", settlement)
+	}
+}
+
+func TestRuntimeUsesPublicHeaderAllowlists(t *testing.T) {
+	var supplierHeaders http.Header
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		supplierHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "Application/JSON; charset=latin1")
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Server", "private-supplier")
+		w.Header().Set("Set-Cookie", "supplier_session=secret")
+		w.Header().Set("X-Supplier-Debug", "private-route")
+		_, _ = io.WriteString(w, `{"model":"supplier/glm","choices":[]}`)
+	}))
+	defer server.Close()
+	billing := &billingFake{}
+	runtime, _ := runtimeFixture(t, server, billing)
+	request := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("OpenAI-Beta", "responses=v1")
+	request.Header.Set("Authorization", "Bearer customer-secret")
+	request.Header.Set("Cookie", "customer_session=secret")
+	request.Header.Set("X-Supplier-Admin", "true")
+	request.Header.Set("X-Request-ID", "customer-controlled")
+	recorder := httptest.NewRecorder()
+	runtime.ServeHTTP(recorder, request, ProxyRequest{
+		TenantID: "customer", ProductID: "glm-5.3", Operation: "chat", Resource: "chat/completions",
+		RequestID: "public-request", TraceParent: "public-trace", Payload: map[string]any{"model": "glm-5.3"},
+	})
+	if supplierHeaders.Get("Accept") != "application/json" || supplierHeaders.Get("OpenAI-Beta") != "responses=v1" {
+		t.Fatalf("safe request headers were not forwarded: %#v", supplierHeaders)
+	}
+	if supplierHeaders.Get("Authorization") != "Bearer secret" || supplierHeaders.Get("X-Request-ID") != "public-request" || supplierHeaders.Get("Traceparent") != "public-trace" {
+		t.Fatalf("runtime-owned request headers were not normalized: %#v", supplierHeaders)
+	}
+	if supplierHeaders.Get("Cookie") != "" || supplierHeaders.Get("X-Supplier-Admin") != "" {
+		t.Fatalf("unapproved customer headers reached supplier: %#v", supplierHeaders)
+	}
+	if recorder.Header().Get("Content-Type") != "application/json" || recorder.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("public response headers were not normalized: %#v", recorder.Header())
+	}
+	if recorder.Header().Get("Server") != "" || recorder.Header().Get("Set-Cookie") != "" || recorder.Header().Get("X-Supplier-Debug") != "" {
+		t.Fatalf("supplier-private headers leaked: %#v", recorder.Header())
+	}
+}
+
+func TestPublicSSEParsesCompleteMultilineEventsAndRetainsResponsesUsage(t *testing.T) {
+	stream := "event: response.completed\r\n" +
+		"data: {\"type\":\"response.completed\",\"model\":\"supplier/glm\",\"sequence\":9007199254740993,\r\n" +
+		"data: \"response\":{\"usage\":{\"input_tokens\":23,\"output_tokens\":7}}}\r\n\r\n" +
+		"data: {\"type\":\"after-usage\",\"model\":\"supplier/glm\"}\r\n\r\n"
+	recorder := &flushingRecorder{ResponseRecorder: httptest.NewRecorder()}
+	input, output, err := copyPublicResponse(recorder, eventStreamResponse(stream), `public/"model`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if input == nil || *input != 23 || output == nil || *output != 7 {
+		t.Fatalf("responses usage was not retained: input=%v output=%v", input, output)
+	}
+	body := recorder.Body.String()
+	if strings.Contains(body, "supplier/glm") || !strings.Contains(body, `"model":"public/\"model"`) || !strings.Contains(body, "9007199254740993") {
+		t.Fatalf("unsafe or lossy SSE rewrite: %q", body)
+	}
+	if !strings.Contains(body, "event: response.completed\n") || recorder.flushes != 2 {
+		t.Fatalf("SSE metadata/framing was not preserved: flushes=%d body=%q", recorder.flushes, body)
+	}
+}
+
+func TestPublicSSEFailsClosedOnMalformedOrUnterminatedEvents(t *testing.T) {
+	tests := map[string]string{
+		"malformed JSON":     "data: not-json\n\n",
+		"unterminated event": `data: {"model":"supplier/glm"}`,
+		"line limit":         "data: " + strings.Repeat("x", maxSSELineBytes+1) + "\n\n",
+	}
+	for name, stream := range tests {
+		t.Run(name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			_, _, err := copyPublicResponse(recorder, eventStreamResponse(stream), "public")
+			if err == nil {
+				t.Fatal("invalid SSE stream was accepted")
+			}
+			if recorder.Body.Len() != 0 {
+				t.Fatalf("invalid event was forwarded: %q", recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestPublicSSEBoundsWholeEventMemory(t *testing.T) {
+	line := ":" + strings.Repeat("x", 1022) + "\n"
+	stream := strings.Repeat(line, maxSSEEventBytes/len(line)+2) + "\n"
+	recorder := httptest.NewRecorder()
+	_, _, err := copyPublicResponse(recorder, eventStreamResponse(stream), "public")
+	if err == nil || recorder.Body.Len() != 0 {
+		t.Fatalf("oversized SSE event was not rejected: err=%v bytes=%d", err, recorder.Body.Len())
+	}
+}
+
+func TestBufferedResponseRewritesWithoutRoundingAndCapturesUsage(t *testing.T) {
+	response := &http.Response{
+		Header: http.Header{"Content-Type": {"application/json"}},
+		Body:   io.NopCloser(bytes.NewBufferString(`{"model":"supplier/glm","sequence":9007199254740993,"usage":{"input_tokens":11,"output_tokens":3}}`)),
+	}
+	recorder := httptest.NewRecorder()
+	input, output, err := copyPublicResponse(recorder, response, "public")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if input == nil || *input != 11 || output == nil || *output != 3 || !strings.Contains(recorder.Body.String(), "9007199254740993") || strings.Contains(recorder.Body.String(), "supplier/glm") {
+		t.Fatalf("buffered rewrite/usage was lossy: input=%v output=%v body=%q", input, output, recorder.Body.String())
+	}
+}
+
+func eventStreamResponse(stream string) *http.Response {
+	return &http.Response{
+		Header: http.Header{"Content-Type": {"Text/Event-Stream; charset=utf-8"}},
+		Body:   io.NopCloser(strings.NewReader(stream)),
+	}
+}

--- a/internal/modelapisupply/offer.go
+++ b/internal/modelapisupply/offer.go
@@ -1,0 +1,265 @@
+package modelapisupply
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/modelapiproduct"
+)
+
+const (
+	OfferActive   = "active"
+	OfferDisabled = "disabled"
+
+	CommercialReady   = "ready"
+	CommercialPending = "pending"
+	CommercialExpired = "expired"
+
+	QualificationQualified = "qualified"
+	QualificationPending   = "pending"
+	QualificationRejected  = "rejected"
+	QualificationExpired   = "expired"
+)
+
+// CostRate is private supplier cost. It is deliberately separate from the
+// supplier-neutral customer retail rate supplied during materialization.
+type CostRate struct {
+	Currency                   string
+	InputMicrousdPerMTok       *int64
+	OutputMicrousdPerMTok      *int64
+	CachedInputMicrousdPerMTok *int64
+	Provenance                 string
+	ValidFrom                  time.Time
+	ValidUntil                 time.Time
+}
+
+type CommercialAuthorization struct {
+	State      string
+	TermsRef   string
+	ValidUntil time.Time
+}
+
+// QualificationEvidence is valid only for its exact immutable tuple and
+// stated protocol, region, and capabilities.
+type QualificationEvidence struct {
+	ID             string
+	State          string
+	TupleKey       string
+	Protocol       string
+	Region         string
+	Capabilities   []string
+	Scope          string
+	EvidenceRef    string
+	EvidenceDigest string
+	Reason         string
+	ObservedAt     time.Time
+	ValidUntil     time.Time
+	SampleCount    int
+	TTFTP95MS      *float64
+	OutputTokensP5 *float64
+}
+
+// HuggingFaceProvenance is discovery metadata only. MaterializeCandidate does
+// not use these fields to establish availability, capabilities, price,
+// qualification, or performance truth.
+type HuggingFaceProvenance struct {
+	RepositoryID string
+	Revision     string
+	License      string
+	SourceURL    string
+	ObservedAt   time.Time
+}
+
+// Offer is an immutable revision of an operator-owned private supplier offer.
+// CredentialReference points at a secret manager; credentials are never part
+// of this record or a compiled supply plan.
+type Offer struct {
+	ID                  string
+	Version             int64
+	OperatorTenantID    string
+	ProductID           string
+	Supplier            string
+	Adapter             string
+	SupplierModelID     string
+	Protocol            string
+	TupleKey            string
+	Region              string
+	CredentialReference string
+	State               string
+	Capabilities        []string
+	Access              string
+	Availability        string
+	Health              string
+	ObservedAt          time.Time
+	CostRate            CostRate
+	Commercial          CommercialAuthorization
+	Qualification       *QualificationEvidence
+	HuggingFace         *HuggingFaceProvenance
+}
+
+type CandidateMaterialization struct {
+	CandidateID string
+	Offer       Offer
+	RetailRate  modelapiproduct.RetailRate
+}
+
+func (o Offer) Validate() error {
+	required := map[string]string{
+		"id": o.ID, "operator tenant id": o.OperatorTenantID, "product id": o.ProductID,
+		"supplier": o.Supplier, "adapter": o.Adapter, "supplier model id": o.SupplierModelID,
+		"protocol": o.Protocol, "tuple key": o.TupleKey, "region": o.Region,
+		"credential reference": o.CredentialReference,
+	}
+	for name, value := range required {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("offer %s is required", name)
+		}
+	}
+	if o.Version <= 0 {
+		return errors.New("offer version must be positive")
+	}
+	if o.State != OfferActive && o.State != OfferDisabled {
+		return fmt.Errorf("unknown offer state %q", o.State)
+	}
+	if len(normalizeStrings(o.Capabilities)) == 0 {
+		return errors.New("offer requires at least one capability")
+	}
+	if err := validateCostRate(o.CostRate); err != nil {
+		return err
+	}
+	if o.Commercial.State != CommercialReady && o.Commercial.State != CommercialPending && o.Commercial.State != CommercialExpired {
+		return fmt.Errorf("unknown commercial authorization state %q", o.Commercial.State)
+	}
+	if o.Commercial.State == CommercialReady && (strings.TrimSpace(o.Commercial.TermsRef) == "" || o.Commercial.ValidUntil.IsZero()) {
+		return errors.New("ready commercial authorization requires terms reference and expiry")
+	}
+	if o.Qualification != nil {
+		if err := validateQualification(*o.Qualification); err != nil {
+			return err
+		}
+	}
+	if o.HuggingFace != nil && o.HuggingFace.ObservedAt.IsZero() {
+		return errors.New("Hugging Face metadata requires an observation timestamp")
+	}
+	return nil
+}
+
+func validateCostRate(rate CostRate) error {
+	if rate.Currency != "USD" {
+		return fmt.Errorf("supplier cost currency %q is unsupported", rate.Currency)
+	}
+	present := rate.InputMicrousdPerMTok != nil || rate.OutputMicrousdPerMTok != nil || rate.CachedInputMicrousdPerMTok != nil || strings.TrimSpace(rate.Provenance) != "" || !rate.ValidFrom.IsZero() || !rate.ValidUntil.IsZero()
+	if !present {
+		return nil
+	}
+	if rate.InputMicrousdPerMTok == nil || rate.OutputMicrousdPerMTok == nil || strings.TrimSpace(rate.Provenance) == "" {
+		return errors.New("partial supplier cost requires input, output, and provenance")
+	}
+	for _, value := range []*int64{rate.InputMicrousdPerMTok, rate.OutputMicrousdPerMTok, rate.CachedInputMicrousdPerMTok} {
+		if value != nil && *value < 0 {
+			return errors.New("supplier cost cannot be negative")
+		}
+	}
+	if rate.ValidFrom.IsZero() || rate.ValidUntil.IsZero() || !rate.ValidUntil.After(rate.ValidFrom) {
+		return errors.New("supplier cost requires an increasing validity window")
+	}
+	return nil
+}
+
+func validateQualification(evidence QualificationEvidence) error {
+	if strings.TrimSpace(evidence.ID) == "" || strings.TrimSpace(evidence.TupleKey) == "" || strings.TrimSpace(evidence.Protocol) == "" || strings.TrimSpace(evidence.Region) == "" {
+		return errors.New("qualification requires id, tuple key, protocol, and region")
+	}
+	if evidence.State != QualificationQualified && evidence.State != QualificationPending && evidence.State != QualificationRejected && evidence.State != QualificationExpired {
+		return fmt.Errorf("unknown qualification state %q", evidence.State)
+	}
+	if evidence.State == QualificationQualified && (strings.TrimSpace(evidence.Scope) == "" || strings.TrimSpace(evidence.EvidenceRef) == "" || strings.TrimSpace(evidence.EvidenceDigest) == "") {
+		return errors.New("qualified evidence requires scope, evidence reference, and digest")
+	}
+	if evidence.State == QualificationQualified && (evidence.ObservedAt.IsZero() || evidence.ValidUntil.IsZero() || !evidence.ValidUntil.After(evidence.ObservedAt)) {
+		return errors.New("qualified evidence requires an increasing validity window")
+	}
+	if !evidence.ObservedAt.IsZero() && !evidence.ValidUntil.IsZero() && !evidence.ValidUntil.After(evidence.ObservedAt) {
+		return errors.New("qualification evidence validity window must increase")
+	}
+	if evidence.SampleCount < 0 {
+		return errors.New("qualification sample count cannot be negative")
+	}
+	return nil
+}
+
+// MaterializeCandidate combines one immutable private offer revision with one
+// immutable public retail rate version. Missing or non-current business
+// evidence remains on the Candidate so Compile can persist explicit rejection
+// reasons instead of turning an incomplete offer into an input error.
+func MaterializeCandidate(input CandidateMaterialization) (Candidate, error) {
+	if strings.TrimSpace(input.CandidateID) == "" {
+		return Candidate{}, errors.New("candidate id is required")
+	}
+	if err := input.Offer.Validate(); err != nil {
+		return Candidate{}, err
+	}
+	if err := input.RetailRate.Validate(); err != nil {
+		return Candidate{}, err
+	}
+	if input.RetailRate.ProductID != input.Offer.ProductID {
+		return Candidate{}, errors.New("retail rate and supplier offer product ids must match")
+	}
+	if input.Offer.CostRate.Currency != input.RetailRate.Currency {
+		return Candidate{}, errors.New("supplier cost and retail rate currencies must match")
+	}
+
+	offer := input.Offer
+	validUntil := earlierTime(offer.CostRate.ValidUntil, input.RetailRate.ValidUntil)
+	retailInput, retailOutput := input.RetailRate.InputMicrousdPerMillion, input.RetailRate.OutputMicrousdPerMillion
+	candidate := Candidate{
+		ID: input.CandidateID, OfferID: offer.ID, OfferVersion: offer.Version,
+		RetailRateID: input.RetailRate.ID, RetailRateVersion: input.RetailRate.Version, Supplier: offer.Supplier,
+		ModelID: offer.ProductID, SupplierModelID: offer.SupplierModelID, TupleKey: offer.TupleKey,
+		Protocol: offer.Protocol, Capabilities: normalizeStrings(offer.Capabilities), Regions: []string{offer.Region},
+		OfferState: offer.State, Access: offer.Access, Availability: offer.Availability, Health: offer.Health,
+		ObservedAt: offer.ObservedAt, RateValidUntil: validUntil,
+		RetailInputMicrousdPerMTok:  &retailInput,
+		RetailOutputMicrousdPerMTok: &retailOutput,
+		CostInputMicrousdPerMTok:    offer.CostRate.InputMicrousdPerMTok,
+		CostOutputMicrousdPerMTok:   offer.CostRate.OutputMicrousdPerMTok,
+		CostBasisProvenance:         offer.CostRate.Provenance, CommercialState: offer.Commercial.State,
+		CommercialValidUntil: offer.Commercial.ValidUntil,
+	}
+	if offer.Qualification != nil {
+		copy := *offer.Qualification
+		copy.Capabilities = normalizeStrings(copy.Capabilities)
+		candidate.Qualification = &copy
+		candidate.Evidence = &CapacityEvidence{
+			TupleKey: copy.TupleKey, ObservedAt: copy.ObservedAt, SampleCount: copy.SampleCount,
+			TTFTP95MS: copy.TTFTP95MS, OutputTokensP5: copy.OutputTokensP5,
+		}
+	}
+	return candidate, nil
+}
+
+func normalizeStrings(values []string) []string {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			set[value] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(set))
+	for value := range set {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func earlierTime(left, right time.Time) time.Time {
+	if left.Before(right) {
+		return left
+	}
+	return right
+}

--- a/internal/modelapisupply/offer_test.go
+++ b/internal/modelapisupply/offer_test.go
@@ -1,0 +1,132 @@
+package modelapisupply
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/modelapiproduct"
+)
+
+func TestMaterializeCandidateKeepsHuggingFaceMetadataAdvisory(t *testing.T) {
+	at := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	offer := completeOffer(at)
+	offer.Capabilities = []string{"streaming", "tool-calling"}
+	offer.HuggingFace = &HuggingFaceProvenance{
+		RepositoryID: "unreviewed/repository", Revision: "candidate", License: "unknown",
+		SourceURL: "https://huggingface.co/unreviewed/repository", ObservedAt: at,
+	}
+	candidate, err := MaterializeCandidate(CandidateMaterialization{
+		CandidateID: "offer-a-v1", Offer: offer,
+		RetailRate: testRetailRate(t, at, at.Add(2*time.Hour)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if candidate.ModelID != offer.ProductID || candidate.SupplierModelID != offer.SupplierModelID {
+		t.Fatalf("Hugging Face metadata changed exact identity: %+v", candidate)
+	}
+	if candidate.RetailRateID != "retail-rate" || candidate.RetailRateVersion != 1 {
+		t.Fatalf("canonical retail rate identity was not materialized: %+v", candidate)
+	}
+	if !reflect.DeepEqual(candidate.Capabilities, []string{"streaming", "tool-calling"}) {
+		t.Fatalf("Hugging Face metadata changed capabilities: %+v", candidate.Capabilities)
+	}
+	if candidate.RateValidUntil != at.Add(2*time.Hour) {
+		t.Fatalf("candidate did not use the earliest private validity boundary: %v", candidate.RateValidUntil)
+	}
+}
+
+func TestMaterializeCandidateDoesNotInventQualification(t *testing.T) {
+	at := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	offer := completeOffer(at)
+	offer.Qualification = nil
+	candidate, err := MaterializeCandidate(CandidateMaterialization{
+		CandidateID: "offer-a-v1", Offer: offer,
+		RetailRate: testRetailRate(t, at, at.Add(time.Hour)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := Compile(baseRequest(at), []Candidate{candidate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Rejections) != 1 || !contains(plan.Rejections[0].Reasons, ReasonQualificationAbsent) {
+		t.Fatalf("unqualified offer became eligible: %+v", plan)
+	}
+}
+
+func TestIncompleteSupplyMaterializesToExplicitPlannerRejections(t *testing.T) {
+	at := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	offer := completeOffer(at)
+	offer.CostRate = CostRate{Currency: "USD"}
+	offer.Commercial = CommercialAuthorization{State: CommercialPending}
+	offer.Qualification.State = QualificationPending
+	offer.Qualification.EvidenceRef = ""
+	offer.Qualification.EvidenceDigest = ""
+	offer.Qualification.ObservedAt = time.Time{}
+	offer.Qualification.ValidUntil = time.Time{}
+	candidate, err := MaterializeCandidate(CandidateMaterialization{
+		CandidateID: "pending-offer", Offer: offer,
+		RetailRate: testRetailRate(t, at, at.Add(time.Hour)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := Compile(baseRequest(at), []Candidate{candidate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, reason := range []string{ReasonRateExpired, ReasonCommercialAuthorization, ReasonCostBasisAbsent, ReasonQualificationNotReady} {
+		if !contains(plan.Rejections[0].Reasons, reason) {
+			t.Fatalf("pending offer omitted %q: %+v", reason, plan.Rejections[0])
+		}
+	}
+}
+
+func testRetailRate(t *testing.T, at, until time.Time) modelapiproduct.RetailRate {
+	t.Helper()
+	rate, err := modelapiproduct.NewRetailRate(modelapiproduct.RetailRateDraft{
+		ID: "retail-rate", ProductID: "logical-model", Version: 1,
+		InputMicrousdPerMillion: 120_000, OutputMicrousdPerMillion: 480_000,
+		PublishedAt: at.Add(-2 * time.Hour), ValidFrom: at.Add(-time.Hour), ValidUntil: until,
+		PublicProvenance: "published contract fixture",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rate
+}
+
+func TestOfferValidationRejectsRawOrIncompleteCommercialData(t *testing.T) {
+	at := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	offer := completeOffer(at)
+	offer.CostRate.OutputMicrousdPerMTok = nil
+	if err := offer.Validate(); err == nil {
+		t.Fatal("cost without provenance was accepted")
+	}
+	offer = completeOffer(at)
+	offer.Commercial.TermsRef = ""
+	if err := offer.Validate(); err == nil {
+		t.Fatal("commercial authorization without terms reference was accepted")
+	}
+}
+
+func completeOffer(at time.Time) Offer {
+	costInput, costOutput := int64(80_000), int64(320_000)
+	return Offer{
+		ID: "offer-a", Version: 1, OperatorTenantID: "operator", ProductID: "logical-model",
+		Supplier: "supplier-a", Adapter: "supplier-a-openai", SupplierModelID: "supplier-a/model",
+		Protocol: "openai", TupleKey: "model@revision|supplier-a|eu", Region: "eu",
+		CredentialReference: "secret://supplier-a", State: OfferActive,
+		Capabilities: []string{"tool-calling", "streaming"}, Access: "ready", Availability: "available", Health: "healthy", ObservedAt: at.Add(-time.Minute),
+		CostRate:   CostRate{Currency: "USD", InputMicrousdPerMTok: &costInput, OutputMicrousdPerMTok: &costOutput, Provenance: "contract-2026-09", ValidFrom: at.Add(-time.Hour), ValidUntil: at.Add(3 * time.Hour)},
+		Commercial: CommercialAuthorization{State: CommercialReady, TermsRef: "msa-1", ValidUntil: at.Add(90 * time.Minute)},
+		Qualification: &QualificationEvidence{
+			ID: "qualification-a", State: QualificationQualified, TupleKey: "model@revision|supplier-a|eu", Protocol: "openai", Region: "eu",
+			Capabilities: []string{"streaming", "tool-calling"}, Scope: "buffered, streaming, tools",
+			EvidenceRef: "evidence://qualification-a", EvidenceDigest: "sha256:qualification", ObservedAt: at.Add(-time.Hour), ValidUntil: at.Add(time.Hour), SampleCount: 100,
+		},
+	}
+}

--- a/internal/modelapisupply/plan.go
+++ b/internal/modelapisupply/plan.go
@@ -28,13 +28,19 @@ const (
 	ReasonProtocolMismatch            = "protocol_mismatch"
 	ReasonCapabilityMissing           = "capability_missing"
 	ReasonRegionUnavailable           = "region_unavailable"
+	ReasonOfferNotActive              = "offer_not_active"
 	ReasonAccessNotReady              = "access_not_ready"
 	ReasonCapacityUnavailable         = "capacity_unavailable"
 	ReasonHealthNotReady              = "health_not_ready"
 	ReasonObservationStale            = "observation_stale"
 	ReasonRateExpired                 = "rate_expired"
+	ReasonCommercialAuthorization     = "commercial_authorization_not_ready"
 	ReasonCostBasisAbsent             = "cost_basis_absent"
 	ReasonMarginBelowFloor            = "margin_below_floor"
+	ReasonQualificationAbsent         = "qualification_absent"
+	ReasonQualificationNotReady       = "qualification_not_ready"
+	ReasonQualificationStale          = "qualification_stale"
+	ReasonQualificationMismatched     = "qualification_mismatched"
 	ReasonCapacityEvidenceAbsent      = "capacity_evidence_absent"
 	ReasonCapacityEvidenceStale       = "capacity_evidence_stale"
 	ReasonCapacityEvidenceMismatched  = "capacity_evidence_mismatched"
@@ -77,6 +83,10 @@ type CapacityEvidence struct {
 // or credential fields so the resulting plan is safe to persist internally.
 type Candidate struct {
 	ID                          string
+	OfferID                     string
+	OfferVersion                int64
+	RetailRateID                string
+	RetailRateVersion           int
 	Supplier                    string
 	ModelID                     string
 	SupplierModelID             string
@@ -84,33 +94,46 @@ type Candidate struct {
 	Protocol                    string
 	Capabilities                []string
 	Regions                     []string
+	OfferState                  string
 	Access                      string
 	Availability                string
 	Health                      string
 	ObservedAt                  time.Time
 	RateValidUntil              time.Time
+	CommercialState             string
+	CommercialValidUntil        time.Time
 	RetailInputMicrousdPerMTok  *int64
 	RetailOutputMicrousdPerMTok *int64
 	CostInputMicrousdPerMTok    *int64
 	CostOutputMicrousdPerMTok   *int64
 	CostBasisProvenance         string
+	Qualification               *QualificationEvidence
 	Evidence                    *CapacityEvidence
 }
 
 type Rejection struct {
-	CandidateID string   `json:"candidate_id"`
-	Reasons     []string `json:"reasons"`
+	CandidateID             string   `json:"candidate_id"`
+	OfferID                 string   `json:"offer_id,omitempty"`
+	OfferVersion            int64    `json:"offer_version,omitempty"`
+	QualificationEvidenceID string   `json:"qualification_evidence_id,omitempty"`
+	Reasons                 []string `json:"reasons"`
 }
 
 type Selection struct {
-	CandidateID                   string `json:"candidate_id"`
-	Supplier                      string `json:"supplier"`
-	SupplierModelID               string `json:"supplier_model_id"`
-	TupleKey                      string `json:"tuple_key"`
-	EstimatedRetailMicrousd       *int64 `json:"estimated_retail_microusd,omitempty"`
-	EstimatedSupplierCostMicrousd *int64 `json:"estimated_supplier_cost_microusd,omitempty"`
-	GrossMarginBPS                int    `json:"gross_margin_bps"`
-	EvidenceSampleCount           int    `json:"evidence_sample_count,omitempty"`
+	CandidateID                   string    `json:"candidate_id"`
+	OfferID                       string    `json:"offer_id,omitempty"`
+	OfferVersion                  int64     `json:"offer_version,omitempty"`
+	RetailRateID                  string    `json:"retail_rate_id,omitempty"`
+	RetailRateVersion             int       `json:"retail_rate_version,omitempty"`
+	QualificationEvidenceID       string    `json:"qualification_evidence_id,omitempty"`
+	Supplier                      string    `json:"supplier"`
+	SupplierModelID               string    `json:"supplier_model_id"`
+	TupleKey                      string    `json:"tuple_key"`
+	EstimatedRetailMicrousd       *int64    `json:"estimated_retail_microusd,omitempty"`
+	EstimatedSupplierCostMicrousd *int64    `json:"estimated_supplier_cost_microusd,omitempty"`
+	GrossMarginBPS                int       `json:"gross_margin_bps"`
+	EvidenceSampleCount           int       `json:"evidence_sample_count,omitempty"`
+	ValidUntil                    time.Time `json:"valid_until"`
 }
 
 type Plan struct {
@@ -121,6 +144,7 @@ type Plan struct {
 	Status        string      `json:"status"`
 	RankingBasis  string      `json:"ranking_basis"`
 	GeneratedAt   time.Time   `json:"generated_at"`
+	ValidUntil    time.Time   `json:"valid_until,omitempty"`
 	Primary       *Selection  `json:"primary,omitempty"`
 	Fallbacks     []Selection `json:"fallbacks"`
 	Rejections    []Rejection `json:"rejections"`
@@ -137,8 +161,8 @@ func Compile(request Request, candidates []Candidate) (Plan, error) {
 	ordered := append([]Candidate(nil), candidates...)
 	sort.SliceStable(ordered, func(i, j int) bool { return ordered[i].ID < ordered[j].ID })
 	for index, candidate := range ordered {
-		if strings.TrimSpace(candidate.ID) == "" || strings.TrimSpace(candidate.Supplier) == "" || strings.TrimSpace(candidate.SupplierModelID) == "" || strings.TrimSpace(candidate.TupleKey) == "" {
-			return Plan{}, fmt.Errorf("candidate %d requires id, supplier, supplier model id, and tuple key", index)
+		if strings.TrimSpace(candidate.ID) == "" || strings.TrimSpace(candidate.OfferID) == "" || candidate.OfferVersion <= 0 || strings.TrimSpace(candidate.RetailRateID) == "" || candidate.RetailRateVersion <= 0 || strings.TrimSpace(candidate.Supplier) == "" || strings.TrimSpace(candidate.SupplierModelID) == "" || strings.TrimSpace(candidate.TupleKey) == "" {
+			return Plan{}, fmt.Errorf("candidate %d requires id, offer revision, retail rate version, supplier, supplier model id, and tuple key", index)
 		}
 		if index > 0 && candidate.ID == ordered[index-1].ID {
 			return Plan{}, fmt.Errorf("candidate id %q is duplicated", candidate.ID)
@@ -150,7 +174,11 @@ func Compile(request Request, candidates []Candidate) (Plan, error) {
 	for _, candidate := range ordered {
 		selection, reasons := evaluate(request, candidate)
 		if len(reasons) > 0 {
-			rejections = append(rejections, Rejection{CandidateID: candidate.ID, Reasons: reasons})
+			rejection := Rejection{CandidateID: candidate.ID, OfferID: candidate.OfferID, OfferVersion: candidate.OfferVersion, Reasons: reasons}
+			if candidate.Qualification != nil {
+				rejection.QualificationEvidenceID = candidate.Qualification.ID
+			}
+			rejections = append(rejections, rejection)
 			continue
 		}
 		eligible = append(eligible, selection)
@@ -182,6 +210,10 @@ func Compile(request Request, candidates []Candidate) (Plan, error) {
 		plan.Status = StatusReady
 		plan.Primary = selectionPointer(eligible[0])
 		plan.Fallbacks = chooseFallbacks(eligible[1:], eligible[0].Supplier, maximumFallbacks(request.MaximumFallbacks))
+		plan.ValidUntil = plan.Primary.ValidUntil
+		for _, fallback := range plan.Fallbacks {
+			plan.ValidUntil = earlierTime(plan.ValidUntil, fallback.ValidUntil)
+		}
 	}
 	digest, err := digestPlan(plan)
 	if err != nil {
@@ -238,6 +270,9 @@ func evaluate(request Request, candidate Candidate) (Selection, []string) {
 	if request.Region != "" && !contains(candidate.Regions, request.Region) {
 		reasons = append(reasons, ReasonRegionUnavailable)
 	}
+	if candidate.OfferState != OfferActive {
+		reasons = append(reasons, ReasonOfferNotActive)
+	}
 	if candidate.Access != "ready" {
 		reasons = append(reasons, ReasonAccessNotReady)
 	}
@@ -252,6 +287,23 @@ func evaluate(request Request, candidate Candidate) (Selection, []string) {
 	}
 	if candidate.RateValidUntil.IsZero() || !candidate.RateValidUntil.UTC().After(request.At) {
 		reasons = append(reasons, ReasonRateExpired)
+	}
+	if candidate.CommercialState != CommercialReady || candidate.CommercialValidUntil.IsZero() || !candidate.CommercialValidUntil.UTC().After(request.At) {
+		reasons = append(reasons, ReasonCommercialAuthorization)
+	}
+
+	qualification := candidate.Qualification
+	switch {
+	case qualification == nil:
+		reasons = append(reasons, ReasonQualificationAbsent)
+	case qualification.State != QualificationQualified:
+		reasons = append(reasons, ReasonQualificationNotReady)
+	case qualification.TupleKey != candidate.TupleKey || qualification.Protocol != candidate.Protocol ||
+		!contains(candidate.Regions, qualification.Region) || !containsAll(qualification.Capabilities, request.Capabilities):
+		reasons = append(reasons, ReasonQualificationMismatched)
+	case qualification.ObservedAt.IsZero() || qualification.ValidUntil.IsZero() ||
+		request.At.Sub(qualification.ObservedAt.UTC()) < 0 || !qualification.ValidUntil.UTC().After(request.At):
+		reasons = append(reasons, ReasonQualificationStale)
 	}
 
 	pricesPresent := candidate.RetailInputMicrousdPerMTok != nil && candidate.RetailOutputMicrousdPerMTok != nil && candidate.CostInputMicrousdPerMTok != nil && candidate.CostOutputMicrousdPerMTok != nil && strings.TrimSpace(candidate.CostBasisProvenance) != ""
@@ -287,9 +339,22 @@ func evaluate(request Request, candidate Candidate) (Selection, []string) {
 		}
 	}
 
-	selection := Selection{CandidateID: candidate.ID, Supplier: candidate.Supplier, SupplierModelID: candidate.SupplierModelID, TupleKey: candidate.TupleKey, GrossMarginBPS: marginBPS}
+	selection := Selection{
+		CandidateID: candidate.ID, OfferID: candidate.OfferID, OfferVersion: candidate.OfferVersion,
+		RetailRateID: candidate.RetailRateID, RetailRateVersion: candidate.RetailRateVersion, Supplier: candidate.Supplier,
+		SupplierModelID: candidate.SupplierModelID, TupleKey: candidate.TupleKey, GrossMarginBPS: marginBPS,
+		ValidUntil: earlierTime(candidate.RateValidUntil.UTC(), candidate.CommercialValidUntil.UTC()),
+	}
+	selection.ValidUntil = earlierTime(selection.ValidUntil, candidate.ObservedAt.UTC().Add(request.MaximumObservationAge))
+	if candidate.Qualification != nil {
+		selection.QualificationEvidenceID = candidate.Qualification.ID
+		selection.ValidUntil = earlierTime(selection.ValidUntil, candidate.Qualification.ValidUntil.UTC())
+	}
 	if candidate.Evidence != nil {
 		selection.EvidenceSampleCount = candidate.Evidence.SampleCount
+		if (request.MaximumTTFTP95MS != nil || request.MinimumOutputTokensPS != nil) && request.MaximumEvidenceAge > 0 {
+			selection.ValidUntil = earlierTime(selection.ValidUntil, candidate.Evidence.ObservedAt.UTC().Add(request.MaximumEvidenceAge))
+		}
 	}
 	if pricesPresent && (request.InputTokens > 0 || request.OutputTokens > 0) {
 		retail, retailErr := managedbilling.TokenCostMicrousd(request.InputTokens, request.OutputTokens, *candidate.RetailInputMicrousdPerMTok, *candidate.RetailOutputMicrousdPerMTok)
@@ -355,6 +420,24 @@ func digestPlan(plan Plan) (string, error) {
 	}
 	digest := sha256.Sum256(body)
 	return "sha256:" + hex.EncodeToString(digest[:]), nil
+}
+
+// CanonicalDigest recomputes the digest over the complete plan while excluding
+// the embedded Digest field. Persistence and publication boundaries use this
+// to reject a plan whose JSON body no longer matches its immutable identity.
+func (plan Plan) CanonicalDigest() (string, error) {
+	return digestPlan(plan)
+}
+
+// HasCanonicalDigest reports whether the embedded digest matches the complete
+// canonical plan body. A plan loaded from storage must pass this check before
+// it can participate in a published route generation.
+func (plan Plan) HasCanonicalDigest() bool {
+	if plan.Digest == "" {
+		return false
+	}
+	digest, err := plan.CanonicalDigest()
+	return err == nil && digest == plan.Digest
 }
 
 func selectionPointer(value Selection) *Selection { return &value }

--- a/internal/modelapisupply/plan_test.go
+++ b/internal/modelapisupply/plan_test.go
@@ -29,6 +29,17 @@ func TestCompileSelectsCheapestExactProfitableTupleAndDiverseFallback(t *testing
 	if plan.RankingBasis != "estimated_customer_cost_for_declared_workload" || plan.Primary.EstimatedRetailMicrousd == nil || plan.Digest == "" {
 		t.Fatalf("plan omitted cost basis or digest: %+v", plan)
 	}
+	if plan.ValidUntil.IsZero() || !plan.ValidUntil.After(at) {
+		t.Fatalf("ready plan omitted its evidence expiry: %+v", plan)
+	}
+	if !plan.HasCanonicalDigest() {
+		t.Fatal("compiled plan did not verify against its canonical digest")
+	}
+
+	plan.RankingBasis = "tampered"
+	if plan.HasCanonicalDigest() {
+		t.Fatal("mutated plan retained a valid canonical digest")
+	}
 }
 
 func TestCompileFailsClosedWithoutComparableEvidence(t *testing.T) {
@@ -105,6 +116,26 @@ func TestCompileIsDeterministicAndDoesNotInventCostWithoutWorkloadShape(t *testi
 	}
 }
 
+func TestCompileRequiresCurrentExactQualificationWithoutAnSLO(t *testing.T) {
+	at := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	request := baseRequest(at)
+	mismatched := candidate("mismatched", "supplier-a", 100_000, 400_000, at)
+	mismatched.Qualification.TupleKey = "another-tuple"
+	stale := candidate("stale-evidence", "supplier-b", 100_000, 400_000, at)
+	stale.Qualification.ValidUntil = at
+
+	plan, err := Compile(request, []Candidate{mismatched, stale})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{"mismatched": ReasonQualificationMismatched, "stale-evidence": ReasonQualificationStale}
+	for _, rejection := range plan.Rejections {
+		if !contains(rejection.Reasons, want[rejection.CandidateID]) {
+			t.Fatalf("qualification rejection lost for %s: %+v", rejection.CandidateID, rejection)
+		}
+	}
+}
+
 func baseRequest(at time.Time) Request {
 	return Request{
 		ModelID: "logical-model", Protocol: "openai", Capabilities: []string{"streaming", "tool-calling"}, Region: "eu",
@@ -114,11 +145,13 @@ func baseRequest(at time.Time) Request {
 
 func candidate(id, supplier string, retailInput, retailOutput int64, at time.Time) Candidate {
 	return Candidate{
-		ID: id, Supplier: supplier, ModelID: "logical-model", SupplierModelID: supplier + "/model", TupleKey: "model@commit|runtime@digest|gpu|" + id,
+		ID: id, OfferID: "offer-" + id, OfferVersion: 1, RetailRateID: "retail-rate", RetailRateVersion: 1, Supplier: supplier, ModelID: "logical-model", SupplierModelID: supplier + "/model", TupleKey: "model@commit|runtime@digest|gpu|" + id,
 		Protocol: "openai", Capabilities: []string{"streaming", "tool-calling", "structured-output"}, Regions: []string{"eu"},
-		Access: "ready", Availability: "available", Health: "healthy", ObservedAt: at.Add(-time.Minute), RateValidUntil: at.Add(time.Hour),
+		OfferState: OfferActive, Access: "ready", Availability: "available", Health: "healthy", ObservedAt: at.Add(-time.Minute), RateValidUntil: at.Add(time.Hour),
+		CommercialState: CommercialReady, CommercialValidUntil: at.Add(time.Hour),
 		RetailInputMicrousdPerMTok: int64Pointer(retailInput), RetailOutputMicrousdPerMTok: int64Pointer(retailOutput),
 		CostInputMicrousdPerMTok: int64Pointer(retailInput * 3 / 4), CostOutputMicrousdPerMTok: int64Pointer(retailOutput * 3 / 4), CostBasisProvenance: "contract fixture",
+		Qualification: &QualificationEvidence{ID: "qualification-" + id, State: QualificationQualified, TupleKey: "model@commit|runtime@digest|gpu|" + id, Protocol: "openai", Region: "eu", Capabilities: []string{"streaming", "tool-calling", "structured-output"}, Scope: "fixture", EvidenceRef: "fixture://" + id, EvidenceDigest: "sha256:" + id, ObservedAt: at.Add(-time.Minute), ValidUntil: at.Add(time.Hour)},
 	}
 }
 

--- a/internal/reconcile/model_api_usage.go
+++ b/internal/reconcile/model_api_usage.go
@@ -1,0 +1,74 @@
+package reconcile
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/infercrane/infercrane/internal/modelapirouting"
+)
+
+var ErrUsageNotReady = errors.New("supplier usage is not ready")
+
+type ModelAPIUsageStore interface {
+	PendingModelAPIUsageReservations(context.Context, int) ([]modelapirouting.Reservation, error)
+	SettleModelAPIUsage(context.Context, string, string, modelapirouting.Usage) (modelapirouting.Reservation, error)
+	ConfirmNoChargeModelAPIUsage(context.Context, string, string, string) error
+}
+
+type ModelAPIUsageEvidence struct {
+	Usage             *modelapirouting.Usage
+	NoChargeConfirmed bool
+	Evidence          string
+}
+
+type ModelAPIUsageResolver interface {
+	ResolveModelAPIUsage(context.Context, modelapirouting.Reservation) (ModelAPIUsageEvidence, error)
+}
+
+// ModelAPIUsageReconciler resolves ambiguous supplier usage without guessing.
+// Unknown evidence remains reserved; an explicit no-charge confirmation or
+// complete token usage is required to mutate customer money.
+type ModelAPIUsageReconciler struct {
+	Store    ModelAPIUsageStore
+	Resolver ModelAPIUsageResolver
+	Logger   *slog.Logger
+	Limit    int
+}
+
+func (r ModelAPIUsageReconciler) Once(ctx context.Context) error {
+	reservations, err := r.Store.PendingModelAPIUsageReservations(ctx, r.Limit)
+	if err != nil {
+		return err
+	}
+	var failures []error
+	for _, reservation := range reservations {
+		evidence, resolveErr := r.Resolver.ResolveModelAPIUsage(ctx, reservation)
+		if resolveErr != nil {
+			if !errors.Is(resolveErr, ErrUsageNotReady) {
+				failures = append(failures, resolveErr)
+			}
+			continue
+		}
+		if evidence.NoChargeConfirmed {
+			if evidence.Evidence == "" {
+				failures = append(failures, errors.New("supplier no-charge result omitted evidence"))
+				continue
+			}
+			if releaseErr := r.Store.ConfirmNoChargeModelAPIUsage(ctx, reservation.TenantID, reservation.ID, evidence.Evidence); releaseErr != nil {
+				failures = append(failures, releaseErr)
+			}
+			continue
+		}
+		if evidence.Usage == nil || evidence.Usage.InputTokens == nil || evidence.Usage.OutputTokens == nil {
+			continue
+		}
+		if _, settleErr := r.Store.SettleModelAPIUsage(ctx, reservation.TenantID, reservation.ID, *evidence.Usage); settleErr != nil {
+			failures = append(failures, settleErr)
+		}
+	}
+	if len(failures) > 0 && r.Logger != nil {
+		r.Logger.Error("hosted model API usage reconciliation incomplete", "failures", len(failures))
+	}
+	return errors.Join(failures...)
+}

--- a/internal/reconcile/model_api_usage_test.go
+++ b/internal/reconcile/model_api_usage_test.go
@@ -1,0 +1,67 @@
+package reconcile
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/infercrane/infercrane/internal/modelapirouting"
+)
+
+type usageReconcileStore struct {
+	pending  []modelapirouting.Reservation
+	settled  []string
+	released []string
+}
+
+func (s *usageReconcileStore) PendingModelAPIUsageReservations(context.Context, int) ([]modelapirouting.Reservation, error) {
+	return s.pending, nil
+}
+func (s *usageReconcileStore) SettleModelAPIUsage(_ context.Context, tenant, id string, _ modelapirouting.Usage) (modelapirouting.Reservation, error) {
+	s.settled = append(s.settled, tenant+"/"+id)
+	return modelapirouting.Reservation{}, nil
+}
+func (s *usageReconcileStore) ConfirmNoChargeModelAPIUsage(_ context.Context, tenant, id, _ string) error {
+	s.released = append(s.released, tenant+"/"+id)
+	return nil
+}
+
+type usageResolverFunc func(context.Context, modelapirouting.Reservation) (ModelAPIUsageEvidence, error)
+
+func (f usageResolverFunc) ResolveModelAPIUsage(ctx context.Context, reservation modelapirouting.Reservation) (ModelAPIUsageEvidence, error) {
+	return f(ctx, reservation)
+}
+
+func TestModelAPIUsageReconcilerNeverGuessesUnknownUsage(t *testing.T) {
+	store := &usageReconcileStore{pending: []modelapirouting.Reservation{{ID: "unknown", TenantID: "tenant"}}}
+	reconciler := ModelAPIUsageReconciler{Store: store, Resolver: usageResolverFunc(func(context.Context, modelapirouting.Reservation) (ModelAPIUsageEvidence, error) {
+		return ModelAPIUsageEvidence{}, ErrUsageNotReady
+	})}
+	if err := reconciler.Once(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.settled) != 0 || len(store.released) != 0 {
+		t.Fatalf("unknown usage mutated money: settled=%v released=%v", store.settled, store.released)
+	}
+}
+
+func TestModelAPIUsageReconcilerRequiresCompleteEvidence(t *testing.T) {
+	store := &usageReconcileStore{pending: []modelapirouting.Reservation{{ID: "usage", TenantID: "tenant"}, {ID: "free", TenantID: "tenant"}}}
+	input, output := 10, 2
+	reconciler := ModelAPIUsageReconciler{Store: store, Resolver: usageResolverFunc(func(_ context.Context, reservation modelapirouting.Reservation) (ModelAPIUsageEvidence, error) {
+		switch reservation.ID {
+		case "usage":
+			return ModelAPIUsageEvidence{Usage: &modelapirouting.Usage{InputTokens: &input, OutputTokens: &output}}, nil
+		case "free":
+			return ModelAPIUsageEvidence{NoChargeConfirmed: true, Evidence: "supplier request ledger"}, nil
+		default:
+			return ModelAPIUsageEvidence{}, errors.New("unexpected")
+		}
+	})}
+	if err := reconciler.Once(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.settled) != 1 || store.settled[0] != "tenant/usage" || len(store.released) != 1 || store.released[0] != "tenant/free" {
+		t.Fatalf("settled=%v released=%v", store.settled, store.released)
+	}
+}

--- a/internal/store/migration_compatibility_test.go
+++ b/internal/store/migration_compatibility_test.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"net/url"
 	"os"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -183,5 +184,50 @@ func TestMigrationLedgerRejectsTamperGapAndNewerDatabase(t *testing.T) {
 				t.Fatalf("%s migration history was accepted", name)
 			}
 		})
+	}
+}
+
+func TestModelAPISupplyEvidenceTablesHaveImmutableTriggers(t *testing.T) {
+	ctx, databaseURL, _ := isolatedMigrationDatabase(t)
+	current, err := Open(ctx, databaseURL, Options{MaxOpenConns: 2, MaxIdleConns: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer current.Close()
+
+	rows, err := current.db.QueryContext(ctx, `
+		SELECT c.relname,t.tgname
+		FROM pg_trigger t
+		JOIN pg_class c ON c.oid=t.tgrelid
+		WHERE NOT t.tgisinternal AND c.relname IN (
+			'model_api_supplier_offers',
+			'model_api_supply_qualifications',
+			'model_api_supply_plans',
+			'model_api_supply_plan_candidates'
+		)
+		ORDER BY c.relname,t.tgname`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	found := map[string]string{}
+	for rows.Next() {
+		var table, trigger string
+		if err = rows.Scan(&table, &trigger); err != nil {
+			t.Fatal(err)
+		}
+		found[table] = trigger
+	}
+	if err = rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{
+		"model_api_supplier_offers":        "model_api_supplier_offers_immutable",
+		"model_api_supply_qualifications":  "model_api_supply_qualifications_immutable",
+		"model_api_supply_plans":           "model_api_supply_plans_immutable",
+		"model_api_supply_plan_candidates": "model_api_supply_plan_candidates_immutable",
+	}
+	if !reflect.DeepEqual(found, want) {
+		t.Fatalf("immutable supply triggers=%v want=%v", found, want)
 	}
 }

--- a/internal/store/migrations/057_model_api_catalog.sql
+++ b/internal/store/migrations/057_model_api_catalog.sql
@@ -1,0 +1,130 @@
+CREATE TABLE model_api_products (
+  id TEXT PRIMARY KEY,
+  display_name TEXT NOT NULL,
+  publisher TEXT NOT NULL,
+  description TEXT NOT NULL,
+  protocol TEXT NOT NULL CHECK(protocol='openai'),
+  tasks_json JSONB NOT NULL CHECK(jsonb_typeof(tasks_json)='array' AND jsonb_array_length(tasks_json)>0),
+  capability_contract_json JSONB NOT NULL CHECK(jsonb_typeof(capability_contract_json)='array' AND jsonb_array_length(capability_contract_json)>0),
+  input_modalities_json JSONB NOT NULL CHECK(jsonb_typeof(input_modalities_json)='array' AND jsonb_array_length(input_modalities_json)>0),
+  output_modalities_json JSONB NOT NULL CHECK(jsonb_typeof(output_modalities_json)='array' AND jsonb_array_length(output_modalities_json)>0),
+  context_window_tokens BIGINT CHECK(context_window_tokens IS NULL OR context_window_tokens>0),
+  availability TEXT NOT NULL DEFAULT 'catalog_only'
+    CHECK(availability IN ('catalog_only','private_preview','available','degraded','unavailable')),
+  self_host_eligibility TEXT NOT NULL DEFAULT 'unknown'
+    CHECK(self_host_eligibility IN ('unknown','eligible','ineligible')),
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  CHECK(updated_at>=created_at)
+);
+
+-- Retail prices are supplier-neutral customer contracts. Supplier cost and
+-- private offer identity live outside this catalog schema.
+CREATE TABLE model_api_retail_rate_cards (
+  id TEXT PRIMARY KEY,
+  product_id TEXT NOT NULL REFERENCES model_api_products(id) ON DELETE RESTRICT,
+  version INTEGER NOT NULL CHECK(version>0),
+  currency TEXT NOT NULL DEFAULT 'USD' CHECK(currency='USD'),
+  input_microusd_per_million BIGINT NOT NULL CHECK(input_microusd_per_million>0),
+  cached_input_microusd_per_million BIGINT CHECK(cached_input_microusd_per_million IS NULL OR cached_input_microusd_per_million>=0),
+  output_microusd_per_million BIGINT NOT NULL CHECK(output_microusd_per_million>0),
+  valid_from TIMESTAMPTZ NOT NULL,
+  valid_until TIMESTAMPTZ NOT NULL,
+  published_at TIMESTAMPTZ NOT NULL,
+  public_provenance TEXT NOT NULL,
+  contract_digest TEXT NOT NULL CHECK(contract_digest LIKE 'sha256:%'),
+  UNIQUE(product_id,version),
+  UNIQUE(product_id,contract_digest),
+  UNIQUE(product_id,id),
+  UNIQUE(product_id,id,version),
+  CHECK(valid_until>valid_from),
+  CHECK(published_at<=valid_from)
+);
+CREATE INDEX model_api_retail_rate_cards_product_validity_idx
+  ON model_api_retail_rate_cards(product_id,valid_from DESC,valid_until DESC);
+
+CREATE FUNCTION infercrane_reject_model_api_rate_mutation() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'model API retail rate cards are immutable; publish a new version';
+END;
+$$;
+CREATE TRIGGER model_api_retail_rate_cards_immutable
+  BEFORE UPDATE OR DELETE ON model_api_retail_rate_cards
+  FOR EACH ROW EXECUTE FUNCTION infercrane_reject_model_api_rate_mutation();
+
+-- This is the operator-private half of a hosted product. The public projection
+-- must not expose these workspace or plan references.
+CREATE TABLE model_api_operator_publications (
+  product_id TEXT PRIMARY KEY REFERENCES model_api_products(id) ON DELETE RESTRICT,
+  operator_tenant_id TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+  serving_plan_id TEXT NOT NULL REFERENCES serving_plans(id) ON DELETE RESTRICT,
+  supply_plan_id TEXT NOT NULL,
+  qualification_state TEXT NOT NULL DEFAULT 'pending'
+    CHECK(qualification_state IN ('pending','qualified','stale')),
+  qualification_evidence_id TEXT NOT NULL DEFAULT '',
+  qualification_valid_until TIMESTAMPTZ,
+  active_retail_rate_card_id TEXT REFERENCES model_api_retail_rate_cards(id) ON DELETE RESTRICT,
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  UNIQUE(product_id,operator_tenant_id,serving_plan_id),
+  FOREIGN KEY(product_id,active_retail_rate_card_id)
+    REFERENCES model_api_retail_rate_cards(product_id,id) ON DELETE RESTRICT,
+  CHECK(updated_at>=created_at),
+  CHECK(
+    (qualification_state='qualified' AND qualification_evidence_id<>'' AND qualification_valid_until IS NOT NULL)
+    OR
+    (qualification_state IN ('pending','stale') AND qualification_evidence_id='' AND qualification_valid_until IS NULL)
+  )
+);
+
+-- Customer policy and money stay customer-owned while the authorized route is
+-- an operator-owned shared plan. This row contains no target, supplier offer,
+-- or credential material.
+CREATE TABLE model_api_product_entitlements (
+  id TEXT PRIMARY KEY,
+  customer_tenant_id TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  product_id TEXT NOT NULL REFERENCES model_api_products(id) ON DELETE RESTRICT,
+  operator_tenant_id TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+  serving_plan_id TEXT NOT NULL REFERENCES serving_plans(id) ON DELETE RESTRICT,
+  retail_rate_card_id TEXT NOT NULL REFERENCES model_api_retail_rate_cards(id) ON DELETE RESTRICT,
+  retail_rate_version INTEGER NOT NULL CHECK(retail_rate_version>0),
+  state TEXT NOT NULL DEFAULT 'pending'
+    CHECK(state IN ('pending','active','suspended','revoked')),
+  requests_per_minute BIGINT CHECK(requests_per_minute IS NULL OR requests_per_minute>0),
+  tokens_per_minute BIGINT CHECK(tokens_per_minute IS NULL OR tokens_per_minute>0),
+  monthly_spend_microusd BIGINT CHECK(monthly_spend_microusd IS NULL OR monthly_spend_microusd>0),
+  max_request_microusd BIGINT CHECK(max_request_microusd IS NULL OR max_request_microusd>0),
+  valid_from TIMESTAMPTZ NOT NULL,
+  valid_until TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  UNIQUE(customer_tenant_id,product_id),
+  FOREIGN KEY(product_id,operator_tenant_id,serving_plan_id)
+    REFERENCES model_api_operator_publications(product_id,operator_tenant_id,serving_plan_id) ON DELETE RESTRICT,
+  FOREIGN KEY(product_id,retail_rate_card_id,retail_rate_version)
+    REFERENCES model_api_retail_rate_cards(product_id,id,version) ON DELETE RESTRICT,
+  CHECK(customer_tenant_id<>operator_tenant_id),
+  CHECK(valid_until IS NULL OR valid_until>valid_from),
+  CHECK(updated_at>=created_at),
+  CHECK(max_request_microusd IS NULL OR monthly_spend_microusd IS NULL OR max_request_microusd<=monthly_spend_microusd)
+);
+CREATE INDEX model_api_product_entitlements_customer_state_idx
+  ON model_api_product_entitlements(customer_tenant_id,state,product_id);
+
+INSERT INTO model_api_products(
+  id,display_name,publisher,description,protocol,tasks_json,
+  capability_contract_json,input_modalities_json,output_modalities_json,
+  availability,self_host_eligibility,created_at,updated_at
+) VALUES
+  ('glm-5.2','GLM-5.2','Z.ai','Planned for coding, reasoning, and bilingual chat workloads.','openai',
+    '["coding","reasoning","chat"]','[{"name":"chat-completions","state":"cataloged"},{"name":"streaming","state":"cataloged"}]','["text"]','["text"]','catalog_only','unknown',NOW(),NOW()),
+  ('glm-5.3','GLM-5.3','Z.ai','Planned for reasoning and long-context workloads.','openai',
+    '["reasoning","long-context","chat"]','[{"name":"chat-completions","state":"cataloged"},{"name":"streaming","state":"cataloged"}]','["text"]','["text"]','catalog_only','unknown',NOW(),NOW()),
+  ('glm-5.3-flash','GLM-5.3-Flash','Z.ai','Planned for cost-sensitive and latency-sensitive workloads.','openai',
+    '["chat","coding"]','[{"name":"chat-completions","state":"cataloged"},{"name":"streaming","state":"cataloged"}]','["text"]','["text"]','catalog_only','unknown',NOW(),NOW()),
+  ('kimi-k3','Kimi-K3','Moonshot AI','Planned for coding and agentic workflows.','openai',
+    '["coding","agents","chat"]','[{"name":"chat-completions","state":"cataloged"},{"name":"streaming","state":"cataloged"}]','["text"]','["text"]','catalog_only','unknown',NOW(),NOW()),
+  ('kimi-k2.6','Kimi-K2.6','Moonshot AI','Planned for coding, agentic, and long-context workloads.','openai',
+    '["coding","agents","long-context","chat"]','[{"name":"chat-completions","state":"cataloged"},{"name":"streaming","state":"cataloged"}]','["text"]','["text"]','catalog_only','unknown',NOW(),NOW()),
+  ('deepseek-v4-flash-0731-fast','DeepSeek-V4-Flash-0731-Fast','DeepSeek','Planned for high-throughput workloads after route qualification.','openai',
+    '["chat","coding","throughput"]','[{"name":"chat-completions","state":"cataloged"},{"name":"streaming","state":"cataloged"}]','["text"]','["text"]','catalog_only','unknown',NOW(),NOW());

--- a/internal/store/migrations/058_model_api_supply.sql
+++ b/internal/store/migrations/058_model_api_supply.sql
@@ -1,0 +1,132 @@
+-- Private, operator-owned supply is versioned independently from public model
+-- products. No supplier credential value belongs in these tables;
+-- credential_reference names an entry in the operator's secret manager.
+CREATE TABLE model_api_supplier_offers (
+  id TEXT NOT NULL,
+  version BIGINT NOT NULL CHECK(version>0),
+  operator_tenant_id TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+  managed_product_id TEXT NOT NULL REFERENCES model_api_products(id) ON DELETE RESTRICT,
+  supplier TEXT NOT NULL,
+  adapter TEXT NOT NULL,
+  supplier_model_id TEXT NOT NULL,
+  protocol TEXT NOT NULL,
+  tuple_key TEXT NOT NULL,
+  region TEXT NOT NULL,
+  credential_reference TEXT NOT NULL,
+  state TEXT NOT NULL CHECK(state IN ('active','disabled')),
+  capabilities_json JSONB NOT NULL CHECK(jsonb_typeof(capabilities_json)='array'),
+  access_state TEXT NOT NULL,
+  availability_state TEXT NOT NULL,
+  health_state TEXT NOT NULL,
+  observed_at TIMESTAMPTZ,
+  cost_currency TEXT NOT NULL CHECK(cost_currency='USD'),
+  cost_input_microusd_per_mtoken BIGINT CHECK(cost_input_microusd_per_mtoken>=0),
+  cost_output_microusd_per_mtoken BIGINT CHECK(cost_output_microusd_per_mtoken>=0),
+  cost_cached_input_microusd_per_mtoken BIGINT CHECK(cost_cached_input_microusd_per_mtoken>=0),
+  cost_basis_provenance TEXT,
+  cost_valid_from TIMESTAMPTZ,
+  cost_valid_until TIMESTAMPTZ,
+  commercial_state TEXT NOT NULL CHECK(commercial_state IN ('ready','pending','expired')),
+  commercial_terms_ref TEXT,
+  commercial_valid_until TIMESTAMPTZ,
+  hf_repository_id TEXT,
+  hf_revision TEXT,
+  hf_license TEXT,
+  hf_source_url TEXT,
+  hf_observed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY(id,version),
+  UNIQUE(id,version,managed_product_id),
+  CHECK((cost_input_microusd_per_mtoken IS NULL AND cost_output_microusd_per_mtoken IS NULL AND cost_cached_input_microusd_per_mtoken IS NULL AND cost_basis_provenance IS NULL AND cost_valid_from IS NULL AND cost_valid_until IS NULL) OR (cost_input_microusd_per_mtoken IS NOT NULL AND cost_output_microusd_per_mtoken IS NOT NULL AND cost_basis_provenance IS NOT NULL AND cost_valid_from IS NOT NULL AND cost_valid_until>cost_valid_from)),
+  CHECK(commercial_state<>'ready' OR (commercial_terms_ref IS NOT NULL AND commercial_valid_until IS NOT NULL)),
+  CHECK((hf_repository_id IS NULL AND hf_revision IS NULL AND hf_license IS NULL AND hf_source_url IS NULL AND hf_observed_at IS NULL) OR hf_observed_at IS NOT NULL)
+);
+CREATE INDEX model_api_supplier_offers_operator_product_idx
+  ON model_api_supplier_offers(operator_tenant_id,managed_product_id,state,version DESC);
+CREATE INDEX model_api_supplier_offers_current_observation_idx
+  ON model_api_supplier_offers(state,observed_at DESC,cost_valid_until);
+
+-- Qualification evidence is exact-tuple, independently expiring evidence. A
+-- Hugging Face observation above can aid discovery but never creates one of
+-- these records or makes an offer callable.
+CREATE TABLE model_api_supply_qualifications (
+  id TEXT PRIMARY KEY,
+  offer_id TEXT NOT NULL,
+  offer_version BIGINT NOT NULL,
+  state TEXT NOT NULL CHECK(state IN ('qualified','pending','rejected','expired')),
+  tuple_key TEXT NOT NULL,
+  protocol TEXT NOT NULL,
+  region TEXT NOT NULL,
+  capabilities_json JSONB NOT NULL CHECK(jsonb_typeof(capabilities_json)='array'),
+  scope TEXT NOT NULL,
+  evidence_ref TEXT,
+  evidence_digest TEXT,
+  reason TEXT,
+  observed_at TIMESTAMPTZ,
+  valid_until TIMESTAMPTZ,
+  sample_count BIGINT NOT NULL DEFAULT 0 CHECK(sample_count>=0),
+  ttft_p95_ms DOUBLE PRECISION CHECK(ttft_p95_ms>0),
+  output_tokens_p5 DOUBLE PRECISION CHECK(output_tokens_p5>0),
+  created_at TIMESTAMPTZ NOT NULL,
+  FOREIGN KEY(offer_id,offer_version) REFERENCES model_api_supplier_offers(id,version) ON DELETE RESTRICT,
+  UNIQUE(id,offer_id,offer_version),
+  CHECK((observed_at IS NULL AND valid_until IS NULL) OR valid_until>observed_at),
+  CHECK(state<>'qualified' OR (evidence_ref IS NOT NULL AND evidence_digest IS NOT NULL AND observed_at IS NOT NULL AND valid_until IS NOT NULL))
+);
+CREATE INDEX model_api_supply_qualifications_offer_idx
+  ON model_api_supply_qualifications(offer_id,offer_version,state,valid_until DESC);
+
+-- Plans persist both the deterministic compiled result and the exact private
+-- inputs used to produce it. The request path consumes a separately published
+-- in-memory snapshot; it does not query these tables.
+CREATE TABLE model_api_supply_plans (
+  id TEXT PRIMARY KEY,
+  operator_tenant_id TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+  managed_product_id TEXT NOT NULL REFERENCES model_api_products(id) ON DELETE RESTRICT,
+  protocol TEXT NOT NULL,
+  schema_version TEXT NOT NULL,
+  digest TEXT NOT NULL UNIQUE,
+  status TEXT NOT NULL CHECK(status IN ('ready','insufficient')),
+  ranking_basis TEXT NOT NULL,
+  request_json JSONB NOT NULL CHECK(jsonb_typeof(request_json)='object'),
+  plan_json JSONB NOT NULL CHECK(jsonb_typeof(plan_json)='object'),
+  generated_at TIMESTAMPTZ NOT NULL,
+  valid_until TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL,
+  UNIQUE(id,managed_product_id),
+  UNIQUE(managed_product_id,operator_tenant_id,id),
+  CHECK((status='ready' AND valid_until>generated_at) OR (status='insufficient' AND valid_until IS NULL))
+);
+CREATE INDEX model_api_supply_plans_operator_product_idx
+  ON model_api_supply_plans(operator_tenant_id,managed_product_id,generated_at DESC);
+
+CREATE TABLE model_api_supply_plan_candidates (
+  plan_id TEXT NOT NULL REFERENCES model_api_supply_plans(id) ON DELETE CASCADE,
+  managed_product_id TEXT NOT NULL,
+  candidate_id TEXT NOT NULL,
+  offer_id TEXT NOT NULL,
+  offer_version BIGINT NOT NULL,
+  qualification_id TEXT,
+  retail_rate_card_id TEXT NOT NULL,
+  retail_rate_version INTEGER NOT NULL CHECK(retail_rate_version>0),
+  disposition TEXT NOT NULL CHECK(disposition IN ('primary','fallback','rejected')),
+  position INTEGER,
+  rejection_reasons_json JSONB NOT NULL DEFAULT '[]'::jsonb CHECK(jsonb_typeof(rejection_reasons_json)='array'),
+  materialization_json JSONB NOT NULL CHECK(jsonb_typeof(materialization_json)='object'),
+  PRIMARY KEY(plan_id,candidate_id),
+  FOREIGN KEY(plan_id,managed_product_id) REFERENCES model_api_supply_plans(id,managed_product_id) ON DELETE CASCADE,
+  FOREIGN KEY(offer_id,offer_version,managed_product_id) REFERENCES model_api_supplier_offers(id,version,managed_product_id) ON DELETE RESTRICT,
+  FOREIGN KEY(qualification_id,offer_id,offer_version) REFERENCES model_api_supply_qualifications(id,offer_id,offer_version) ON DELETE RESTRICT,
+  FOREIGN KEY(managed_product_id,retail_rate_card_id,retail_rate_version)
+    REFERENCES model_api_retail_rate_cards(product_id,id,version) ON DELETE RESTRICT,
+  CHECK((disposition='primary' AND position=0) OR (disposition='fallback' AND position>0) OR (disposition='rejected' AND position IS NULL)),
+  CHECK((disposition='rejected' AND jsonb_array_length(rejection_reasons_json)>0) OR (disposition<>'rejected' AND jsonb_array_length(rejection_reasons_json)=0))
+);
+CREATE INDEX model_api_supply_plan_candidates_offer_idx
+  ON model_api_supply_plan_candidates(offer_id,offer_version,plan_id);
+
+ALTER TABLE model_api_operator_publications
+  ADD CONSTRAINT model_api_operator_publications_supply_plan_fk
+  FOREIGN KEY(product_id,operator_tenant_id,supply_plan_id)
+  REFERENCES model_api_supply_plans(managed_product_id,operator_tenant_id,id)
+  ON DELETE RESTRICT;

--- a/internal/store/migrations/059_model_api_hosted_runtime.sql
+++ b/internal/store/migrations/059_model_api_hosted_runtime.sql
@@ -1,0 +1,62 @@
+-- Request-path accounting for shared hosted Model APIs. Customer identity,
+-- entitlement, and money stay tenant-owned; operator supply references remain
+-- private. Immutable retail prices are copied onto each reservation so later
+-- publication changes cannot alter settlement.
+CREATE TABLE model_api_usage_reservations (
+  id TEXT PRIMARY KEY,
+  customer_tenant_id TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  product_id TEXT NOT NULL REFERENCES model_api_products(id) ON DELETE RESTRICT,
+  entitlement_id TEXT NOT NULL REFERENCES model_api_product_entitlements(id) ON DELETE RESTRICT,
+  operator_tenant_id TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+  serving_plan_id TEXT NOT NULL REFERENCES serving_plans(id) ON DELETE RESTRICT,
+  supply_plan_id TEXT NOT NULL REFERENCES model_api_supply_plans(id) ON DELETE RESTRICT,
+  candidate_id TEXT NOT NULL,
+  offer_id TEXT NOT NULL,
+  offer_version BIGINT NOT NULL CHECK(offer_version>0),
+  supplier TEXT NOT NULL,
+  supplier_model_id TEXT NOT NULL,
+  retail_rate_card_id TEXT NOT NULL,
+  retail_rate_version INTEGER NOT NULL CHECK(retail_rate_version>0),
+  retail_rate_contract_digest TEXT NOT NULL CHECK(retail_rate_contract_digest LIKE 'sha256:%'),
+  input_microusd_per_million BIGINT NOT NULL CHECK(input_microusd_per_million>0),
+  output_microusd_per_million BIGINT NOT NULL CHECK(output_microusd_per_million>0),
+  reserved_microusd BIGINT NOT NULL CHECK(reserved_microusd>0),
+  actual_microusd BIGINT CHECK(actual_microusd IS NULL OR actual_microusd>=0),
+  input_tokens BIGINT CHECK(input_tokens IS NULL OR input_tokens>=0),
+  output_tokens BIGINT CHECK(output_tokens IS NULL OR output_tokens>=0),
+  state TEXT NOT NULL CHECK(state IN ('reserved','transmitted','response_started','settled','released','pending_reconciliation')),
+  resolution TEXT NOT NULL DEFAULT '',
+  transmitted_at TIMESTAMPTZ,
+  response_started_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  FOREIGN KEY(customer_tenant_id,product_id)
+    REFERENCES model_api_product_entitlements(customer_tenant_id,product_id) ON DELETE RESTRICT,
+  FOREIGN KEY(product_id,operator_tenant_id,supply_plan_id)
+    REFERENCES model_api_supply_plans(managed_product_id,operator_tenant_id,id) ON DELETE RESTRICT,
+  FOREIGN KEY(offer_id,offer_version,product_id)
+    REFERENCES model_api_supplier_offers(id,version,managed_product_id) ON DELETE RESTRICT,
+  FOREIGN KEY(product_id,retail_rate_card_id,retail_rate_version)
+    REFERENCES model_api_retail_rate_cards(product_id,id,version) ON DELETE RESTRICT,
+  CHECK(customer_tenant_id<>operator_tenant_id),
+  CHECK(updated_at>=created_at),
+  CHECK(transmitted_at IS NULL OR transmitted_at>=created_at),
+  CHECK(response_started_at IS NULL OR (transmitted_at IS NOT NULL AND response_started_at>=transmitted_at))
+);
+CREATE INDEX model_api_usage_reservations_customer_state_idx
+  ON model_api_usage_reservations(customer_tenant_id,state,created_at DESC);
+CREATE INDEX model_api_usage_reservations_reconciliation_idx
+  ON model_api_usage_reservations(state,updated_at)
+  WHERE state='pending_reconciliation';
+
+CREATE TABLE model_api_usage_ledger (
+  id TEXT PRIMARY KEY,
+  customer_tenant_id TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  reservation_id TEXT NOT NULL REFERENCES model_api_usage_reservations(id) ON DELETE RESTRICT,
+  kind TEXT NOT NULL CHECK(kind='settlement'),
+  currency TEXT NOT NULL DEFAULT 'USD' CHECK(currency='USD'),
+  amount_microusd BIGINT NOT NULL CHECK(amount_microusd<=0),
+  description TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  UNIQUE(customer_tenant_id,reservation_id,kind)
+);

--- a/internal/store/migrations/060_model_api_supply_immutability.sql
+++ b/internal/store/migrations/060_model_api_supply_immutability.sql
@@ -1,0 +1,24 @@
+-- Supplier offers, qualification evidence, and compiled plans are immutable
+-- evidence. Corrections must create a new version/record so a published route
+-- can always be reconstructed and audited against the exact historical input.
+CREATE FUNCTION infercrane_reject_model_api_supply_mutation() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'model API supply evidence is immutable; publish a new version';
+END;
+$$;
+
+CREATE TRIGGER model_api_supplier_offers_immutable
+  BEFORE UPDATE OR DELETE ON model_api_supplier_offers
+  FOR EACH ROW EXECUTE FUNCTION infercrane_reject_model_api_supply_mutation();
+
+CREATE TRIGGER model_api_supply_qualifications_immutable
+  BEFORE UPDATE OR DELETE ON model_api_supply_qualifications
+  FOR EACH ROW EXECUTE FUNCTION infercrane_reject_model_api_supply_mutation();
+
+CREATE TRIGGER model_api_supply_plans_immutable
+  BEFORE UPDATE OR DELETE ON model_api_supply_plans
+  FOR EACH ROW EXECUTE FUNCTION infercrane_reject_model_api_supply_mutation();
+
+CREATE TRIGGER model_api_supply_plan_candidates_immutable
+  BEFORE UPDATE OR DELETE ON model_api_supply_plan_candidates
+  FOR EACH ROW EXECUTE FUNCTION infercrane_reject_model_api_supply_mutation();

--- a/internal/store/model_api_catalog.go
+++ b/internal/store/model_api_catalog.go
@@ -1,0 +1,540 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/modelapiproduct"
+)
+
+const modelAPIProductSelect = `SELECT id,display_name,publisher,description,protocol,tasks_json::text,capability_contract_json::text,input_modalities_json::text,output_modalities_json::text,context_window_tokens,availability,self_host_eligibility FROM model_api_products`
+const modelAPIRateSelect = `SELECT id,product_id,version,currency,input_microusd_per_million,cached_input_microusd_per_million,output_microusd_per_million,valid_from,valid_until,published_at,public_provenance,contract_digest FROM model_api_retail_rate_cards`
+const modelAPIOperatorPublicationSelect = `SELECT product_id,operator_tenant_id,serving_plan_id,supply_plan_id,qualification_state,qualification_evidence_id,qualification_valid_until,active_retail_rate_card_id,updated_at FROM model_api_operator_publications`
+const modelAPIEntitlementSelect = `SELECT id,customer_tenant_id,product_id,operator_tenant_id,serving_plan_id,retail_rate_card_id,retail_rate_version,state,requests_per_minute,tokens_per_minute,monthly_spend_microusd,max_request_microusd,valid_from,valid_until,created_at,updated_at FROM model_api_product_entitlements`
+
+const modelAPIOperatorPublicationForTenantQuery = modelAPIOperatorPublicationSelect + ` WHERE operator_tenant_id=? AND product_id=?`
+const modelAPIEntitlementForTenantQuery = modelAPIEntitlementSelect + ` WHERE customer_tenant_id=? AND product_id=?`
+
+type ModelAPIProductAccess struct {
+	Product     modelapiproduct.PublicProjection               `json:"product"`
+	Entitlement *modelapiproduct.CustomerEntitlementProjection `json:"entitlement,omitempty"`
+	Authorized  bool                                           `json:"authorized"`
+}
+
+// SaveManagedModelAPIProduct persists the supplier-neutral product contract.
+// Moving a product into a callable display state requires an already persisted,
+// current operator publication; catalog metadata alone can never activate it.
+func (s *Store) SaveManagedModelAPIProduct(ctx context.Context, product modelapiproduct.Product) (modelapiproduct.Product, error) {
+	if err := product.Validate(); err != nil {
+		return modelapiproduct.Product{}, err
+	}
+	tasks, capabilities, inputs, outputs, err := encodeModelAPIProductJSON(product)
+	if err != nil {
+		return modelapiproduct.Product{}, err
+	}
+	tx, err := s.beginTx(ctx)
+	if err != nil {
+		return modelapiproduct.Product{}, err
+	}
+	defer tx.Rollback()
+
+	if product.Availability == modelapiproduct.AvailabilityAvailable || product.Availability == modelapiproduct.AvailabilityDegraded {
+		publication, publicationErr := modelAPIOperatorPublicationForProduct(ctx, tx, product.ID)
+		if publicationErr != nil {
+			if errors.Is(publicationErr, ErrNotFound) {
+				return modelapiproduct.Product{}, errors.New("callable product availability requires an operator publication")
+			}
+			return modelapiproduct.Product{}, publicationErr
+		}
+		if err = publication.ValidateAt(product, time.Now().UTC()); err != nil {
+			return modelapiproduct.Product{}, fmt.Errorf("callable product publication is stale or incomplete: %w", err)
+		}
+	}
+
+	stamp := time.Now().UTC()
+	_, err = tx.ExecContext(ctx, `INSERT INTO model_api_products(id,display_name,publisher,description,protocol,tasks_json,capability_contract_json,input_modalities_json,output_modalities_json,context_window_tokens,availability,self_host_eligibility,created_at,updated_at) VALUES(?,?,?,?,?,?::jsonb,?::jsonb,?::jsonb,?::jsonb,?,?,?,?,?) ON CONFLICT(id) DO UPDATE SET display_name=EXCLUDED.display_name,publisher=EXCLUDED.publisher,description=EXCLUDED.description,protocol=EXCLUDED.protocol,tasks_json=EXCLUDED.tasks_json,capability_contract_json=EXCLUDED.capability_contract_json,input_modalities_json=EXCLUDED.input_modalities_json,output_modalities_json=EXCLUDED.output_modalities_json,context_window_tokens=EXCLUDED.context_window_tokens,availability=EXCLUDED.availability,self_host_eligibility=EXCLUDED.self_host_eligibility,updated_at=EXCLUDED.updated_at`,
+		product.ID, product.DisplayName, product.Publisher, product.Description, product.Protocol,
+		tasks, capabilities, inputs, outputs, nullableInt64(product.ContextWindowTokens), product.Availability, product.SelfHostEligibility, stamp, stamp)
+	if err != nil {
+		return modelapiproduct.Product{}, err
+	}
+	if err = tx.Commit(); err != nil {
+		return modelapiproduct.Product{}, err
+	}
+	return s.ManagedModelAPIProduct(ctx, product.ID)
+}
+
+func (s *Store) ManagedModelAPIProduct(ctx context.Context, productID string) (modelapiproduct.Product, error) {
+	if productID == "" {
+		return modelapiproduct.Product{}, errors.New("product id is required")
+	}
+	return scanModelAPIProduct(s.QueryRowContext(ctx, modelAPIProductSelect+` WHERE id=?`, productID))
+}
+
+func (s *Store) ManagedModelAPIProducts(ctx context.Context) ([]modelapiproduct.Product, error) {
+	rows, err := s.QueryContext(ctx, modelAPIProductSelect+` ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	products := make([]modelapiproduct.Product, 0, 6)
+	for rows.Next() {
+		product, scanErr := scanModelAPIProduct(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		products = append(products, product)
+	}
+	return products, rows.Err()
+}
+
+// PublishModelAPIRetailRate inserts one immutable version. Replays of the exact
+// contract are idempotent; conflicting IDs or versions fail without mutation.
+func (s *Store) PublishModelAPIRetailRate(ctx context.Context, rate modelapiproduct.RetailRate) (modelapiproduct.RetailRate, error) {
+	if err := rate.Validate(); err != nil {
+		return modelapiproduct.RetailRate{}, err
+	}
+	// PostgreSQL stores timestamptz at microsecond precision. Reject a contract
+	// that would be rounded on write, because that would invalidate its digest.
+	for _, value := range []time.Time{rate.ValidFrom, rate.ValidUntil, rate.PublishedAt} {
+		if !value.Equal(value.Truncate(time.Microsecond)) {
+			return modelapiproduct.RetailRate{}, errors.New("retail rate timestamps must use PostgreSQL-safe microsecond precision")
+		}
+	}
+	_, err := s.ExecContext(ctx, `INSERT INTO model_api_retail_rate_cards(id,product_id,version,currency,input_microusd_per_million,cached_input_microusd_per_million,output_microusd_per_million,valid_from,valid_until,published_at,public_provenance,contract_digest) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)`,
+		rate.ID, rate.ProductID, rate.Version, rate.Currency, rate.InputMicrousdPerMillion,
+		nullableInt64(rate.CachedInputMicrousdPerMillion), rate.OutputMicrousdPerMillion,
+		rate.ValidFrom.UTC(), rate.ValidUntil.UTC(), rate.PublishedAt.UTC(), rate.PublicProvenance, rate.ContractDigest)
+	if err == nil {
+		return s.ModelAPIRetailRate(ctx, rate.ProductID, rate.Version)
+	}
+	if !isUniqueViolation(err) {
+		return modelapiproduct.RetailRate{}, err
+	}
+	existing, lookupErr := s.ModelAPIRetailRate(ctx, rate.ProductID, rate.Version)
+	if lookupErr == nil && modelAPIRatesEqual(existing, rate) {
+		return existing, nil
+	}
+	return modelapiproduct.RetailRate{}, fmt.Errorf("%w: retail rate id or version already has a different contract", ErrConflict)
+}
+
+func (s *Store) ModelAPIRetailRate(ctx context.Context, productID string, version int) (modelapiproduct.RetailRate, error) {
+	if productID == "" || version <= 0 {
+		return modelapiproduct.RetailRate{}, errors.New("product id and positive retail rate version are required")
+	}
+	return scanModelAPIRetailRate(s.QueryRowContext(ctx, modelAPIRateSelect+` WHERE product_id=? AND version=?`, productID, version))
+}
+
+func (s *Store) CurrentModelAPIRetailRate(ctx context.Context, productID string, at time.Time) (modelapiproduct.RetailRate, error) {
+	if productID == "" || at.IsZero() {
+		return modelapiproduct.RetailRate{}, errors.New("product id and evaluation time are required")
+	}
+	rate, err := scanModelAPIRetailRate(s.QueryRowContext(ctx, modelAPIRateSelect+` WHERE product_id=? AND valid_from<=? AND valid_until>? ORDER BY version DESC LIMIT 1`, productID, at.UTC(), at.UTC()))
+	if err != nil {
+		return modelapiproduct.RetailRate{}, err
+	}
+	if !rate.CurrentAt(at) {
+		return modelapiproduct.RetailRate{}, ErrNotFound
+	}
+	return rate, nil
+}
+
+// SaveModelAPIOperatorPublication is operator-scoped. A second operator cannot
+// take over a product publication, and referenced plans must belong to the same
+// operator and public product.
+func (s *Store) SaveModelAPIOperatorPublication(ctx context.Context, operatorTenant string, publication modelapiproduct.OperatorPublication) (modelapiproduct.OperatorPublication, error) {
+	if operatorTenant == "" || publication.OperatorWorkspaceID != operatorTenant {
+		return modelapiproduct.OperatorPublication{}, errors.New("operator tenant must own the publication")
+	}
+	product, err := s.ManagedModelAPIProduct(ctx, publication.ProductID)
+	if err != nil {
+		return modelapiproduct.OperatorPublication{}, err
+	}
+	publication.UpdatedAt = time.Now().UTC()
+	if err = publication.ValidateAt(product, publication.UpdatedAt); err != nil {
+		return modelapiproduct.OperatorPublication{}, err
+	}
+	tx, err := s.beginTx(ctx)
+	if err != nil {
+		return modelapiproduct.OperatorPublication{}, err
+	}
+	defer tx.Rollback()
+	var planExists bool
+	if err = tx.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM serving_plans WHERE id=? AND tenant_id=?)`, publication.ServingPlanID, operatorTenant).Scan(&planExists); err != nil {
+		return modelapiproduct.OperatorPublication{}, err
+	}
+	if !planExists {
+		return modelapiproduct.OperatorPublication{}, ErrNotFound
+	}
+	var supplyPlanExists bool
+	if err = tx.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM model_api_supply_plans WHERE id=? AND operator_tenant_id=? AND managed_product_id=?)`, publication.SupplyPlanID, operatorTenant, publication.ProductID).Scan(&supplyPlanExists); err != nil {
+		return modelapiproduct.OperatorPublication{}, err
+	}
+	if !supplyPlanExists {
+		return modelapiproduct.OperatorPublication{}, ErrNotFound
+	}
+	if publication.RetailRate != nil {
+		storedRate, rateErr := modelAPIRetailRateByVersion(ctx, tx, publication.ProductID, publication.RetailRate.Version)
+		if rateErr != nil {
+			return modelapiproduct.OperatorPublication{}, rateErr
+		}
+		if !modelAPIRatesEqual(storedRate, *publication.RetailRate) {
+			return modelapiproduct.OperatorPublication{}, fmt.Errorf("%w: publication retail rate does not match the immutable stored contract", ErrConflict)
+		}
+	}
+	var existingOperator sql.NullString
+	err = tx.QueryRowContext(ctx, `SELECT operator_tenant_id FROM model_api_operator_publications WHERE product_id=? FOR UPDATE`, publication.ProductID).Scan(&existingOperator)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return modelapiproduct.OperatorPublication{}, err
+	}
+	if existingOperator.Valid && existingOperator.String != operatorTenant {
+		return modelapiproduct.OperatorPublication{}, fmt.Errorf("%w: product publication belongs to another operator", ErrConflict)
+	}
+	stamp := publication.UpdatedAt
+	result, err := tx.ExecContext(ctx, `INSERT INTO model_api_operator_publications(product_id,operator_tenant_id,serving_plan_id,supply_plan_id,qualification_state,qualification_evidence_id,qualification_valid_until,active_retail_rate_card_id,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?) ON CONFLICT(product_id) DO UPDATE SET serving_plan_id=EXCLUDED.serving_plan_id,supply_plan_id=EXCLUDED.supply_plan_id,qualification_state=EXCLUDED.qualification_state,qualification_evidence_id=EXCLUDED.qualification_evidence_id,qualification_valid_until=EXCLUDED.qualification_valid_until,active_retail_rate_card_id=EXCLUDED.active_retail_rate_card_id,updated_at=EXCLUDED.updated_at WHERE model_api_operator_publications.operator_tenant_id=EXCLUDED.operator_tenant_id`,
+		publication.ProductID, operatorTenant, publication.ServingPlanID, publication.SupplyPlanID,
+		publication.Qualification.State, publication.Qualification.EvidenceID, nullableTime(publication.Qualification.EvidenceUntil),
+		nullableRateID(publication.RetailRate), stamp, stamp)
+	if err != nil {
+		return modelapiproduct.OperatorPublication{}, err
+	}
+	if affected, affectedErr := result.RowsAffected(); affectedErr != nil {
+		return modelapiproduct.OperatorPublication{}, affectedErr
+	} else if affected == 0 {
+		return modelapiproduct.OperatorPublication{}, fmt.Errorf("%w: product publication belongs to another operator", ErrConflict)
+	}
+	if err = tx.Commit(); err != nil {
+		return modelapiproduct.OperatorPublication{}, err
+	}
+	return s.ModelAPIOperatorPublication(ctx, operatorTenant, publication.ProductID)
+}
+
+func (s *Store) ModelAPIOperatorPublication(ctx context.Context, operatorTenant, productID string) (modelapiproduct.OperatorPublication, error) {
+	if operatorTenant == "" || productID == "" {
+		return modelapiproduct.OperatorPublication{}, errors.New("operator tenant and product id are required")
+	}
+	return modelAPIOperatorPublicationFromRow(ctx, s, s.QueryRowContext(ctx, modelAPIOperatorPublicationForTenantQuery, operatorTenant, productID))
+}
+
+// SaveModelAPIProductEntitlement persists the customer-owned authorization to
+// shared operator supply. Active grants must match the current publication,
+// serving plan, and immutable retail rate exactly.
+func (s *Store) SaveModelAPIProductEntitlement(ctx context.Context, customerTenant string, entitlement modelapiproduct.ProductEntitlement) (modelapiproduct.ProductEntitlement, error) {
+	if customerTenant == "" || entitlement.CustomerWorkspaceID != customerTenant {
+		return modelapiproduct.ProductEntitlement{}, errors.New("customer tenant must own the entitlement")
+	}
+	stamp := time.Now().UTC()
+	if entitlement.ID == "" {
+		id, err := newID()
+		if err != nil {
+			return modelapiproduct.ProductEntitlement{}, err
+		}
+		entitlement.ID = id
+	}
+	if entitlement.CreatedAt.IsZero() {
+		entitlement.CreatedAt = stamp
+	}
+	entitlement.UpdatedAt = stamp
+	if err := entitlement.Validate(); err != nil {
+		return modelapiproduct.ProductEntitlement{}, err
+	}
+	product, err := s.ManagedModelAPIProduct(ctx, entitlement.ProductID)
+	if err != nil {
+		return modelapiproduct.ProductEntitlement{}, err
+	}
+	publication, err := s.ModelAPIOperatorPublication(ctx, entitlement.OperatorWorkspaceID, entitlement.ProductID)
+	if err != nil {
+		return modelapiproduct.ProductEntitlement{}, err
+	}
+	if publication.ServingPlanID != entitlement.ServingPlanID || publication.RetailRate == nil || publication.RetailRate.ID != entitlement.RetailRateID || publication.RetailRate.Version != entitlement.RetailRateVersion {
+		return modelapiproduct.ProductEntitlement{}, fmt.Errorf("%w: entitlement does not match the operator publication and retail rate", ErrConflict)
+	}
+	if entitlement.State == modelapiproduct.EntitlementActive {
+		if err = publication.ValidateAt(product, stamp); err != nil || !entitlement.ActiveAt(stamp) {
+			return modelapiproduct.ProductEntitlement{}, errors.New("active entitlement requires a current callable publication and validity window")
+		}
+		projection, projectionErr := modelapiproduct.PublicProjectionAt(product, &publication, stamp)
+		if projectionErr != nil || !projection.Callable {
+			return modelapiproduct.ProductEntitlement{}, errors.New("active entitlement requires a callable public product")
+		}
+	}
+	tx, err := s.beginTx(ctx)
+	if err != nil {
+		return modelapiproduct.ProductEntitlement{}, err
+	}
+	defer tx.Rollback()
+	var existingID string
+	err = tx.QueryRowContext(ctx, `SELECT id FROM model_api_product_entitlements WHERE customer_tenant_id=? AND product_id=? FOR UPDATE`, customerTenant, entitlement.ProductID).Scan(&existingID)
+	if err == nil && existingID != entitlement.ID {
+		return modelapiproduct.ProductEntitlement{}, fmt.Errorf("%w: customer product already has a different entitlement identity", ErrConflict)
+	}
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return modelapiproduct.ProductEntitlement{}, err
+	}
+	result, err := tx.ExecContext(ctx, `INSERT INTO model_api_product_entitlements(id,customer_tenant_id,product_id,operator_tenant_id,serving_plan_id,retail_rate_card_id,retail_rate_version,state,requests_per_minute,tokens_per_minute,monthly_spend_microusd,max_request_microusd,valid_from,valid_until,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(customer_tenant_id,product_id) DO UPDATE SET operator_tenant_id=EXCLUDED.operator_tenant_id,serving_plan_id=EXCLUDED.serving_plan_id,retail_rate_card_id=EXCLUDED.retail_rate_card_id,retail_rate_version=EXCLUDED.retail_rate_version,state=EXCLUDED.state,requests_per_minute=EXCLUDED.requests_per_minute,tokens_per_minute=EXCLUDED.tokens_per_minute,monthly_spend_microusd=EXCLUDED.monthly_spend_microusd,max_request_microusd=EXCLUDED.max_request_microusd,valid_from=EXCLUDED.valid_from,valid_until=EXCLUDED.valid_until,updated_at=EXCLUDED.updated_at WHERE model_api_product_entitlements.id=EXCLUDED.id`,
+		entitlement.ID, customerTenant, entitlement.ProductID, entitlement.OperatorWorkspaceID, entitlement.ServingPlanID,
+		entitlement.RetailRateID, entitlement.RetailRateVersion, entitlement.State,
+		nullableInt64(entitlement.Limits.RequestsPerMinute), nullableInt64(entitlement.Limits.TokensPerMinute),
+		nullableInt64(entitlement.Limits.MonthlySpendMicrousd), nullableInt64(entitlement.Limits.MaxRequestMicrousd),
+		entitlement.ValidFrom.UTC(), nullableTime(entitlement.ValidUntil), entitlement.CreatedAt.UTC(), stamp)
+	if err != nil {
+		return modelapiproduct.ProductEntitlement{}, err
+	}
+	if affected, affectedErr := result.RowsAffected(); affectedErr != nil {
+		return modelapiproduct.ProductEntitlement{}, affectedErr
+	} else if affected == 0 {
+		return modelapiproduct.ProductEntitlement{}, fmt.Errorf("%w: customer product already has a different entitlement identity", ErrConflict)
+	}
+	if err = tx.Commit(); err != nil {
+		return modelapiproduct.ProductEntitlement{}, err
+	}
+	return s.ModelAPIProductEntitlement(ctx, customerTenant, entitlement.ProductID)
+}
+
+func (s *Store) ModelAPIProductEntitlement(ctx context.Context, customerTenant, productID string) (modelapiproduct.ProductEntitlement, error) {
+	if customerTenant == "" || productID == "" {
+		return modelapiproduct.ProductEntitlement{}, errors.New("customer tenant and product id are required")
+	}
+	return scanModelAPIProductEntitlement(s.QueryRowContext(ctx, modelAPIEntitlementForTenantQuery, customerTenant, productID))
+}
+
+func (s *Store) PublicModelAPIProduct(ctx context.Context, productID string, at time.Time) (modelapiproduct.PublicProjection, error) {
+	if productID == "" || at.IsZero() {
+		return modelapiproduct.PublicProjection{}, errors.New("product id and evaluation time are required")
+	}
+	product, err := s.ManagedModelAPIProduct(ctx, productID)
+	if err != nil {
+		return modelapiproduct.PublicProjection{}, err
+	}
+	publication, err := modelAPIOperatorPublicationForProduct(ctx, s, productID)
+	if errors.Is(err, ErrNotFound) {
+		return modelapiproduct.PublicProjectionAt(product, nil, at)
+	}
+	if err != nil {
+		return modelapiproduct.PublicProjection{}, err
+	}
+	return modelapiproduct.PublicProjectionAt(product, &publication, at)
+}
+
+func (s *Store) PublicModelAPIProducts(ctx context.Context, at time.Time) ([]modelapiproduct.PublicProjection, error) {
+	if at.IsZero() {
+		return nil, errors.New("evaluation time is required")
+	}
+	products, err := s.ManagedModelAPIProducts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	projections := make([]modelapiproduct.PublicProjection, 0, len(products))
+	for _, product := range products {
+		projection, projectionErr := s.PublicModelAPIProduct(ctx, product.ID, at)
+		if projectionErr != nil {
+			return nil, projectionErr
+		}
+		projections = append(projections, projection)
+	}
+	return projections, nil
+}
+
+// ModelAPIProductAccess combines only customer-safe projections. Internal plan
+// references never leave the repository through this result.
+func (s *Store) ModelAPIProductAccess(ctx context.Context, customerTenant, productID string, at time.Time) (ModelAPIProductAccess, error) {
+	product, err := s.PublicModelAPIProduct(ctx, productID, at)
+	if err != nil {
+		return ModelAPIProductAccess{}, err
+	}
+	access := ModelAPIProductAccess{Product: product}
+	entitlement, err := s.ModelAPIProductEntitlement(ctx, customerTenant, productID)
+	if errors.Is(err, ErrNotFound) {
+		return access, nil
+	}
+	if err != nil {
+		return ModelAPIProductAccess{}, err
+	}
+	projection, err := entitlement.CustomerProjection()
+	if err != nil {
+		return ModelAPIProductAccess{}, err
+	}
+	access.Entitlement = &projection
+	access.Authorized = product.Callable && entitlement.ActiveAt(at) && product.RetailRate != nil && product.RetailRate.ID == entitlement.RetailRateID && product.RetailRate.Version == entitlement.RetailRateVersion
+	return access, nil
+}
+
+type modelAPICatalogQueryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+type modelAPIRowScanner interface {
+	Scan(...any) error
+}
+
+func scanModelAPIProduct(row modelAPIRowScanner) (modelapiproduct.Product, error) {
+	product := modelapiproduct.Product{SchemaVersion: modelapiproduct.ProductSchemaVersion}
+	var tasksJSON, capabilitiesJSON, inputsJSON, outputsJSON string
+	var contextTokens sql.NullInt64
+	err := row.Scan(&product.ID, &product.DisplayName, &product.Publisher, &product.Description, &product.Protocol,
+		&tasksJSON, &capabilitiesJSON, &inputsJSON, &outputsJSON, &contextTokens, &product.Availability, &product.SelfHostEligibility)
+	if errors.Is(err, sql.ErrNoRows) {
+		return modelapiproduct.Product{}, ErrNotFound
+	}
+	if err != nil {
+		return modelapiproduct.Product{}, err
+	}
+	if err = json.Unmarshal([]byte(tasksJSON), &product.Tasks); err != nil {
+		return modelapiproduct.Product{}, fmt.Errorf("decode model API product tasks: %w", err)
+	}
+	if err = json.Unmarshal([]byte(capabilitiesJSON), &product.Capabilities); err != nil {
+		return modelapiproduct.Product{}, fmt.Errorf("decode model API product capabilities: %w", err)
+	}
+	if err = json.Unmarshal([]byte(inputsJSON), &product.InputModalities); err != nil {
+		return modelapiproduct.Product{}, fmt.Errorf("decode model API product input modalities: %w", err)
+	}
+	if err = json.Unmarshal([]byte(outputsJSON), &product.OutputModalities); err != nil {
+		return modelapiproduct.Product{}, fmt.Errorf("decode model API product output modalities: %w", err)
+	}
+	if contextTokens.Valid {
+		product.ContextWindowTokens = &contextTokens.Int64
+	}
+	if err = product.Validate(); err != nil {
+		return modelapiproduct.Product{}, fmt.Errorf("stored model API product is invalid: %w", err)
+	}
+	return product, nil
+}
+
+func scanModelAPIRetailRate(row modelAPIRowScanner) (modelapiproduct.RetailRate, error) {
+	var rate modelapiproduct.RetailRate
+	var cached sql.NullInt64
+	err := row.Scan(&rate.ID, &rate.ProductID, &rate.Version, &rate.Currency, &rate.InputMicrousdPerMillion,
+		&cached, &rate.OutputMicrousdPerMillion, &rate.ValidFrom, &rate.ValidUntil, &rate.PublishedAt,
+		&rate.PublicProvenance, &rate.ContractDigest)
+	if errors.Is(err, sql.ErrNoRows) {
+		return modelapiproduct.RetailRate{}, ErrNotFound
+	}
+	if err != nil {
+		return modelapiproduct.RetailRate{}, err
+	}
+	if cached.Valid {
+		rate.CachedInputMicrousdPerMillion = &cached.Int64
+	}
+	if err = rate.Validate(); err != nil {
+		return modelapiproduct.RetailRate{}, fmt.Errorf("stored model API retail rate is invalid: %w", err)
+	}
+	return rate, nil
+}
+
+func scanModelAPIProductEntitlement(row modelAPIRowScanner) (modelapiproduct.ProductEntitlement, error) {
+	entitlement := modelapiproduct.ProductEntitlement{SchemaVersion: modelapiproduct.EntitlementSchemaVersion}
+	var requests, tokens, monthly, maximum sql.NullInt64
+	var validUntil sql.NullTime
+	err := row.Scan(&entitlement.ID, &entitlement.CustomerWorkspaceID, &entitlement.ProductID, &entitlement.OperatorWorkspaceID,
+		&entitlement.ServingPlanID, &entitlement.RetailRateID, &entitlement.RetailRateVersion, &entitlement.State,
+		&requests, &tokens, &monthly, &maximum, &entitlement.ValidFrom, &validUntil, &entitlement.CreatedAt, &entitlement.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return modelapiproduct.ProductEntitlement{}, ErrNotFound
+	}
+	if err != nil {
+		return modelapiproduct.ProductEntitlement{}, err
+	}
+	entitlement.Limits = modelapiproduct.CustomerLimits{
+		RequestsPerMinute: nullableInt64Pointer(requests), TokensPerMinute: nullableInt64Pointer(tokens),
+		MonthlySpendMicrousd: nullableInt64Pointer(monthly), MaxRequestMicrousd: nullableInt64Pointer(maximum),
+	}
+	if validUntil.Valid {
+		value := validUntil.Time.UTC()
+		entitlement.ValidUntil = &value
+	}
+	if err = entitlement.Validate(); err != nil {
+		return modelapiproduct.ProductEntitlement{}, fmt.Errorf("stored model API entitlement is invalid: %w", err)
+	}
+	return entitlement, nil
+}
+
+func modelAPIOperatorPublicationForProduct(ctx context.Context, query modelAPICatalogQueryer, productID string) (modelapiproduct.OperatorPublication, error) {
+	return modelAPIOperatorPublicationFromRow(ctx, query, query.QueryRowContext(ctx, modelAPIOperatorPublicationSelect+` WHERE product_id=?`, productID))
+}
+
+func modelAPIOperatorPublicationFromRow(ctx context.Context, query modelAPICatalogQueryer, row modelAPIRowScanner) (modelapiproduct.OperatorPublication, error) {
+	publication := modelapiproduct.OperatorPublication{SchemaVersion: modelapiproduct.OperatorProjectionSchemaVersion}
+	var evidenceUntil sql.NullTime
+	var rateID sql.NullString
+	err := row.Scan(&publication.ProductID, &publication.OperatorWorkspaceID, &publication.ServingPlanID, &publication.SupplyPlanID,
+		&publication.Qualification.State, &publication.Qualification.EvidenceID, &evidenceUntil, &rateID, &publication.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return modelapiproduct.OperatorPublication{}, ErrNotFound
+	}
+	if err != nil {
+		return modelapiproduct.OperatorPublication{}, err
+	}
+	if evidenceUntil.Valid {
+		value := evidenceUntil.Time.UTC()
+		publication.Qualification.EvidenceUntil = &value
+	}
+	if rateID.Valid {
+		rate, rateErr := scanModelAPIRetailRate(query.QueryRowContext(ctx, modelAPIRateSelect+` WHERE id=? AND product_id=?`, rateID.String, publication.ProductID))
+		if rateErr != nil {
+			return modelapiproduct.OperatorPublication{}, rateErr
+		}
+		publication.RetailRate = &rate
+	}
+	return publication, nil
+}
+
+func modelAPIRetailRateByVersion(ctx context.Context, query modelAPICatalogQueryer, productID string, version int) (modelapiproduct.RetailRate, error) {
+	return scanModelAPIRetailRate(query.QueryRowContext(ctx, modelAPIRateSelect+` WHERE product_id=? AND version=?`, productID, version))
+}
+
+func encodeModelAPIProductJSON(product modelapiproduct.Product) (string, string, string, string, error) {
+	values := []any{product.Tasks, product.Capabilities, product.InputModalities, product.OutputModalities}
+	encoded := make([]string, len(values))
+	for index, value := range values {
+		body, err := json.Marshal(value)
+		if err != nil {
+			return "", "", "", "", err
+		}
+		encoded[index] = string(body)
+	}
+	return encoded[0], encoded[1], encoded[2], encoded[3], nil
+}
+
+func modelAPIRatesEqual(left, right modelapiproduct.RetailRate) bool {
+	return left.ID == right.ID && left.ProductID == right.ProductID && left.Version == right.Version && left.Currency == right.Currency &&
+		left.InputMicrousdPerMillion == right.InputMicrousdPerMillion && equalOptionalInt64(left.CachedInputMicrousdPerMillion, right.CachedInputMicrousdPerMillion) &&
+		left.OutputMicrousdPerMillion == right.OutputMicrousdPerMillion && left.ValidFrom.Equal(right.ValidFrom) && left.ValidUntil.Equal(right.ValidUntil) &&
+		left.PublishedAt.Equal(right.PublishedAt) && left.PublicProvenance == right.PublicProvenance && left.ContractDigest == right.ContractDigest
+}
+
+func equalOptionalInt64(left, right *int64) bool {
+	return left == nil && right == nil || left != nil && right != nil && *left == *right
+}
+
+func nullableInt64(value *int64) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func nullableInt64Pointer(value sql.NullInt64) *int64 {
+	if !value.Valid {
+		return nil
+	}
+	copy := value.Int64
+	return &copy
+}
+
+func nullableTime(value *time.Time) any {
+	if value == nil {
+		return nil
+	}
+	return value.UTC()
+}
+
+func nullableRateID(rate *modelapiproduct.RetailRate) any {
+	if rate == nil {
+		return nil
+	}
+	return rate.ID
+}

--- a/internal/store/model_api_catalog_test.go
+++ b/internal/store/model_api_catalog_test.go
@@ -1,0 +1,254 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/domain"
+	"github.com/infercrane/infercrane/internal/modelapiproduct"
+)
+
+func TestModelAPICatalogQueriesKeepPrivateReadsTenantScoped(t *testing.T) {
+	for name, test := range map[string]struct {
+		query string
+		want  []string
+	}{
+		"operator publication": {modelAPIOperatorPublicationForTenantQuery, []string{"operator_tenant_id=?", "product_id=?"}},
+		"customer entitlement": {modelAPIEntitlementForTenantQuery, []string{"customer_tenant_id=?", "product_id=?"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			for _, predicate := range test.want {
+				if !strings.Contains(test.query, predicate) {
+					t.Fatalf("private query is missing isolation predicate %q: %s", predicate, test.query)
+				}
+			}
+		})
+	}
+}
+
+func TestModelAPICatalogRepositoryRejectsCrossTenantInputsBeforeDatabaseAccess(t *testing.T) {
+	store := &Store{}
+	if _, err := store.SaveModelAPIOperatorPublication(context.Background(), "operator-a", modelapiproduct.OperatorPublication{OperatorWorkspaceID: "operator-b"}); err == nil {
+		t.Fatal("operator mismatch must fail before database access")
+	}
+	if _, err := store.SaveModelAPIProductEntitlement(context.Background(), "customer-a", modelapiproduct.ProductEntitlement{CustomerWorkspaceID: "customer-b"}); err == nil {
+		t.Fatal("customer mismatch must fail before database access")
+	}
+	if _, err := store.CurrentModelAPIRetailRate(context.Background(), "glm-5.3", time.Time{}); err == nil {
+		t.Fatal("zero evaluation time must fail before database access")
+	}
+	stamp := time.Date(2030, 1, 1, 0, 0, 0, 123, time.UTC)
+	rate, err := modelapiproduct.NewRetailRate(modelapiproduct.RetailRateDraft{
+		ID: "rate-1", ProductID: "glm-5.3", Version: 1,
+		InputMicrousdPerMillion: 1, OutputMicrousdPerMillion: 1,
+		PublishedAt: stamp, ValidFrom: stamp.Add(time.Hour), ValidUntil: stamp.Add(2 * time.Hour), PublicProvenance: "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = store.PublishModelAPIRetailRate(context.Background(), rate); err == nil || !strings.Contains(err.Error(), "microsecond") {
+		t.Fatalf("sub-microsecond immutable rate was not rejected before database access: %v", err)
+	}
+}
+
+func TestModelAPICatalogRepositoryPersistsRedactsAndFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	s := openStore(t, ctx)
+	suffix := strings.ReplaceAll(time.Now().UTC().Format("150405.000000000"), ".", "-")
+	operatorTenant := "model-api-operator-" + suffix
+	otherOperator := "model-api-other-operator-" + suffix
+	customerTenant := "model-api-customer-" + suffix
+	otherCustomer := "model-api-other-customer-" + suffix
+	for _, tenant := range []string{operatorTenant, otherOperator, customerTenant, otherCustomer} {
+		if err := s.CreateTenant(ctx, tenant, tenant); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	product, err := s.ManagedModelAPIProduct(ctx, "glm-5.3-flash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A previous interrupted integration test must not leave the global seeded
+	// product callable for this isolated scenario.
+	product.Availability = modelapiproduct.AvailabilityCatalogOnly
+	if product, err = s.SaveManagedModelAPIProduct(ctx, product); err != nil {
+		t.Fatal(err)
+	}
+	product.Availability = modelapiproduct.AvailabilityAvailable
+	if _, err = s.SaveManagedModelAPIProduct(ctx, product); err == nil {
+		t.Fatal("product became available without an operator publication")
+	}
+	product.Availability = modelapiproduct.AvailabilityCatalogOnly
+	t.Cleanup(func() {
+		product.Availability = modelapiproduct.AvailabilityCatalogOnly
+		if _, cleanupErr := s.SaveManagedModelAPIProduct(context.Background(), product); cleanupErr != nil {
+			t.Errorf("restore catalog-only product: %v", cleanupErr)
+		}
+	})
+
+	target, err := s.AddTargetForTenant(ctx, operatorTenant, domain.Target{
+		Name: "model-api-target-" + suffix, URL: "http://model-api-" + suffix + ":8000",
+		Provider: "existing", Runtime: "vllm", UpstreamModel: product.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment, err := s.ApplyDeploymentForTenant(ctx, operatorTenant, domain.Deployment{Name: "model-api-deployment-" + suffix, Model: product.ID}, []string{target.Name})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var servingPlanID string
+	if err = s.QueryRowContext(ctx, `SELECT active_serving_plan_id FROM endpoints WHERE tenant_id=? AND id=?`, operatorTenant, deployment.ID+"-endpoint").Scan(&servingPlanID); err != nil {
+		t.Fatal(err)
+	}
+
+	var version int
+	if err = s.QueryRowContext(ctx, `SELECT COALESCE(MAX(version),0)+1 FROM model_api_retail_rate_cards WHERE product_id=?`, product.ID).Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	capabilityUntil := now.Add(time.Hour)
+	for index := range product.Capabilities {
+		if product.Capabilities[index].Name == "chat-completions" || product.Capabilities[index].Name == "streaming" {
+			product.Capabilities[index].State = modelapiproduct.ClaimQualified
+			product.Capabilities[index].EvidenceID = "capability-evidence-" + product.Capabilities[index].Name + "-" + suffix
+			product.Capabilities[index].EvidenceUntil = &capabilityUntil
+		}
+	}
+	if product, err = s.SaveManagedModelAPIProduct(ctx, product); err != nil {
+		t.Fatal(err)
+	}
+	rate, err := modelapiproduct.NewRetailRate(modelapiproduct.RetailRateDraft{
+		ID: product.ID + "-rate-" + fmt.Sprint(version), ProductID: product.ID, Version: version,
+		InputMicrousdPerMillion: 100_000, OutputMicrousdPerMillion: 400_000,
+		PublishedAt: now.Add(-2 * time.Hour), ValidFrom: now.Add(-time.Hour), ValidUntil: now.Add(2 * time.Hour),
+		PublicProvenance: "InferCrane integration-test retail rate",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	storedRate, err := s.PublishModelAPIRetailRate(ctx, rate)
+	if err != nil || storedRate.ContractDigest != rate.ContractDigest {
+		t.Fatalf("publish rate=%+v err=%v", storedRate, err)
+	}
+	replayedRate, err := s.PublishModelAPIRetailRate(ctx, rate)
+	if err != nil || replayedRate.ID != storedRate.ID {
+		t.Fatalf("idempotent rate replay=%+v err=%v", replayedRate, err)
+	}
+	currentRate, err := s.CurrentModelAPIRetailRate(ctx, product.ID, now)
+	if err != nil || currentRate.ID != storedRate.ID {
+		t.Fatalf("current rate=%+v err=%v", currentRate, err)
+	}
+	if _, err = s.CurrentModelAPIRetailRate(ctx, product.ID, rate.ValidUntil); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expired current rate error=%v, want not found", err)
+	}
+	if _, err = s.ExecContext(ctx, `UPDATE model_api_retail_rate_cards SET output_microusd_per_million=output_microusd_per_million+1 WHERE id=?`, rate.ID); err == nil {
+		t.Fatal("immutable retail rate accepted an update")
+	}
+
+	supplyPlanID := "model-api-supply-plan-" + suffix
+	if _, err = s.ExecContext(ctx, `INSERT INTO model_api_supply_plans(id,operator_tenant_id,managed_product_id,protocol,schema_version,digest,status,ranking_basis,request_json,plan_json,generated_at,created_at) VALUES(?,?,?,?,?,?, 'ready','test','{}'::jsonb,'{}'::jsonb,?,?)`,
+		supplyPlanID, operatorTenant, product.ID, product.Protocol, "managed-model-supply-plan/v1", "sha256:test-"+suffix, now, now); err != nil {
+		t.Fatal(err)
+	}
+	evidenceUntil := now.Add(time.Hour)
+	publication := modelapiproduct.OperatorPublication{
+		SchemaVersion: modelapiproduct.OperatorProjectionSchemaVersion,
+		ProductID:     product.ID, OperatorWorkspaceID: operatorTenant, ServingPlanID: servingPlanID, SupplyPlanID: supplyPlanID,
+		Qualification: modelapiproduct.RouteQualification{State: modelapiproduct.QualificationQualified, EvidenceID: "private-evidence-" + suffix, EvidenceUntil: &evidenceUntil},
+		RetailRate:    &storedRate,
+	}
+	publication, err = s.SaveModelAPIOperatorPublication(ctx, operatorTenant, publication)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if publication.OperatorWorkspaceID != operatorTenant || publication.RetailRate == nil || publication.RetailRate.ID != rate.ID {
+		t.Fatalf("stored operator publication=%+v", publication)
+	}
+	if _, err = s.ModelAPIOperatorPublication(ctx, otherOperator, product.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("other operator read error=%v, want not found", err)
+	}
+	takeover := publication
+	takeover.OperatorWorkspaceID = otherOperator
+	if _, err = s.SaveModelAPIOperatorPublication(ctx, otherOperator, takeover); !errors.Is(err, ErrNotFound) && !errors.Is(err, ErrConflict) {
+		t.Fatalf("cross-operator publication takeover error=%v", err)
+	}
+
+	product.Availability = modelapiproduct.AvailabilityAvailable
+	product, err = s.SaveManagedModelAPIProduct(ctx, product)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projection, err := s.PublicModelAPIProduct(ctx, product.ID, now)
+	if err != nil || !projection.Callable || projection.RetailRate == nil {
+		t.Fatalf("public projection=%+v err=%v", projection, err)
+	}
+	publicJSON, err := json.Marshal(projection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, private := range []string{operatorTenant, servingPlanID, supplyPlanID, publication.Qualification.EvidenceID} {
+		if strings.Contains(string(publicJSON), private) {
+			t.Fatalf("public projection leaked %q: %s", private, publicJSON)
+		}
+	}
+
+	rpm, monthly, maximum := int64(60), int64(10_000_000), int64(100_000)
+	entitlement := modelapiproduct.ProductEntitlement{
+		SchemaVersion:       modelapiproduct.EntitlementSchemaVersion,
+		CustomerWorkspaceID: customerTenant, ProductID: product.ID,
+		OperatorWorkspaceID: operatorTenant, ServingPlanID: servingPlanID,
+		RetailRateID: rate.ID, RetailRateVersion: rate.Version, State: modelapiproduct.EntitlementActive,
+		Limits:    modelapiproduct.CustomerLimits{RequestsPerMinute: &rpm, MonthlySpendMicrousd: &monthly, MaxRequestMicrousd: &maximum},
+		ValidFrom: now.Add(-time.Minute),
+	}
+	entitlement, err = s.SaveModelAPIProductEntitlement(ctx, customerTenant, entitlement)
+	if err != nil || entitlement.ID == "" {
+		t.Fatalf("entitlement=%+v err=%v", entitlement, err)
+	}
+	if _, err = s.ModelAPIProductEntitlement(ctx, otherCustomer, product.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("other customer read error=%v, want not found", err)
+	}
+	crossTenant := entitlement
+	crossTenant.CustomerWorkspaceID = customerTenant
+	if _, err = s.SaveModelAPIProductEntitlement(ctx, otherCustomer, crossTenant); err == nil {
+		t.Fatal("cross-customer entitlement write succeeded")
+	}
+	access, err := s.ModelAPIProductAccess(ctx, customerTenant, product.ID, now)
+	if err != nil || !access.Authorized || access.Entitlement == nil {
+		t.Fatalf("customer access=%+v err=%v", access, err)
+	}
+	accessJSON, err := json.Marshal(access)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, private := range []string{operatorTenant, servingPlanID, supplyPlanID, publication.Qualification.EvidenceID} {
+		if strings.Contains(string(accessJSON), private) {
+			t.Fatalf("customer access leaked %q: %s", private, accessJSON)
+		}
+	}
+	otherAccess, err := s.ModelAPIProductAccess(ctx, otherCustomer, product.ID, now)
+	if err != nil || otherAccess.Authorized || otherAccess.Entitlement != nil {
+		t.Fatalf("other customer access=%+v err=%v", otherAccess, err)
+	}
+
+	// Stale evidence can exist in storage during an incident, but public and
+	// customer reads must immediately stop authorizing traffic.
+	if _, err = s.ExecContext(ctx, `UPDATE model_api_operator_publications SET qualification_valid_until=? WHERE product_id=? AND operator_tenant_id=?`, now.Add(-time.Second), product.ID, operatorTenant); err != nil {
+		t.Fatal(err)
+	}
+	staleProjection, err := s.PublicModelAPIProduct(ctx, product.ID, now)
+	if err != nil || staleProjection.Callable || staleProjection.Availability != modelapiproduct.AvailabilityUnavailable || staleProjection.RetailRate == nil {
+		t.Fatalf("stale public projection=%+v err=%v", staleProjection, err)
+	}
+	staleAccess, err := s.ModelAPIProductAccess(ctx, customerTenant, product.ID, now)
+	if err != nil || staleAccess.Authorized {
+		t.Fatalf("stale customer access=%+v err=%v", staleAccess, err)
+	}
+}

--- a/internal/store/model_api_route_publication.go
+++ b/internal/store/model_api_route_publication.go
@@ -1,0 +1,280 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/modelapiproduct"
+	"github.com/infercrane/infercrane/internal/modelapirouting"
+	"github.com/infercrane/infercrane/internal/modelapisupply"
+)
+
+// PublishedModelAPIRoutes compiles the complete secret-free hosted routing
+// generation. It intentionally fails the whole generation when any active
+// entitlement points at stale or mismatched control-plane evidence.
+func (s *Store) PublishedModelAPIRoutes(ctx context.Context, at time.Time) ([]modelapirouting.RouteSource, error) {
+	if at.IsZero() {
+		return nil, errors.New("route publication time is required")
+	}
+	at = at.UTC()
+	inner, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return nil, err
+	}
+	tx := &tx{inner}
+	defer tx.Rollback()
+	rows, err := tx.QueryContext(ctx, `SELECT
+		e.id,e.customer_tenant_id,e.product_id,e.operator_tenant_id,e.serving_plan_id,e.retail_rate_card_id,e.retail_rate_version,e.state,e.requests_per_minute,e.tokens_per_minute,e.monthly_spend_microusd,e.max_request_microusd,e.valid_from,e.valid_until,
+		p.supply_plan_id,p.qualification_state,p.qualification_evidence_id,p.qualification_valid_until,p.active_retail_rate_card_id,
+		m.protocol,m.capability_contract_json::text,m.availability,
+		r.contract_digest,r.input_microusd_per_million,r.cached_input_microusd_per_million,r.output_microusd_per_million,r.valid_from,r.valid_until,
+		sp.protocol,sp.schema_version,sp.digest,sp.status,sp.plan_json::text,sp.generated_at,sp.valid_until
+	FROM model_api_product_entitlements e
+	JOIN model_api_operator_publications p ON p.product_id=e.product_id AND p.operator_tenant_id=e.operator_tenant_id AND p.serving_plan_id=e.serving_plan_id
+	JOIN model_api_products m ON m.id=e.product_id
+	JOIN model_api_retail_rate_cards r ON r.product_id=e.product_id AND r.id=e.retail_rate_card_id AND r.version=e.retail_rate_version
+	JOIN model_api_supply_plans sp ON sp.id=p.supply_plan_id AND sp.managed_product_id=e.product_id AND sp.operator_tenant_id=e.operator_tenant_id
+	WHERE e.state='active' ORDER BY e.customer_tenant_id,e.product_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	type draft struct {
+		source     modelapirouting.RouteSource
+		operations []string
+		plan       modelapisupply.Plan
+	}
+	drafts := make([]draft, 0)
+	for rows.Next() {
+		var source modelapirouting.RouteSource
+		var entitlementUntil, publicationUntil, planUntil sql.NullTime
+		var cachedInput sql.NullInt64
+		var requestsPerMinute, tokensPerMinute, monthlySpend, maxRequestValue sql.NullInt64
+		var publicationState, activeRateID, productProtocol, capabilitiesJSON, availability string
+		var planProtocol, planSchema, planDigest, planStatus, planJSON string
+		var generatedAt time.Time
+		if err = rows.Scan(
+			&source.Entitlement.ID, &source.Entitlement.CustomerTenantID, &source.Entitlement.ProductID, &source.Entitlement.OperatorTenantID,
+			&source.Entitlement.ServingPlanID, &source.Entitlement.RetailRateID, &source.Entitlement.RetailRateVersion, &source.Entitlement.State,
+			&requestsPerMinute, &tokensPerMinute, &monthlySpend, &maxRequestValue, &source.Entitlement.ValidFrom, &entitlementUntil,
+			&source.Publication.SupplyPlanID, &publicationState, &source.Publication.EvidenceID, &publicationUntil, &activeRateID,
+			&productProtocol, &capabilitiesJSON, &availability,
+			&source.Rate.ContractDigest, &source.Rate.InputMicrousdPerMillion, &cachedInput, &source.Rate.OutputMicrousdPerMillion, &source.Rate.ValidFrom, &source.Rate.ValidUntil,
+			&planProtocol, &planSchema, &planDigest, &planStatus, &planJSON, &generatedAt, &planUntil,
+		); err != nil {
+			return nil, err
+		}
+		source.Publication.ProductID = source.Entitlement.ProductID
+		source.Publication.OperatorTenantID = source.Entitlement.OperatorTenantID
+		source.Publication.ServingPlanID = source.Entitlement.ServingPlanID
+		source.Rate.ID, source.Rate.ProductID, source.Rate.Version = source.Entitlement.RetailRateID, source.Entitlement.ProductID, source.Entitlement.RetailRateVersion
+		if maxRequestValue.Valid {
+			source.Entitlement.MaxRequestMicrousd = maxRequestValue.Int64
+		}
+		if entitlementUntil.Valid {
+			value := entitlementUntil.Time.UTC()
+			source.Entitlement.ValidUntil = &value
+		}
+		if cachedInput.Valid {
+			value := cachedInput.Int64
+			source.Rate.CachedInputMicrousdPerMillion = &value
+		}
+		var claims []modelapiproduct.CapabilityClaim
+		if json.Unmarshal([]byte(capabilitiesJSON), &claims) != nil {
+			return nil, fmt.Errorf("hosted product %q has invalid capability contract", source.Entitlement.ProductID)
+		}
+		operations, capabilityUntil, operationErr := qualifiedOperations(claims, at)
+		if operationErr != nil {
+			return nil, fmt.Errorf("hosted product %q: %w", source.Entitlement.ProductID, operationErr)
+		}
+		if requestsPerMinute.Valid || tokensPerMinute.Valid || monthlySpend.Valid || source.Entitlement.MaxRequestMicrousd <= 0 || source.Rate.CachedInputMicrousdPerMillion != nil ||
+			publicationState != "qualified" || !publicationUntil.Valid || !at.Before(publicationUntil.Time.UTC()) || activeRateID != source.Rate.ID ||
+			productProtocol != "openai" || (availability != "available" && availability != "degraded") || planProtocol != "openai" || planSchema != modelapisupply.SchemaVersion ||
+			planStatus != modelapisupply.StatusReady || !planUntil.Valid || !at.Before(planUntil.Time.UTC()) || at.Before(source.Entitlement.ValidFrom.UTC()) ||
+			(source.Entitlement.ValidUntil != nil && !at.Before(source.Entitlement.ValidUntil.UTC())) || at.Before(source.Rate.ValidFrom.UTC()) || !at.Before(source.Rate.ValidUntil.UTC()) {
+			return nil, fmt.Errorf("hosted product %q has stale or incompatible publication, entitlement, plan, or rate", source.Entitlement.ProductID)
+		}
+		var plan modelapisupply.Plan
+		if json.Unmarshal([]byte(planJSON), &plan) != nil || plan.Digest != planDigest || !plan.HasCanonicalDigest() || plan.SchemaVersion != planSchema || plan.ModelID != source.Entitlement.ProductID ||
+			plan.Protocol != planProtocol || plan.Status != modelapisupply.StatusReady || plan.Primary == nil || !plan.ValidUntil.Equal(planUntil.Time.UTC()) || !generatedAt.UTC().Equal(plan.GeneratedAt.UTC()) {
+			return nil, fmt.Errorf("hosted product %q supply plan materialization does not match its persisted contract", source.Entitlement.ProductID)
+		}
+		source.Publication.ValidUntil = earliestTime(publicationUntil.Time, source.Rate.ValidUntil, planUntil.Time, capabilityUntil)
+		source.Publication.EvidenceValidUntil = publicationUntil.Time.UTC()
+		drafts = append(drafts, draft{source: source, operations: operations, plan: plan})
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	if err = rows.Close(); err != nil {
+		return nil, err
+	}
+	sources := make([]modelapirouting.RouteSource, 0, len(drafts))
+	for _, item := range drafts {
+		source := item.source
+		source.Candidates, err = publishedModelAPICandidates(ctx, tx, at, source, item.operations, item.plan)
+		if err != nil {
+			return nil, err
+		}
+		if len(source.Candidates) == 0 {
+			return nil, fmt.Errorf("hosted product %q has no qualified supply candidate", source.Entitlement.ProductID)
+		}
+		source.Publication.CompatibilityKey = source.Candidates[0].Candidate.CompatibilityKey
+		sources = append(sources, source)
+	}
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+	return sources, nil
+}
+
+func publishedModelAPICandidates(ctx context.Context, tx *tx, at time.Time, source modelapirouting.RouteSource, operations []string, plan modelapisupply.Plan) ([]modelapirouting.CandidateSource, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT c.candidate_id,c.offer_id,c.offer_version,c.qualification_id,c.retail_rate_card_id,c.retail_rate_version,c.disposition,c.position,
+		o.supplier,o.adapter,o.supplier_model_id,o.protocol,o.tuple_key,o.region,o.credential_reference,o.state,o.capabilities_json::text,o.access_state,o.availability_state,o.health_state,o.observed_at,o.cost_valid_until,o.commercial_state,o.commercial_valid_until,
+		q.id,q.state,q.tuple_key,q.protocol,q.region,q.capabilities_json::text,q.evidence_ref,q.evidence_digest,q.observed_at,q.valid_until
+	FROM model_api_supply_plan_candidates c
+	JOIN model_api_supplier_offers o ON o.id=c.offer_id AND o.version=c.offer_version AND o.managed_product_id=c.managed_product_id
+	JOIN model_api_supply_qualifications q ON q.id=c.qualification_id AND q.offer_id=c.offer_id AND q.offer_version=c.offer_version
+	WHERE c.plan_id=? AND c.managed_product_id=? AND c.disposition IN ('primary','fallback')
+	ORDER BY c.position`, source.Publication.SupplyPlanID, source.Entitlement.ProductID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	candidates := make([]modelapirouting.CandidateSource, 0)
+	for rows.Next() {
+		var item modelapirouting.CandidateSource
+		var candidateRateVersion int
+		var qualificationID, rateID, disposition, offerState, access, availability, health, qualificationState string
+		var region, offerCapabilitiesJSON, qualificationTuple, qualificationProtocol, qualificationRegion, qualificationCapabilitiesJSON string
+		var evidenceRef, evidenceDigest sql.NullString
+		var position int
+		var observed, costUntil, commercialUntil, qualificationObserved, qualificationUntil sql.NullTime
+		var commercialState string
+		candidate := &item.Candidate
+		if err = rows.Scan(&candidate.ID, &candidate.OfferID, &candidate.OfferVersion, &qualificationID, &rateID, &candidateRateVersion, &disposition, &position,
+			&candidate.Supplier, &item.Adapter, &candidate.SupplierModelID, &candidate.Protocol, &candidate.CompatibilityKey, &region, &item.CredentialReference, &offerState, &offerCapabilitiesJSON, &access, &availability, &health, &observed, &costUntil, &commercialState, &commercialUntil,
+			&candidate.QualificationEvidenceID, &qualificationState, &qualificationTuple, &qualificationProtocol, &qualificationRegion, &qualificationCapabilitiesJSON, &evidenceRef, &evidenceDigest, &qualificationObserved, &qualificationUntil); err != nil {
+			return nil, err
+		}
+		candidate.ProductID, candidate.OperatorTenantID = source.Entitlement.ProductID, source.Entitlement.OperatorTenantID
+		candidate.ServingPlanID, candidate.SupplyPlanID = source.Entitlement.ServingPlanID, source.Publication.SupplyPlanID
+		var offerCapabilities, qualificationCapabilities []string
+		if json.Unmarshal([]byte(offerCapabilitiesJSON), &offerCapabilities) != nil || json.Unmarshal([]byte(qualificationCapabilitiesJSON), &qualificationCapabilities) != nil {
+			return nil, fmt.Errorf("hosted candidate %q has invalid capabilities", candidate.ID)
+		}
+		sort.Strings(offerCapabilities)
+		sort.Strings(qualificationCapabilities)
+		selection, expectedPosition, selectionOK := selectionAt(plan, disposition, position)
+		if !selectionOK || selection.CandidateID != candidate.ID || selection.OfferID != candidate.OfferID || selection.OfferVersion != candidate.OfferVersion ||
+			selection.RetailRateID != rateID || selection.RetailRateVersion != candidateRateVersion || selection.QualificationEvidenceID != qualificationID || selection.Supplier != candidate.Supplier ||
+			selection.SupplierModelID != candidate.SupplierModelID || selection.TupleKey != candidate.CompatibilityKey || expectedPosition != position || rateID != source.Rate.ID || candidateRateVersion != source.Rate.Version ||
+			offerState != "active" || access != "ready" || availability != "available" || health != "healthy" || !observed.Valid || observed.Time.After(at) || !costUntil.Valid || !at.Before(costUntil.Time) ||
+			commercialState != "ready" || !commercialUntil.Valid || !at.Before(commercialUntil.Time) || qualificationState != "qualified" || qualificationTuple != candidate.CompatibilityKey ||
+			qualificationProtocol != candidate.Protocol || qualificationRegion != region || !reflect.DeepEqual(offerCapabilities, qualificationCapabilities) || !evidenceRef.Valid || evidenceRef.String == "" ||
+			!evidenceDigest.Valid || evidenceDigest.String == "" || !qualificationObserved.Valid || qualificationObserved.Time.After(at) || !qualificationUntil.Valid || !at.Before(qualificationUntil.Time) ||
+			selection.ValidUntil.IsZero() || !at.Before(selection.ValidUntil.UTC()) || !supportsPublishedOperations(offerCapabilities, operations) {
+			return nil, fmt.Errorf("hosted candidate %q does not exactly match current plan, rate, qualification, and evidence", candidate.ID)
+		}
+		candidate.Operations = append([]string(nil), operations...)
+		candidate.Qualified, candidate.Available = true, true
+		candidate.ValidUntil = earliestTime(source.Publication.ValidUntil, selection.ValidUntil, costUntil.Time, commercialUntil.Time, qualificationUntil.Time)
+		candidates = append(candidates, item)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(candidates) != 1+len(plan.Fallbacks) {
+		return nil, errors.New("persisted hosted candidates do not exactly match the supply plan")
+	}
+	compatibility := candidates[0].Candidate.CompatibilityKey
+	for _, candidate := range candidates[1:] {
+		if candidate.Candidate.CompatibilityKey != compatibility {
+			return nil, errors.New("hosted fallback is not exactly compatible with the primary")
+		}
+	}
+	return candidates, nil
+}
+
+func supportsPublishedOperations(capabilities, operations []string) bool {
+	available := make(map[string]bool, len(capabilities))
+	for _, capability := range capabilities {
+		available[capability] = true
+	}
+	for _, operation := range operations {
+		claim := map[string]string{"chat": "chat-completions", "completions": "completions", "responses": "responses", "embeddings": "embeddings", "streaming": "streaming"}[operation]
+		if claim == "" || !available[claim] {
+			return false
+		}
+	}
+	return true
+}
+
+func selectionAt(plan modelapisupply.Plan, disposition string, position int) (modelapisupply.Selection, int, bool) {
+	if disposition == "primary" && position == 0 && plan.Primary != nil {
+		return *plan.Primary, 0, true
+	}
+	if disposition == "fallback" && position > 0 && position <= len(plan.Fallbacks) {
+		return plan.Fallbacks[position-1], position, true
+	}
+	return modelapisupply.Selection{}, 0, false
+}
+
+func qualifiedOperations(claims []modelapiproduct.CapabilityClaim, at time.Time) ([]string, time.Time, error) {
+	operations := make([]string, 0)
+	var validUntil time.Time
+	var streamingUntil time.Time
+	requiresStreaming := false
+	for _, claim := range claims {
+		if !claim.CurrentAt(at) {
+			continue
+		}
+		if claim.Name == "streaming" {
+			streamingUntil = claim.EvidenceUntil.UTC()
+			continue
+		}
+		operation, callable := claim.CallableOperation()
+		if !callable {
+			continue
+		}
+		operations = append(operations, operation)
+		requiresStreaming = requiresStreaming || operation == "chat" || operation == "completions" || operation == "responses"
+		if validUntil.IsZero() || claim.EvidenceUntil.Before(validUntil) {
+			validUntil = claim.EvidenceUntil.UTC()
+		}
+	}
+	if len(operations) == 0 || validUntil.IsZero() {
+		return nil, time.Time{}, errors.New("no current qualified callable capability evidence")
+	}
+	if requiresStreaming {
+		if streamingUntil.IsZero() {
+			return nil, time.Time{}, errors.New("stream-capable operations require current qualified streaming evidence")
+		}
+		operations = append(operations, "streaming")
+		if streamingUntil.Before(validUntil) {
+			validUntil = streamingUntil
+		}
+	}
+	sort.Strings(operations)
+	return operations, validUntil, nil
+}
+
+func earliestTime(values ...time.Time) time.Time {
+	var earliest time.Time
+	for _, value := range values {
+		value = value.UTC()
+		if value.IsZero() {
+			continue
+		}
+		if earliest.IsZero() || value.Before(earliest) {
+			earliest = value
+		}
+	}
+	return earliest
+}

--- a/internal/store/model_api_route_publication_test.go
+++ b/internal/store/model_api_route_publication_test.go
@@ -1,0 +1,58 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/modelapiproduct"
+	"github.com/infercrane/infercrane/internal/modelapisupply"
+)
+
+func TestPublishedRouteCompilerRequiresCurrentQualifiedCallableEvidence(t *testing.T) {
+	now := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
+	current := now.Add(time.Hour)
+	expired := now.Add(-time.Second)
+	claims := []modelapiproduct.CapabilityClaim{
+		{Name: "streaming", State: modelapiproduct.ClaimQualified, EvidenceID: "stream", EvidenceUntil: &current},
+		{Name: "chat-completions", State: modelapiproduct.ClaimQualified, EvidenceID: "chat", EvidenceUntil: &current},
+		{Name: "embeddings", State: modelapiproduct.ClaimQualified, EvidenceID: "old", EvidenceUntil: &expired},
+	}
+	operations, until, err := qualifiedOperations(claims, now)
+	if err != nil || len(operations) != 2 || operations[0] != "chat" || operations[1] != "streaming" || !until.Equal(current) {
+		t.Fatalf("operations=%#v until=%s err=%v", operations, until, err)
+	}
+	if _, _, err = qualifiedOperations([]modelapiproduct.CapabilityClaim{{Name: "chat-completions", State: modelapiproduct.ClaimCataloged}}, now); err == nil {
+		t.Fatal("catalog metadata without current evidence became callable")
+	}
+	if _, _, err = qualifiedOperations([]modelapiproduct.CapabilityClaim{{Name: "chat-completions", State: modelapiproduct.ClaimQualified, EvidenceID: "chat", EvidenceUntil: &current}}, now); err == nil {
+		t.Fatal("stream-capable route launched without qualified streaming evidence")
+	}
+	operations, _, err = qualifiedOperations([]modelapiproduct.CapabilityClaim{{Name: "embeddings", State: modelapiproduct.ClaimQualified, EvidenceID: "embedding", EvidenceUntil: &current}}, now)
+	if err != nil || len(operations) != 1 || operations[0] != "embeddings" {
+		t.Fatalf("non-streaming operation unexpectedly required streaming evidence: operations=%v err=%v", operations, err)
+	}
+	if supportsPublishedOperations([]string{"chat-completions"}, []string{"chat", "streaming"}) {
+		t.Fatal("candidate without streaming qualification matched a streaming-qualified snapshot")
+	}
+	if !supportsPublishedOperations([]string{"chat-completions", "streaming"}, []string{"chat", "streaming"}) {
+		t.Fatal("candidate with exact operation and streaming qualification was rejected")
+	}
+}
+
+func TestPublishedRouteCompilerMatchesExactPersistedPlanPosition(t *testing.T) {
+	plan := modelapisupply.Plan{
+		Primary:   &modelapisupply.Selection{CandidateID: "primary"},
+		Fallbacks: []modelapisupply.Selection{{CandidateID: "fallback-one"}, {CandidateID: "fallback-two"}},
+	}
+	selection, position, ok := selectionAt(plan, "primary", 0)
+	if !ok || position != 0 || selection.CandidateID != "primary" {
+		t.Fatalf("primary selection=%#v position=%d ok=%v", selection, position, ok)
+	}
+	selection, position, ok = selectionAt(plan, "fallback", 2)
+	if !ok || position != 2 || selection.CandidateID != "fallback-two" {
+		t.Fatalf("fallback selection=%#v position=%d ok=%v", selection, position, ok)
+	}
+	if _, _, ok = selectionAt(plan, "fallback", 3); ok {
+		t.Fatal("candidate outside immutable plan was accepted")
+	}
+}

--- a/internal/store/model_api_routes.go
+++ b/internal/store/model_api_routes.go
@@ -1,0 +1,380 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/managedbilling"
+	"github.com/infercrane/infercrane/internal/modelapirouting"
+)
+
+// ReserveModelAPIUsage durably reserves the entitlement's per-request ceiling
+// before any supplier transmission. Routing is already resolved from an
+// in-memory snapshot; this transaction is the money fence only.
+func (s *Store) ReserveModelAPIUsage(ctx context.Context, request modelapirouting.ReservationRequest) (modelapirouting.Reservation, error) {
+	if err := request.Validate(); err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	tx, err := s.beginTx(ctx)
+	if err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	defer tx.Rollback()
+
+	if existing, found, lookupErr := modelAPIReservationMaybe(ctx, tx, request.TenantID, request.ID); lookupErr != nil {
+		return modelapirouting.Reservation{}, lookupErr
+	} else if found {
+		if existing.ProductID != request.ProductID || existing.EntitlementID != request.EntitlementID || existing.RetailRateDigest != request.RetailRate.ContractDigest {
+			return modelapirouting.Reservation{}, fmt.Errorf("%w: hosted reservation identity belongs to a different contract", ErrConflict)
+		}
+		return existing, tx.Commit()
+	}
+
+	var operatorTenant, servingPlan, supplyPlan, rateID, state string
+	var rateVersion int
+	var maxRequest int64
+	var requestsPerMinute, tokensPerMinute, monthlySpend sql.NullInt64
+	var validFrom time.Time
+	var validUntil sql.NullTime
+	err = tx.QueryRowContext(ctx, `SELECT e.operator_tenant_id,e.serving_plan_id,p.supply_plan_id,e.retail_rate_card_id,e.retail_rate_version,e.state,e.requests_per_minute,e.tokens_per_minute,e.monthly_spend_microusd,COALESCE(e.max_request_microusd,0),e.valid_from,e.valid_until FROM model_api_product_entitlements e JOIN model_api_operator_publications p ON p.product_id=e.product_id AND p.operator_tenant_id=e.operator_tenant_id AND p.serving_plan_id=e.serving_plan_id WHERE e.id=? AND e.customer_tenant_id=? AND e.product_id=? FOR SHARE OF e,p`, request.EntitlementID, request.TenantID, request.ProductID).Scan(&operatorTenant, &servingPlan, &supplyPlan, &rateID, &rateVersion, &state, &requestsPerMinute, &tokensPerMinute, &monthlySpend, &maxRequest, &validFrom, &validUntil)
+	if errors.Is(err, sql.ErrNoRows) {
+		return modelapirouting.Reservation{}, ErrNotFound
+	}
+	if err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	at := request.CreatedAt.UTC()
+	active := state == "active" && !at.Before(validFrom.UTC()) && (!validUntil.Valid || at.Before(validUntil.Time.UTC()))
+	if !active || requestsPerMinute.Valid || tokensPerMinute.Valid || monthlySpend.Valid || request.RetailRate.CachedInputMicrousdPerMillion != nil || operatorTenant != request.OperatorTenantID || servingPlan != request.ServingPlanID || supplyPlan != request.SupplyPlanID || rateID != request.RetailRate.ID || rateVersion != request.RetailRate.Version || maxRequest != request.MaxRequestMicrousd {
+		return modelapirouting.Reservation{}, fmt.Errorf("%w: hosted entitlement changed before billing authorization", ErrConflict)
+	}
+
+	var storedDigest string
+	var storedInput, storedOutput int64
+	var storedCachedInput sql.NullInt64
+	var storedFrom, storedUntil time.Time
+	err = tx.QueryRowContext(ctx, `SELECT contract_digest,input_microusd_per_million,cached_input_microusd_per_million,output_microusd_per_million,valid_from,valid_until FROM model_api_retail_rate_cards WHERE product_id=? AND id=? AND version=?`, request.ProductID, rateID, rateVersion).Scan(&storedDigest, &storedInput, &storedCachedInput, &storedOutput, &storedFrom, &storedUntil)
+	if errors.Is(err, sql.ErrNoRows) {
+		return modelapirouting.Reservation{}, ErrNotFound
+	}
+	if err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	if storedCachedInput.Valid || storedDigest != request.RetailRate.ContractDigest || storedInput != request.RetailRate.InputMicrousdPerMillion || storedOutput != request.RetailRate.OutputMicrousdPerMillion || at.Before(storedFrom.UTC()) || !at.Before(storedUntil.UTC()) {
+		return modelapirouting.Reservation{}, fmt.Errorf("%w: immutable retail rate changed or expired before billing authorization", ErrConflict)
+	}
+
+	var supplier, supplierModel string
+	var offerVersion int64
+	err = tx.QueryRowContext(ctx, `SELECT o.supplier,o.supplier_model_id,o.version FROM model_api_supply_plan_candidates c JOIN model_api_supplier_offers o ON o.id=c.offer_id AND o.version=c.offer_version AND o.managed_product_id=c.managed_product_id WHERE c.plan_id=? AND c.managed_product_id=? AND c.candidate_id=? AND c.offer_id=? AND c.offer_version=? AND c.disposition IN ('primary','fallback')`, supplyPlan, request.ProductID, request.CandidateID, request.OfferID, request.OfferVersion).Scan(&supplier, &supplierModel, &offerVersion)
+	if errors.Is(err, sql.ErrNoRows) {
+		return modelapirouting.Reservation{}, ErrNotFound
+	}
+	if err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	if supplier != request.Supplier || supplierModel != request.SupplierModelID || offerVersion != request.OfferVersion {
+		return modelapirouting.Reservation{}, fmt.Errorf("%w: hosted supplier candidate changed before billing authorization", ErrConflict)
+	}
+
+	var balance, reserved, debt int64
+	err = tx.QueryRowContext(ctx, `SELECT balance_microusd,reserved_microusd,debt_microusd FROM managed_wallets WHERE tenant_id=? FOR UPDATE`, request.TenantID).Scan(&balance, &reserved, &debt)
+	if errors.Is(err, sql.ErrNoRows) || balance-reserved-debt < request.MaxRequestMicrousd {
+		return modelapirouting.Reservation{}, modelapirouting.ErrInsufficientPrepaidBalance
+	}
+	if err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	stamp := request.CreatedAt.UTC()
+	_, err = tx.ExecContext(ctx, `INSERT INTO model_api_usage_reservations(id,customer_tenant_id,product_id,entitlement_id,operator_tenant_id,serving_plan_id,supply_plan_id,candidate_id,offer_id,offer_version,supplier,supplier_model_id,retail_rate_card_id,retail_rate_version,retail_rate_contract_digest,input_microusd_per_million,output_microusd_per_million,reserved_microusd,state,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'reserved',?,?)`,
+		request.ID, request.TenantID, request.ProductID, request.EntitlementID, request.OperatorTenantID,
+		request.ServingPlanID, request.SupplyPlanID, request.CandidateID, request.OfferID, request.OfferVersion,
+		request.Supplier, request.SupplierModelID, request.RetailRate.ID, request.RetailRate.Version,
+		request.RetailRate.ContractDigest, request.RetailRate.InputMicrousdPerMillion,
+		request.RetailRate.OutputMicrousdPerMillion, request.MaxRequestMicrousd, stamp, stamp)
+	if err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE managed_wallets SET reserved_microusd=reserved_microusd+?,updated_at=? WHERE tenant_id=?`, request.MaxRequestMicrousd, stamp, request.TenantID); err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	if err = tx.Commit(); err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	return s.ModelAPIUsageReservation(ctx, request.TenantID, request.ID)
+}
+
+func (s *Store) MarkModelAPIUsageTransmitted(ctx context.Context, tenant, reservationID string, at time.Time) error {
+	return s.advanceModelAPIUsage(ctx, tenant, reservationID, "transmitted", at)
+}
+
+func (s *Store) MarkModelAPIUsageResponseStarted(ctx context.Context, tenant, reservationID string, at time.Time) error {
+	return s.advanceModelAPIUsage(ctx, tenant, reservationID, "response_started", at)
+}
+
+func (s *Store) advanceModelAPIUsage(ctx context.Context, tenant, reservationID, target string, at time.Time) error {
+	if tenant == "" || reservationID == "" || at.IsZero() || (target != "transmitted" && target != "response_started") {
+		return errors.New("tenant, reservation, valid state, and timestamp are required")
+	}
+	tx, err := s.beginTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	row, err := modelAPIReservationForUpdate(ctx, tx, tenant, reservationID)
+	if err != nil {
+		return err
+	}
+	if target == "transmitted" {
+		if row.State == "transmitted" || row.State == "response_started" || row.State == "pending_reconciliation" || row.State == "settled" {
+			return tx.Commit()
+		}
+		if row.State != "reserved" {
+			return fmt.Errorf("%w: only an unsent reservation can be marked transmitted", ErrConflict)
+		}
+		_, err = tx.ExecContext(ctx, `UPDATE model_api_usage_reservations SET state='transmitted',transmitted_at=?,updated_at=? WHERE customer_tenant_id=? AND id=?`, at.UTC(), at.UTC(), tenant, reservationID)
+	} else {
+		if row.State == "response_started" || row.State == "pending_reconciliation" || row.State == "settled" {
+			return tx.Commit()
+		}
+		if row.State != "transmitted" {
+			return fmt.Errorf("%w: response start requires a transmitted reservation", ErrConflict)
+		}
+		_, err = tx.ExecContext(ctx, `UPDATE model_api_usage_reservations SET state='response_started',response_started_at=?,updated_at=? WHERE customer_tenant_id=? AND id=?`, at.UTC(), at.UTC(), tenant, reservationID)
+	}
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) SettleModelAPIUsage(ctx context.Context, tenant, reservationID string, usage modelapirouting.Usage) (modelapirouting.Reservation, error) {
+	tx, err := s.beginTx(ctx)
+	if err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	defer tx.Rollback()
+	row, err := modelAPIReservationForUpdate(ctx, tx, tenant, reservationID)
+	if err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	if row.State == "settled" || row.State == "released" {
+		return row, tx.Commit()
+	}
+	if row.State == "reserved" {
+		return modelapirouting.Reservation{}, fmt.Errorf("%w: unsent hosted usage cannot be settled", ErrConflict)
+	}
+	stamp := time.Now().UTC()
+	if usage.InputTokens == nil || usage.OutputTokens == nil {
+		_, err = tx.ExecContext(ctx, `UPDATE model_api_usage_reservations SET state='pending_reconciliation',resolution='supplier usage absent; reservation retained',updated_at=? WHERE customer_tenant_id=? AND id=?`, stamp, tenant, reservationID)
+		if err != nil {
+			return modelapirouting.Reservation{}, err
+		}
+		row.State, row.Resolution, row.UpdatedAt = "pending_reconciliation", "supplier usage absent; reservation retained", stamp
+		return row, tx.Commit()
+	}
+	actual, err := managedbilling.TokenCostMicrousd(*usage.InputTokens, *usage.OutputTokens, row.InputMicrousdPerMillion, row.OutputMicrousdPerMillion)
+	if err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	resolution := "observed token usage at reserved retail rate"
+	if actual > row.ReservedMicrousd {
+		actual = row.ReservedMicrousd
+		resolution = "observed cost exceeded request ceiling; charged reservation ceiling"
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE managed_wallets SET balance_microusd=balance_microusd-?,reserved_microusd=reserved_microusd-?,updated_at=? WHERE tenant_id=?`, actual, row.ReservedMicrousd, stamp, tenant); err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	if _, err = tx.ExecContext(ctx, `INSERT INTO model_api_usage_ledger(id,customer_tenant_id,reservation_id,kind,currency,amount_microusd,description,created_at) VALUES(?,?,?,'settlement','USD',?,?,?) ON CONFLICT(customer_tenant_id,reservation_id,kind) DO NOTHING`, "settlement_"+reservationID, tenant, reservationID, -actual, resolution, stamp); err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE model_api_usage_reservations SET actual_microusd=?,input_tokens=?,output_tokens=?,state='settled',resolution=?,updated_at=? WHERE customer_tenant_id=? AND id=?`, actual, *usage.InputTokens, *usage.OutputTokens, resolution, stamp, tenant, reservationID); err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	if err = reconcileManagedDebtTx(ctx, tx, tenant, stamp.Format(time.RFC3339Nano)); err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	if err = tx.Commit(); err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	row.ActualMicrousd, row.InputTokens, row.OutputTokens, row.State, row.Resolution, row.UpdatedAt = actual, usage.InputTokens, usage.OutputTokens, "settled", resolution, stamp
+	return row, nil
+}
+
+func (s *Store) ReleaseUnsentModelAPIUsage(ctx context.Context, tenant, reservationID, reason string) error {
+	if tenant == "" || reservationID == "" || reason == "" {
+		return errors.New("tenant, reservation, and reason are required")
+	}
+	tx, err := s.beginTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	row, err := modelAPIReservationForUpdate(ctx, tx, tenant, reservationID)
+	if err != nil {
+		return err
+	}
+	if row.State == "released" {
+		return tx.Commit()
+	}
+	if row.State != "reserved" || row.TransmittedAt != nil {
+		return fmt.Errorf("%w: transmitted or response-started usage must be reconciled, not released", ErrConflict)
+	}
+	stamp := time.Now().UTC()
+	if _, err = tx.ExecContext(ctx, `UPDATE managed_wallets SET reserved_microusd=reserved_microusd-?,updated_at=? WHERE tenant_id=?`, row.ReservedMicrousd, stamp, tenant); err != nil {
+		return err
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE model_api_usage_reservations SET state='released',resolution=?,updated_at=? WHERE customer_tenant_id=? AND id=?`, reason, stamp, tenant, reservationID); err != nil {
+		return err
+	}
+	if err = reconcileManagedDebtTx(ctx, tx, tenant, stamp.Format(time.RFC3339Nano)); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// ConfirmNoChargeModelAPIUsage releases a transmitted reservation only after
+// an operator reconciler has durable supplier evidence that no charge
+// occurred. This is intentionally not part of Runtime's request-path Billing
+// interface.
+func (s *Store) ConfirmNoChargeModelAPIUsage(ctx context.Context, tenant, reservationID, evidence string) error {
+	if tenant == "" || reservationID == "" || evidence == "" {
+		return errors.New("tenant, reservation, and no-charge evidence are required")
+	}
+	tx, err := s.beginTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	row, err := modelAPIReservationForUpdate(ctx, tx, tenant, reservationID)
+	if err != nil {
+		return err
+	}
+	if row.State == "released" {
+		return tx.Commit()
+	}
+	if row.State != "pending_reconciliation" && row.State != "transmitted" && row.State != "response_started" {
+		return fmt.Errorf("%w: only ambiguous hosted usage can be confirmed uncharged", ErrConflict)
+	}
+	stamp := time.Now().UTC()
+	if _, err = tx.ExecContext(ctx, `UPDATE managed_wallets SET reserved_microusd=reserved_microusd-?,updated_at=? WHERE tenant_id=?`, row.ReservedMicrousd, stamp, tenant); err != nil {
+		return err
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE model_api_usage_reservations SET state='released',resolution=?,updated_at=? WHERE customer_tenant_id=? AND id=?`, "supplier confirmed no charge: "+evidence, stamp, tenant, reservationID); err != nil {
+		return err
+	}
+	if err = reconcileManagedDebtTx(ctx, tx, tenant, stamp.Format(time.RFC3339Nano)); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) PendingModelAPIUsageReservations(ctx context.Context, limit int) ([]modelapirouting.Reservation, error) {
+	if limit < 1 || limit > 500 {
+		limit = 100
+	}
+	rows, err := s.QueryContext(ctx, modelAPIReservationSelect+` WHERE state='pending_reconciliation' ORDER BY updated_at,id LIMIT ?`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make([]modelapirouting.Reservation, 0)
+	for rows.Next() {
+		var item modelapirouting.Reservation
+		var transmitted, responseStarted sql.NullTime
+		if err = rows.Scan(&item.ID, &item.TenantID, &item.ProductID, &item.EntitlementID, &item.RetailRateID, &item.RetailRateVersion,
+			&item.RetailRateDigest, &item.InputMicrousdPerMillion, &item.OutputMicrousdPerMillion, &item.ReservedMicrousd,
+			&item.ActualMicrousd, &item.InputTokens, &item.OutputTokens, &item.State, &item.Resolution, &transmitted,
+			&responseStarted, &item.CreatedAt, &item.UpdatedAt); err != nil {
+			return nil, err
+		}
+		if transmitted.Valid {
+			value := transmitted.Time.UTC()
+			item.TransmittedAt = &value
+		}
+		if responseStarted.Valid {
+			value := responseStarted.Time.UTC()
+			item.ResponseStartedAt = &value
+		}
+		result = append(result, item)
+	}
+	return result, rows.Err()
+}
+
+func (s *Store) ModelAPIUsageReservation(ctx context.Context, tenant, reservationID string) (modelapirouting.Reservation, error) {
+	row, found, err := modelAPIReservationMaybe(ctx, s, tenant, reservationID)
+	if err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	if !found {
+		return modelapirouting.Reservation{}, ErrNotFound
+	}
+	return row, nil
+}
+
+type modelAPIReservationQueryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+const modelAPIReservationSelect = `SELECT id,customer_tenant_id,product_id,entitlement_id,retail_rate_card_id,retail_rate_version,retail_rate_contract_digest,input_microusd_per_million,output_microusd_per_million,reserved_microusd,COALESCE(actual_microusd,0),input_tokens,output_tokens,state,resolution,transmitted_at,response_started_at,created_at,updated_at FROM model_api_usage_reservations`
+
+func modelAPIReservationMaybe(ctx context.Context, queryer modelAPIReservationQueryer, tenant, reservationID string) (modelapirouting.Reservation, bool, error) {
+	row, err := scanModelAPIUsageReservation(queryer.QueryRowContext(ctx, modelAPIReservationSelect+` WHERE customer_tenant_id=? AND id=?`, tenant, reservationID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return modelapirouting.Reservation{}, false, nil
+	}
+	return row, err == nil, err
+}
+
+func modelAPIReservationForUpdate(ctx context.Context, tx *tx, tenant, reservationID string) (modelapirouting.Reservation, error) {
+	row, err := scanModelAPIUsageReservation(tx.QueryRowContext(ctx, modelAPIReservationSelect+` WHERE customer_tenant_id=? AND id=? FOR UPDATE`, tenant, reservationID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return modelapirouting.Reservation{}, ErrNotFound
+	}
+	return row, err
+}
+
+func scanModelAPIUsageReservation(row *sql.Row) (modelapirouting.Reservation, error) {
+	var out modelapirouting.Reservation
+	var transmitted, responseStarted sql.NullTime
+	err := row.Scan(&out.ID, &out.TenantID, &out.ProductID, &out.EntitlementID, &out.RetailRateID, &out.RetailRateVersion,
+		&out.RetailRateDigest, &out.InputMicrousdPerMillion, &out.OutputMicrousdPerMillion, &out.ReservedMicrousd,
+		&out.ActualMicrousd, &out.InputTokens, &out.OutputTokens, &out.State, &out.Resolution, &transmitted,
+		&responseStarted, &out.CreatedAt, &out.UpdatedAt)
+	if err != nil {
+		return modelapirouting.Reservation{}, err
+	}
+	if transmitted.Valid {
+		value := transmitted.Time.UTC()
+		out.TransmittedAt = &value
+	}
+	if responseStarted.Valid {
+		value := responseStarted.Time.UTC()
+		out.ResponseStartedAt = &value
+	}
+	out.CreatedAt, out.UpdatedAt = out.CreatedAt.UTC(), out.UpdatedAt.UTC()
+	return out, nil
+}
+
+// ModelAPIBillingAdapter gives Runtime the narrow money-fence interface while
+// keeping Store method names explicit next to existing managed endpoint APIs.
+type ModelAPIBillingAdapter struct{ Store *Store }
+
+func (a ModelAPIBillingAdapter) Reserve(ctx context.Context, request modelapirouting.ReservationRequest) (modelapirouting.Reservation, error) {
+	return a.Store.ReserveModelAPIUsage(ctx, request)
+}
+func (a ModelAPIBillingAdapter) MarkTransmitted(ctx context.Context, tenant, reservation string, at time.Time) error {
+	return a.Store.MarkModelAPIUsageTransmitted(ctx, tenant, reservation, at)
+}
+func (a ModelAPIBillingAdapter) MarkResponseStarted(ctx context.Context, tenant, reservation string, at time.Time) error {
+	return a.Store.MarkModelAPIUsageResponseStarted(ctx, tenant, reservation, at)
+}
+func (a ModelAPIBillingAdapter) Settle(ctx context.Context, tenant, reservation string, usage modelapirouting.Usage) (modelapirouting.Reservation, error) {
+	return a.Store.SettleModelAPIUsage(ctx, tenant, reservation, usage)
+}
+func (a ModelAPIBillingAdapter) ReleaseUnsent(ctx context.Context, tenant, reservation, reason string) error {
+	return a.Store.ReleaseUnsentModelAPIUsage(ctx, tenant, reservation, reason)
+}

--- a/internal/supplieradapter/contracts.go
+++ b/internal/supplieradapter/contracts.go
@@ -1,0 +1,282 @@
+// Package supplieradapter defines the private boundary between InferCrane and
+// an inference supplier. It owns provider-specific wire translation while the
+// gateway, billing, and public model contracts remain supplier-neutral.
+package supplieradapter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	OperationChatCompletions = "chat.completions"
+	OperationResponses       = "responses"
+
+	UsageComplete = "complete"
+	UsagePartial  = "partial"
+	UsageAbsent   = "absent"
+
+	BillingNotTransmitted    = "not_transmitted"
+	BillingNoChargeConfirmed = "no_charge_confirmed"
+	BillingChargeKnown       = "charge_known"
+	BillingAmbiguous         = "ambiguous"
+
+	RetryNever      = "never"
+	RetrySameOffer  = "same_offer"
+	RetryOtherOffer = "other_offer"
+
+	ErrorInvalidRequest = "invalid_request"
+	ErrorAuthentication = "authentication_failed"
+	ErrorAuthorization  = "authorization_failed"
+	ErrorRateLimited    = "rate_limited"
+	ErrorUnavailable    = "unavailable"
+	ErrorTimeout        = "timeout"
+	ErrorTransport      = "transport"
+	ErrorProtocol       = "protocol_error"
+	ErrorCancelled      = "cancelled"
+	ErrorInternal       = "internal"
+)
+
+// Target is an operator-owned supplier route. CredentialReference names a
+// secret-manager entry; it must never contain the secret itself.
+type Target struct {
+	Supplier            string
+	BaseURL             string
+	SupplierModelID     string
+	Region              string
+	CredentialReference string
+}
+
+// CredentialResolver resolves a reference only inside the trusted adapter
+// boundary. The returned bytes must not be persisted or included in errors.
+type CredentialResolver interface {
+	Resolve(ctx context.Context, reference string) ([]byte, error)
+}
+
+type ContentPart struct {
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	ImageURL string `json:"image_url,omitempty"`
+}
+
+type Message struct {
+	Role    string        `json:"role"`
+	Name    string        `json:"name,omitempty"`
+	Content []ContentPart `json:"content"`
+}
+
+type Tool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// Request is the normalized inference request. Supplier-specific parameters
+// belong in an adapter implementation, not in the public or planner contract.
+type Request struct {
+	ID              string
+	Operation       string
+	ModelID         string
+	Messages        []Message
+	Tools           []Tool
+	ResponseFormat  json.RawMessage
+	MaxOutputTokens *int
+	Temperature     *float64
+	Stream          bool
+}
+
+func (r Request) Validate() error {
+	if strings.TrimSpace(r.ID) == "" || strings.TrimSpace(r.ModelID) == "" {
+		return errors.New("request id and model id are required")
+	}
+	if r.Operation != OperationChatCompletions && r.Operation != OperationResponses {
+		return fmt.Errorf("unsupported normalized operation %q", r.Operation)
+	}
+	if len(r.Messages) == 0 {
+		return errors.New("at least one message is required")
+	}
+	if r.MaxOutputTokens != nil && *r.MaxOutputTokens <= 0 {
+		return errors.New("max output tokens must be positive")
+	}
+	if r.Temperature != nil && (*r.Temperature < 0 || *r.Temperature > 2) {
+		return errors.New("temperature must be between 0 and 2")
+	}
+	for index, message := range r.Messages {
+		if strings.TrimSpace(message.Role) == "" || len(message.Content) == 0 {
+			return fmt.Errorf("message %d requires a role and content", index)
+		}
+	}
+	for index, tool := range r.Tools {
+		if strings.TrimSpace(tool.Name) == "" || len(tool.InputSchema) == 0 || !json.Valid(tool.InputSchema) {
+			return fmt.Errorf("tool %d requires a name and valid input schema", index)
+		}
+	}
+	if len(r.ResponseFormat) > 0 && !json.Valid(r.ResponseFormat) {
+		return errors.New("response format must be valid JSON")
+	}
+	return nil
+}
+
+type Usage struct {
+	State           string
+	InputTokens     *int64
+	OutputTokens    *int64
+	CachedInput     *int64
+	ReasoningTokens *int64
+}
+
+func (u Usage) Validate() error {
+	if u.State != UsageComplete && u.State != UsagePartial && u.State != UsageAbsent {
+		return fmt.Errorf("unknown usage state %q", u.State)
+	}
+	values := []*int64{u.InputTokens, u.OutputTokens, u.CachedInput, u.ReasoningTokens}
+	for _, value := range values {
+		if value != nil && *value < 0 {
+			return errors.New("usage token counts cannot be negative")
+		}
+	}
+	if u.State == UsageComplete && (u.InputTokens == nil || u.OutputTokens == nil) {
+		return errors.New("complete usage requires input and output tokens")
+	}
+	if u.State == UsageAbsent && (u.InputTokens != nil || u.OutputTokens != nil || u.CachedInput != nil || u.ReasoningTokens != nil) {
+		return errors.New("absent usage cannot carry token counts")
+	}
+	return nil
+}
+
+type Choice struct {
+	Index        int
+	Message      *Message
+	Text         string
+	FinishReason string
+}
+
+type Response struct {
+	ID                string
+	ModelID           string
+	SupplierRequestID string
+	Choices           []Choice
+	Usage             Usage
+}
+
+type StreamEvent struct {
+	Type              string
+	ChoiceIndex       int
+	TextDelta         string
+	FinishReason      string
+	Usage             *Usage
+	SupplierRequestID string
+}
+
+type Stream interface {
+	Next(ctx context.Context) (StreamEvent, error)
+	Close() error
+}
+
+// Error is safe to retain in operational records. Message must be sanitized;
+// raw upstream bodies and credentials never belong here.
+type Error struct {
+	Code              string
+	Message           string
+	HTTPStatus        int
+	SupplierRequestID string
+	Retry             string
+	RetryAfter        time.Duration
+	Billing           string
+	ResponseStarted   bool
+	Cause             error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	if strings.TrimSpace(e.Message) != "" {
+		return e.Code + ": " + e.Message
+	}
+	return e.Code
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+func (e *Error) Validate() error {
+	if e == nil {
+		return errors.New("supplier error is required")
+	}
+	if !oneOf(e.Code, ErrorInvalidRequest, ErrorAuthentication, ErrorAuthorization, ErrorRateLimited, ErrorUnavailable, ErrorTimeout, ErrorTransport, ErrorProtocol, ErrorCancelled, ErrorInternal) {
+		return fmt.Errorf("unknown supplier error code %q", e.Code)
+	}
+	if !oneOf(e.Retry, RetryNever, RetrySameOffer, RetryOtherOffer) {
+		return fmt.Errorf("unknown retry hint %q", e.Retry)
+	}
+	if !oneOf(e.Billing, BillingNotTransmitted, BillingNoChargeConfirmed, BillingChargeKnown, BillingAmbiguous) {
+		return fmt.Errorf("unknown billing outcome %q", e.Billing)
+	}
+	if e.RetryAfter < 0 {
+		return errors.New("retry delay cannot be negative")
+	}
+	return nil
+}
+
+// SafeToRetry is intentionally stricter than the supplier's retry hint. A
+// request is retryable only before response bytes and when double billing has
+// been ruled out.
+func (e *Error) SafeToRetry() bool {
+	if e == nil || e.ResponseStarted || (e.Retry != RetrySameOffer && e.Retry != RetryOtherOffer) {
+		return false
+	}
+	return e.Billing == BillingNotTransmitted || e.Billing == BillingNoChargeConfirmed
+}
+
+type RateLimit struct {
+	RequestsRemaining *int64
+	TokensRemaining   *int64
+	ResetAt           *time.Time
+}
+
+type InventoryItem struct {
+	SupplierModelID string
+	Region          string
+	Available       bool
+}
+
+// Observation normalizes health, access, inventory, and rate-limit signals.
+// It is evidence at ObservedAt, not a durable availability promise.
+type Observation struct {
+	Access       string
+	Availability string
+	Health       string
+	ObservedAt   time.Time
+	RateLimit    RateLimit
+	Inventory    []InventoryItem
+}
+
+// Adapter owns provider-specific authentication and wire translation. It must
+// return *Error for supplier failures so billing ambiguity and retry safety are
+// never inferred from an HTTP status alone.
+type Adapter interface {
+	Name() string
+	BuildRequest(ctx context.Context, target Target, request Request, credentials CredentialResolver) (*http.Request, error)
+	DecodeResponse(ctx context.Context, response *http.Response) (Response, error)
+	OpenStream(ctx context.Context, response *http.Response) (Stream, error)
+	Probe(ctx context.Context, target Target, credentials CredentialResolver) (Observation, error)
+}
+
+func oneOf(value string, allowed ...string) bool {
+	for _, item := range allowed {
+		if value == item {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/supplieradapter/contracts_test.go
+++ b/internal/supplieradapter/contracts_test.go
@@ -1,0 +1,65 @@
+package supplieradapter
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestRequestValidationPreservesNormalizedContract(t *testing.T) {
+	maximum := 128
+	request := Request{
+		ID: "request-1", Operation: OperationChatCompletions, ModelID: "glm-5.3", MaxOutputTokens: &maximum,
+		Messages: []Message{{Role: "user", Content: []ContentPart{{Type: "text", Text: "hello"}}}},
+		Tools:    []Tool{{Name: "lookup", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+	}
+	if err := request.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	request.Tools[0].InputSchema = json.RawMessage(`{`)
+	if err := request.Validate(); err == nil {
+		t.Fatal("invalid supplier-neutral tool schema was accepted")
+	}
+}
+
+func TestUsageKeepsAbsentAndPartialDistinct(t *testing.T) {
+	input := int64(12)
+	if err := (Usage{State: UsagePartial, InputTokens: &input}).Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := (Usage{State: UsageComplete, InputTokens: &input}).Validate(); err == nil {
+		t.Fatal("complete usage without output tokens was accepted")
+	}
+	if err := (Usage{State: UsageAbsent, InputTokens: &input}).Validate(); err == nil {
+		t.Fatal("absent usage with invented token counts was accepted")
+	}
+}
+
+func TestSupplierErrorRequiresKnownNoChargeBeforeRetry(t *testing.T) {
+	safe := &Error{Code: ErrorUnavailable, Retry: RetryOtherOffer, Billing: BillingNotTransmitted}
+	if err := safe.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if !safe.SafeToRetry() {
+		t.Fatal("pre-transmission failure should be safe to retry")
+	}
+	for name, value := range map[string]*Error{
+		"ambiguous billing": {Code: ErrorTimeout, Retry: RetryOtherOffer, Billing: BillingAmbiguous},
+		"response started":  {Code: ErrorTransport, Retry: RetryOtherOffer, Billing: BillingNoChargeConfirmed, ResponseStarted: true},
+		"retry forbidden":   {Code: ErrorInvalidRequest, Retry: RetryNever, Billing: BillingNotTransmitted},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if value.SafeToRetry() {
+				t.Fatal("unsafe supplier failure became retryable")
+			}
+		})
+	}
+	cause := errors.New("transport closed")
+	normalized := &Error{Code: ErrorTransport, Cause: cause}
+	if !errors.Is(normalized, cause) {
+		t.Fatal("normalized error did not preserve its internal cause")
+	}
+	if err := (&Error{Code: ErrorTimeout, Retry: RetryOtherOffer, Billing: "assume_free"}).Validate(); err == nil {
+		t.Fatal("unknown billing outcome was accepted")
+	}
+}


### PR DESCRIPTION
## Summary
- add supplier-neutral Model API products, immutable offers, qualifications, supply plans, retail rates, and tenant entitlements
- add fail-closed route publication, strict hosted streaming proxy, prepaid reservation/settlement, reconciliation contracts, and append-only migrations
- document the product capability map and production rollout for gateway, suppliers, Stripe, canary, and later GPU targets

## Safety
- catalog entries remain non-callable without current exact qualification, rate, entitlement, and operation evidence
- cached-token prices and unsupported RPM/TPM/monthly limits fail closed
- supplier headers and SSE events are strictly allowlisted and bounded

## Verification
- go test ./...
- go vet ./...
- focused race suites
- all historical PostgreSQL migration prefix upgrades
- immutable supply trigger integration test