### PR TITLE
Expose hosted Model API usage evidence

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1517,6 +1517,227 @@
         },
         "type": "object"
       },
+      "HostedModelAPIUsage": {
+        "additionalProperties": false,
+        "properties": {
+          "bucket_seconds": {
+            "maximum": 86400,
+            "minimum": 60,
+            "type": "integer"
+          },
+          "currency": {
+            "const": "USD",
+            "type": "string"
+          },
+          "evidence": {
+            "$ref": "#/components/schemas/HostedModelAPIUsageEvidence"
+          },
+          "models": {
+            "items": {
+              "$ref": "#/components/schemas/HostedModelAPIUsageModel"
+            },
+            "type": "array"
+          },
+          "series": {
+            "items": {
+              "$ref": "#/components/schemas/HostedModelAPIUsageBucket"
+            },
+            "maxItems": 500,
+            "type": "array"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/HostedModelAPIUsageSummary"
+          },
+          "window_end": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "window_start": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "window_start",
+          "window_end",
+          "bucket_seconds",
+          "currency",
+          "summary",
+          "models",
+          "series",
+          "evidence"
+        ],
+        "type": "object"
+      },
+      "HostedModelAPIUsageBucket": {
+        "additionalProperties": false,
+        "properties": {
+          "started_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/HostedModelAPIUsageSummary"
+          }
+        },
+        "required": [
+          "started_at",
+          "usage"
+        ],
+        "type": "object"
+      },
+      "HostedModelAPIUsageEvidence": {
+        "additionalProperties": false,
+        "properties": {
+          "available": {
+            "items": {
+              "enum": [
+                "requests",
+                "reconciliation_state",
+                "settled_spend",
+                "tokens"
+              ],
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "content_recorded": {
+            "const": false,
+            "type": "boolean"
+          },
+          "latest_request_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "reconciliation_complete": {
+            "type": "boolean"
+          },
+          "request_scope": {
+            "const": "funded_supplier_attempts",
+            "type": "string"
+          },
+          "source": {
+            "const": "model_api_usage_reservations+model_api_usage_ledger",
+            "type": "string"
+          },
+          "token_usage_complete": {
+            "type": "boolean"
+          },
+          "unavailable": {
+            "items": {
+              "enum": [
+                "errors",
+                "latency",
+                "ttft",
+                "tokens"
+              ],
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "source",
+          "request_scope",
+          "latest_request_at",
+          "token_usage_complete",
+          "reconciliation_complete",
+          "content_recorded",
+          "available",
+          "unavailable"
+        ],
+        "type": "object"
+      },
+      "HostedModelAPIUsageModel": {
+        "additionalProperties": false,
+        "properties": {
+          "latest_request_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "product_id": {
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/HostedModelAPIUsageSummary"
+          }
+        },
+        "required": [
+          "product_id",
+          "latest_request_at",
+          "usage"
+        ],
+        "type": "object"
+      },
+      "HostedModelAPIUsageSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "confirmed_no_charge_requests": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "in_flight_requests": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "input_tokens": {
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "output_tokens": {
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "pending_reconciliation_requests": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "settled_requests": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "settled_spend_microusd": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "settlement_entries": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "token_usage_samples": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "transmitted_requests": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "transmitted_requests",
+          "settled_requests",
+          "in_flight_requests",
+          "pending_reconciliation_requests",
+          "confirmed_no_charge_requests",
+          "token_usage_samples",
+          "settlement_entries",
+          "input_tokens",
+          "output_tokens",
+          "settled_spend_microusd"
+        ],
+        "type": "object"
+      },
       "IntentPlan": {
         "additionalProperties": false,
         "properties": {
@@ -9855,6 +10076,78 @@
           }
         ],
         "summary": "Inspect one managed Model API identity without supplier disclosure",
+        "tags": [
+          "Model APIs"
+        ]
+      }
+    },
+    "/api/v1/model-api-usage": {
+      "get": {
+        "operationId": "getHostedModelAPIUsage",
+        "parameters": [
+          {
+            "description": "Lookback window for funded supplier attempts.",
+            "in": "query",
+            "name": "window_seconds",
+            "required": false,
+            "schema": {
+              "default": 86400,
+              "maximum": 2592000,
+              "minimum": 60,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Time-series bucket size; the response is limited to 500 buckets.",
+            "in": "query",
+            "name": "bucket_seconds",
+            "required": false,
+            "schema": {
+              "default": 900,
+              "maximum": 86400,
+              "minimum": 60,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Exact public Model API product ID. Omit to include all hosted products for the authenticated tenant.",
+            "in": "query",
+            "name": "model",
+            "required": false,
+            "schema": {
+              "maxLength": 256,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedModelAPIUsage"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Typed API error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Read tenant-scoped hosted Model API settlement evidence",
         "tags": [
           "Model APIs"
         ]

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1517,6 +1517,227 @@
         },
         "type": "object"
       },
+      "HostedModelAPIUsage": {
+        "additionalProperties": false,
+        "properties": {
+          "bucket_seconds": {
+            "maximum": 86400,
+            "minimum": 60,
+            "type": "integer"
+          },
+          "currency": {
+            "const": "USD",
+            "type": "string"
+          },
+          "evidence": {
+            "$ref": "#/components/schemas/HostedModelAPIUsageEvidence"
+          },
+          "models": {
+            "items": {
+              "$ref": "#/components/schemas/HostedModelAPIUsageModel"
+            },
+            "type": "array"
+          },
+          "series": {
+            "items": {
+              "$ref": "#/components/schemas/HostedModelAPIUsageBucket"
+            },
+            "maxItems": 500,
+            "type": "array"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/HostedModelAPIUsageSummary"
+          },
+          "window_end": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "window_start": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "window_start",
+          "window_end",
+          "bucket_seconds",
+          "currency",
+          "summary",
+          "models",
+          "series",
+          "evidence"
+        ],
+        "type": "object"
+      },
+      "HostedModelAPIUsageBucket": {
+        "additionalProperties": false,
+        "properties": {
+          "started_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/HostedModelAPIUsageSummary"
+          }
+        },
+        "required": [
+          "started_at",
+          "usage"
+        ],
+        "type": "object"
+      },
+      "HostedModelAPIUsageEvidence": {
+        "additionalProperties": false,
+        "properties": {
+          "available": {
+            "items": {
+              "enum": [
+                "requests",
+                "reconciliation_state",
+                "settled_spend",
+                "tokens"
+              ],
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "content_recorded": {
+            "const": false,
+            "type": "boolean"
+          },
+          "latest_request_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "reconciliation_complete": {
+            "type": "boolean"
+          },
+          "request_scope": {
+            "const": "funded_supplier_attempts",
+            "type": "string"
+          },
+          "source": {
+            "const": "model_api_usage_reservations+model_api_usage_ledger",
+            "type": "string"
+          },
+          "token_usage_complete": {
+            "type": "boolean"
+          },
+          "unavailable": {
+            "items": {
+              "enum": [
+                "errors",
+                "latency",
+                "ttft",
+                "tokens"
+              ],
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "source",
+          "request_scope",
+          "latest_request_at",
+          "token_usage_complete",
+          "reconciliation_complete",
+          "content_recorded",
+          "available",
+          "unavailable"
+        ],
+        "type": "object"
+      },
+      "HostedModelAPIUsageModel": {
+        "additionalProperties": false,
+        "properties": {
+          "latest_request_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "product_id": {
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/HostedModelAPIUsageSummary"
+          }
+        },
+        "required": [
+          "product_id",
+          "latest_request_at",
+          "usage"
+        ],
+        "type": "object"
+      },
+      "HostedModelAPIUsageSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "confirmed_no_charge_requests": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "in_flight_requests": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "input_tokens": {
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "output_tokens": {
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "pending_reconciliation_requests": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "settled_requests": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "settled_spend_microusd": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "settlement_entries": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "token_usage_samples": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "transmitted_requests": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "transmitted_requests",
+          "settled_requests",
+          "in_flight_requests",
+          "pending_reconciliation_requests",
+          "confirmed_no_charge_requests",
+          "token_usage_samples",
+          "settlement_entries",
+          "input_tokens",
+          "output_tokens",
+          "settled_spend_microusd"
+        ],
+        "type": "object"
+      },
       "IntentPlan": {
         "additionalProperties": false,
         "properties": {
@@ -9855,6 +10076,78 @@
           }
         ],
         "summary": "Inspect one managed Model API identity without supplier disclosure",
+        "tags": [
+          "Model APIs"
+        ]
+      }
+    },
+    "/api/v1/model-api-usage": {
+      "get": {
+        "operationId": "getHostedModelAPIUsage",
+        "parameters": [
+          {
+            "description": "Lookback window for funded supplier attempts.",
+            "in": "query",
+            "name": "window_seconds",
+            "required": false,
+            "schema": {
+              "default": 86400,
+              "maximum": 2592000,
+              "minimum": 60,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Time-series bucket size; the response is limited to 500 buckets.",
+            "in": "query",
+            "name": "bucket_seconds",
+            "required": false,
+            "schema": {
+              "default": 900,
+              "maximum": 86400,
+              "minimum": 60,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Exact public Model API product ID. Omit to include all hosted products for the authenticated tenant.",
+            "in": "query",
+            "name": "model",
+            "required": false,
+            "schema": {
+              "maxLength": 256,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedModelAPIUsage"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Typed API error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Read tenant-scoped hosted Model API settlement evidence",
         "tags": [
           "Model APIs"
         ]

--- a/internal/apicontract/contract.go
+++ b/internal/apicontract/contract.go
@@ -42,6 +42,7 @@ var Routes = []Route{
 	{"POST", "/planning/intents", "planIntent", "Planning", "Compile bounded user intent into an editable reviewed configuration", "IntentPlanRequest", "IntentPlanEnvelope", 200, false},
 	{"GET", "/model-api-catalog", "listModelAPICatalog", "Model APIs", "Browse supplier-neutral managed Model API identities", "", "ObjectList", 200, false},
 	{"GET", "/model-api-catalog/{id}", "getModelAPICatalogEntry", "Model APIs", "Inspect one managed Model API identity without supplier disclosure", "", "Object", 200, false},
+	{"GET", "/model-api-usage", "getHostedModelAPIUsage", "Model APIs", "Read tenant-scoped hosted Model API settlement evidence", "", "HostedModelAPIUsage", 200, false},
 	{"POST", "/admin/model-api/products", "publishModelAPIProduct", "Model API administration", "Publish an immutable shared Model API product contract", "Object", "Object", 201, false},
 	{"POST", "/admin/model-api/rates", "publishModelAPIRetailRate", "Model API administration", "Publish an immutable customer-visible Model API rate", "Object", "Object", 201, false},
 	{"POST", "/admin/model-api/offers", "publishModelAPISupplierOffer", "Model API administration", "Publish an immutable supplier offer using a credential reference", "Object", "Object", 201, false},
@@ -212,6 +213,9 @@ func Document() (map[string]any, error) {
 		if route.Path == "/catalog/gpu-prices" || route.Path == "/public/catalog/gpu-prices" {
 			parameters = append(parameters, gpuPriceQueryParameters(route.Path == "/public/catalog/gpu-prices")...)
 		}
+		if route.Path == "/model-api-usage" {
+			parameters = append(parameters, hostedModelAPIUsageQueryParameters()...)
+		}
 		if route.Path == "/billing/webhooks/stripe" {
 			parameters = append(parameters, map[string]any{"name": "Stripe-Signature", "in": "header", "required": true, "description": "Stripe webhook HMAC signature; the request is unauthenticated by bearer token and grants balance only after verification.", "schema": map[string]any{"type": "string"}})
 		}
@@ -312,6 +316,14 @@ func gpuPriceQueryParameters(public bool) []map[string]any {
 	}
 }
 
+func hostedModelAPIUsageQueryParameters() []map[string]any {
+	return []map[string]any{
+		{"name": "window_seconds", "in": "query", "required": false, "description": "Lookback window for funded supplier attempts.", "schema": map[string]any{"type": "integer", "minimum": 60, "maximum": 2592000, "default": 86400}},
+		{"name": "bucket_seconds", "in": "query", "required": false, "description": "Time-series bucket size; the response is limited to 500 buckets.", "schema": map[string]any{"type": "integer", "minimum": 60, "maximum": 86400, "default": 900}},
+		{"name": "model", "in": "query", "required": false, "description": "Exact public Model API product ID. Omit to include all hosted products for the authenticated tenant.", "schema": map[string]any{"type": "string", "maxLength": 256}},
+	}
+}
+
 func ref(name string) map[string]any { return map[string]any{"$ref": "#/components/schemas/" + name} }
 
 func schemas() map[string]any {
@@ -355,6 +367,11 @@ func schemas() map[string]any {
 		"ProviderConnectionCreate":        map[string]any{"type": "object", "additionalProperties": false, "required": []string{"name", "adapter", "target", "secret_reference_id"}, "properties": map[string]any{"name": map[string]any{"type": "string"}, "adapter": map[string]any{"type": "string", "enum": []string{"openrouter", "openai-compatible-external", "modal", "runpod-serverless-api", "fly-io"}}, "target": map[string]any{"type": "string"}, "secret_reference_id": map[string]any{"type": "string"}}},
 		"ManagedWallet":                   map[string]any{"type": "object", "additionalProperties": false, "required": []string{"tenant_id", "currency", "balance_microusd", "reserved_microusd", "available_microusd", "updated_at"}, "properties": map[string]any{"tenant_id": map[string]any{"type": "string"}, "currency": map[string]any{"type": "string", "const": "USD"}, "balance_microusd": map[string]any{"type": "integer"}, "reserved_microusd": map[string]any{"type": "integer", "minimum": 0}, "available_microusd": map[string]any{"type": "integer"}, "updated_at": map[string]any{"type": "string", "format": "date-time"}}},
 		"ManagedWalletEnvelope":           map[string]any{"type": "object", "required": []string{"data", "funding_mode", "funding_available", "funding_provider", "checkout_amounts_microusd"}, "properties": map[string]any{"data": ref("ManagedWallet"), "funding_mode": map[string]any{"type": "string", "const": "prepaid"}, "funding_available": map[string]any{"type": "boolean"}, "funding_provider": map[string]any{"type": "string", "enum": []string{"", "stripe"}}, "checkout_amounts_microusd": map[string]any{"type": "array", "items": map[string]any{"type": "integer", "enum": []int64{25000000, 50000000, 100000000, 250000000, 500000000}}}, "payment_collection": map[string]any{"type": "string"}, "credit_id": map[string]any{"type": "string"}, "payment_collected_by_infercrane": map[string]any{"type": "boolean"}}},
+		"HostedModelAPIUsageSummary":      hostedModelAPIUsageSummarySchema(),
+		"HostedModelAPIUsageModel":        map[string]any{"type": "object", "additionalProperties": false, "required": []string{"product_id", "latest_request_at", "usage"}, "properties": map[string]any{"product_id": map[string]any{"type": "string"}, "latest_request_at": map[string]any{"type": "string", "format": "date-time"}, "usage": ref("HostedModelAPIUsageSummary")}},
+		"HostedModelAPIUsageBucket":       map[string]any{"type": "object", "additionalProperties": false, "required": []string{"started_at", "usage"}, "properties": map[string]any{"started_at": map[string]any{"type": "string", "format": "date-time"}, "usage": ref("HostedModelAPIUsageSummary")}},
+		"HostedModelAPIUsageEvidence":     hostedModelAPIUsageEvidenceSchema(),
+		"HostedModelAPIUsage":             hostedModelAPIUsageSchema(),
 		"ManagedCheckoutRequest":          map[string]any{"type": "object", "additionalProperties": false, "required": []string{"amount_microusd"}, "properties": map[string]any{"amount_microusd": map[string]any{"type": "integer", "enum": []int64{25000000, 50000000, 100000000, 250000000, 500000000}}}},
 		"ManagedCheckoutSession":          map[string]any{"type": "object", "additionalProperties": false, "required": []string{"funding_intent_id", "provider", "provider_id", "url", "amount_microusd", "currency", "expires_at"}, "properties": map[string]any{"funding_intent_id": map[string]any{"type": "string", "pattern": `^funding_[a-f0-9]{32}$`}, "provider": map[string]any{"type": "string", "const": "stripe"}, "provider_id": map[string]any{"type": "string", "minLength": 1}, "url": map[string]any{"type": "string", "format": "uri"}, "amount_microusd": map[string]any{"type": "integer", "minimum": 1}, "currency": map[string]any{"type": "string", "const": "USD"}, "expires_at": map[string]any{"type": "string", "format": "date-time"}}},
 		"ManagedCheckoutEnvelope":         map[string]any{"type": "object", "additionalProperties": false, "required": []string{"checkout", "balance_changed", "credit_authority"}, "properties": map[string]any{"checkout": ref("ManagedCheckoutSession"), "balance_changed": map[string]any{"type": "boolean", "const": false}, "credit_authority": map[string]any{"type": "string", "const": "verified_provider_webhook"}}},
@@ -431,6 +448,61 @@ func schemas() map[string]any {
 		"ExternalPolicyEnvelope":         map[string]any{"type": "object", "required": []string{"policy"}, "properties": map[string]any{"policy": ref("ExternalPolicy")}},
 		"ChatCompletionRequest":          map[string]any{"type": "object", "required": []string{"model", "messages"}, "properties": map[string]any{"model": map[string]any{"type": "string", "description": "Stable InferCrane endpoint name; migrated v1 deployment aliases remain compatible endpoints."}, "messages": map[string]any{"type": "array", "minItems": 1, "items": map[string]any{"type": "object", "required": []string{"role", "content"}, "properties": map[string]any{"role": map[string]any{"type": "string"}, "content": map[string]any{"type": "string"}}}}, "stream": map[string]any{"type": "boolean", "default": false}}, "additionalProperties": true},
 		"Empty":                          map[string]any{"type": "null"},
+	}
+}
+
+func hostedModelAPIUsageSummarySchema() map[string]any {
+	nonNegativeInteger := func() map[string]any { return map[string]any{"type": "integer", "minimum": 0} }
+	nullableNonNegativeInteger := func() map[string]any { return map[string]any{"type": []string{"integer", "null"}, "minimum": 0} }
+	return map[string]any{
+		"type": "object", "additionalProperties": false,
+		"required": []string{"transmitted_requests", "settled_requests", "in_flight_requests", "pending_reconciliation_requests", "confirmed_no_charge_requests", "token_usage_samples", "settlement_entries", "input_tokens", "output_tokens", "settled_spend_microusd"},
+		"properties": map[string]any{
+			"transmitted_requests":            nonNegativeInteger(),
+			"settled_requests":                nonNegativeInteger(),
+			"in_flight_requests":              nonNegativeInteger(),
+			"pending_reconciliation_requests": nonNegativeInteger(),
+			"confirmed_no_charge_requests":    nonNegativeInteger(),
+			"token_usage_samples":             nonNegativeInteger(),
+			"settlement_entries":              nonNegativeInteger(),
+			"input_tokens":                    nullableNonNegativeInteger(),
+			"output_tokens":                   nullableNonNegativeInteger(),
+			"settled_spend_microusd":          nonNegativeInteger(),
+		},
+	}
+}
+
+func hostedModelAPIUsageEvidenceSchema() map[string]any {
+	return map[string]any{
+		"type": "object", "additionalProperties": false,
+		"required": []string{"source", "request_scope", "latest_request_at", "token_usage_complete", "reconciliation_complete", "content_recorded", "available", "unavailable"},
+		"properties": map[string]any{
+			"source":                  map[string]any{"type": "string", "const": "model_api_usage_reservations+model_api_usage_ledger"},
+			"request_scope":           map[string]any{"type": "string", "const": "funded_supplier_attempts"},
+			"latest_request_at":       map[string]any{"type": []string{"string", "null"}, "format": "date-time"},
+			"token_usage_complete":    map[string]any{"type": "boolean"},
+			"reconciliation_complete": map[string]any{"type": "boolean"},
+			"content_recorded":        map[string]any{"type": "boolean", "const": false},
+			"available":               map[string]any{"type": "array", "uniqueItems": true, "items": map[string]any{"type": "string", "enum": []string{"requests", "reconciliation_state", "settled_spend", "tokens"}}},
+			"unavailable":             map[string]any{"type": "array", "uniqueItems": true, "items": map[string]any{"type": "string", "enum": []string{"errors", "latency", "ttft", "tokens"}}},
+		},
+	}
+}
+
+func hostedModelAPIUsageSchema() map[string]any {
+	return map[string]any{
+		"type": "object", "additionalProperties": false,
+		"required": []string{"window_start", "window_end", "bucket_seconds", "currency", "summary", "models", "series", "evidence"},
+		"properties": map[string]any{
+			"window_start":   map[string]any{"type": "string", "format": "date-time"},
+			"window_end":     map[string]any{"type": "string", "format": "date-time"},
+			"bucket_seconds": map[string]any{"type": "integer", "minimum": 60, "maximum": 86400},
+			"currency":       map[string]any{"type": "string", "const": "USD"},
+			"summary":        ref("HostedModelAPIUsageSummary"),
+			"models":         map[string]any{"type": "array", "items": ref("HostedModelAPIUsageModel")},
+			"series":         map[string]any{"type": "array", "maxItems": 500, "items": ref("HostedModelAPIUsageBucket")},
+			"evidence":       ref("HostedModelAPIUsageEvidence"),
+		},
 	}
 }
 

--- a/internal/apicontract/model_api_usage_test.go
+++ b/internal/apicontract/model_api_usage_test.go
@@ -1,0 +1,36 @@
+package apicontract
+
+import "testing"
+
+func TestHostedModelAPIUsageContractIsBoundedAndDoesNotClaimPerformance(t *testing.T) {
+	doc, err := Document()
+	if err != nil {
+		t.Fatal(err)
+	}
+	operation := doc["paths"].(map[string]any)["/api/v1/model-api-usage"].(map[string]any)["get"].(map[string]any)
+	parameters, ok := operation["parameters"].([]map[string]any)
+	if !ok {
+		t.Fatalf("hosted usage query parameters missing: %#v", operation["parameters"])
+	}
+	found := map[string]bool{}
+	for _, parameter := range parameters {
+		found[parameter["name"].(string)] = true
+	}
+	for _, name := range []string{"window_seconds", "bucket_seconds", "model"} {
+		if !found[name] {
+			t.Fatalf("hosted usage query parameter %q missing", name)
+		}
+	}
+	schemas := doc["components"].(map[string]any)["schemas"].(map[string]any)
+	summary := schemas["HostedModelAPIUsageSummary"].(map[string]any)["properties"].(map[string]any)
+	for _, unavailable := range []string{"errors", "error_rate", "latency", "p95_latency_ms", "ttft", "p95_ttft_ms"} {
+		if summary[unavailable] != nil {
+			t.Fatalf("hosted billing evidence must not claim %q", unavailable)
+		}
+	}
+	for _, required := range []string{"transmitted_requests", "pending_reconciliation_requests", "input_tokens", "settled_spend_microusd"} {
+		if summary[required] == nil {
+			t.Fatalf("hosted usage schema missing %q", required)
+		}
+	}
+}

--- a/internal/controlapi/api.go
+++ b/internal/controlapi/api.go
@@ -143,6 +143,9 @@ type diagnosticStore interface {
 type monitoringStore interface {
 	EndpointMonitoring(context.Context, string, string, time.Duration, time.Duration) (domain.EndpointMonitoringSnapshot, error)
 }
+type hostedModelAPIUsageStore interface {
+	HostedModelAPIUsage(context.Context, string, string, time.Duration, time.Duration) (domain.HostedModelAPIUsageSnapshot, error)
+}
 type operationalMeasurementStore interface {
 	RecordOperationalMeasurements(context.Context, string, string, []domain.OperationalMeasurement) ([]domain.OperationalMeasurement, error)
 }
@@ -397,6 +400,7 @@ func (a API) Handler() http.Handler {
 	mux.HandleFunc("POST /api/v1/planning/intents", a.auth(authz.Read, a.planIntent))
 	mux.HandleFunc("GET /api/v1/model-api-catalog", a.auth(authz.Read, a.modelAPIModels))
 	mux.HandleFunc("GET /api/v1/model-api-catalog/{id}", a.auth(authz.Read, a.modelAPIModel))
+	mux.HandleFunc("GET /api/v1/model-api-usage", a.auth(authz.Read, a.hostedModelAPIUsage))
 	mux.HandleFunc("POST /api/v1/admin/model-api/products", a.auth(authz.ManageModelAPI, a.publishModelAPIProduct))
 	mux.HandleFunc("POST /api/v1/admin/model-api/rates", a.auth(authz.ManageModelAPI, a.publishModelAPIRetailRate))
 	mux.HandleFunc("POST /api/v1/admin/model-api/offers", a.auth(authz.ManageModelAPI, a.publishModelAPISupplierOffer))

--- a/internal/controlapi/model_api_usage.go
+++ b/internal/controlapi/model_api_usage.go
@@ -1,0 +1,59 @@
+package controlapi
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/domain"
+)
+
+func (a API) hostedModelAPIUsage(w http.ResponseWriter, r *http.Request) {
+	usageStore, ok := a.Store.(hostedModelAPIUsageStore)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "capability_unavailable", "hosted Model API usage is not supported by this store")
+		return
+	}
+	allowed := map[string]bool{"window_seconds": true, "bucket_seconds": true, "model": true}
+	for key, values := range r.URL.Query() {
+		if !allowed[key] || len(values) != 1 {
+			writeError(w, http.StatusBadRequest, "invalid_request", "hosted Model API usage accepts one window_seconds, bucket_seconds, and model value")
+			return
+		}
+	}
+	windowSeconds := 24 * 60 * 60
+	if raw := r.URL.Query().Get("window_seconds"); raw != "" {
+		value, err := strconv.Atoi(raw)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "window_seconds must be an integer")
+			return
+		}
+		windowSeconds = value
+	}
+	bucketSeconds := defaultMonitoringBucket(windowSeconds)
+	if raw := r.URL.Query().Get("bucket_seconds"); raw != "" {
+		value, err := strconv.Atoi(raw)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "bucket_seconds must be an integer")
+			return
+		}
+		bucketSeconds = value
+	}
+	if windowSeconds < 60 || windowSeconds > 30*24*60*60 || bucketSeconds < 60 || bucketSeconds > 24*60*60 || bucketSeconds > windowSeconds || (windowSeconds+bucketSeconds-1)/bucketSeconds+1 > 500 {
+		writeError(w, http.StatusUnprocessableEntity, "validation_failed", "hosted Model API usage requires a 1 minute..30 day window, a 1 minute..24 hour bucket, and at most 500 buckets")
+		return
+	}
+	model := r.URL.Query().Get("model")
+	if model != strings.TrimSpace(model) || len(model) > 256 {
+		writeError(w, http.StatusUnprocessableEntity, "validation_failed", "model must be trimmed and at most 256 characters")
+		return
+	}
+	actor := r.Context().Value(identityKey{}).(domain.Principal)
+	snapshot, err := usageStore.HostedModelAPIUsage(r.Context(), actor.TenantID, model, time.Duration(windowSeconds)*time.Second, time.Duration(bucketSeconds)*time.Second)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "model_api_usage_unavailable", "hosted Model API usage evidence could not be read")
+		return
+	}
+	writeJSON(w, http.StatusOK, snapshot)
+}

--- a/internal/controlapi/model_api_usage_test.go
+++ b/internal/controlapi/model_api_usage_test.go
@@ -1,0 +1,99 @@
+package controlapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/authz"
+	"github.com/infercrane/infercrane/internal/domain"
+)
+
+type fakeHostedModelAPIUsageStore struct {
+	*fakeStore
+	snapshot domain.HostedModelAPIUsageSnapshot
+	tenant   string
+	model    string
+	window   time.Duration
+	bucket   time.Duration
+	err      error
+}
+
+func (f *fakeHostedModelAPIUsageStore) HostedModelAPIUsage(_ context.Context, tenant, model string, window, bucket time.Duration) (domain.HostedModelAPIUsageSnapshot, error) {
+	f.tenant, f.model, f.window, f.bucket = tenant, model, window, bucket
+	return f.snapshot, f.err
+}
+
+func TestHostedModelAPIUsageIsTenantScopedAndTruthful(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	input, output := int64(120), int64(40)
+	base := &fakeStore{principal: domain.Principal{ID: "reader", TenantID: "tenant-a", Name: "reader", Role: string(authz.Viewer), Scopes: []string{"read"}}}
+	usage := &fakeHostedModelAPIUsageStore{fakeStore: base, snapshot: domain.HostedModelAPIUsageSnapshot{
+		WindowStart: now.Add(-time.Hour), WindowEnd: now, BucketSeconds: 300, Currency: "USD",
+		Summary:  domain.HostedModelAPIUsageSummary{TransmittedRequests: 2, SettledRequests: 1, PendingReconciliationRequests: 1, TokenUsageSamples: 1, SettlementEntries: 1, InputTokens: &input, OutputTokens: &output, SettledSpendMicrousd: 2400},
+		Models:   []domain.HostedModelAPIUsageModel{{ProductID: "glm-5.2", LatestRequestAt: now, Usage: domain.HostedModelAPIUsageSummary{TransmittedRequests: 2}}},
+		Series:   []domain.HostedModelAPIUsageBucket{},
+		Evidence: domain.HostedModelAPIUsageEvidence{Source: "model_api_usage_reservations+model_api_usage_ledger", RequestScope: "funded_supplier_attempts", LatestRequestAt: &now, ContentRecorded: false, Available: []string{"requests", "tokens", "settled_spend"}, Unavailable: []string{"errors", "latency", "ttft"}},
+	}}
+	handler := (API{Store: usage, Authenticator: usage}).Handler()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/model-api-usage?window_seconds=3600&bucket_seconds=300&model=glm-5.2", nil)
+	request.Header.Set("Authorization", "Bearer tenant-token")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	body := response.Body.String()
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, body)
+	}
+	if usage.tenant != "tenant-a" || usage.model != "glm-5.2" || usage.window != time.Hour || usage.bucket != 5*time.Minute {
+		t.Fatalf("unexpected store request tenant=%q model=%q window=%s bucket=%s", usage.tenant, usage.model, usage.window, usage.bucket)
+	}
+	for _, expected := range []string{`"transmitted_requests":2`, `"pending_reconciliation_requests":1`, `"input_tokens":120`, `"settled_spend_microusd":2400`, `"request_scope":"funded_supplier_attempts"`, `"content_recorded":false`} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("missing %s in %s", expected, body)
+		}
+	}
+	for _, forbidden := range []string{`"supplier"`, `"supplier_model_id"`, `"error_count"`, `"p95_latency_ms"`, `"p95_ttft_ms"`} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("hosted usage leaked or invented %s in %s", forbidden, body)
+		}
+	}
+}
+
+func TestHostedModelAPIUsageRejectsUnboundedOrAmbiguousQueries(t *testing.T) {
+	base := &fakeStore{principal: domain.Principal{ID: "reader", TenantID: "tenant-a", Name: "reader", Role: string(authz.Viewer), Scopes: []string{"read"}}}
+	usage := &fakeHostedModelAPIUsageStore{fakeStore: base}
+	handler := (API{Store: usage, Authenticator: usage}).Handler()
+	for _, test := range []struct {
+		query string
+		want  int
+	}{
+		{"?unexpected=1", http.StatusBadRequest},
+		{"?model=a&model=b", http.StatusBadRequest},
+		{"?window_seconds=abc", http.StatusBadRequest},
+		{"?window_seconds=2592000&bucket_seconds=60", http.StatusUnprocessableEntity},
+		{"?model=%20glm-5.2", http.StatusUnprocessableEntity},
+	} {
+		request := httptest.NewRequest(http.MethodGet, "/api/v1/model-api-usage"+test.query, nil)
+		request.Header.Set("Authorization", "Bearer tenant-token")
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+		if response.Code != test.want {
+			t.Fatalf("query=%q status=%d want=%d body=%s", test.query, response.Code, test.want, response.Body.String())
+		}
+	}
+}
+
+func TestHostedModelAPIUsageRequiresReadScope(t *testing.T) {
+	base := &fakeStore{principal: domain.Principal{ID: "operator", TenantID: "tenant-a", Name: "operator", Role: string(authz.Operator), Scopes: []string{"deploy"}}}
+	usage := &fakeHostedModelAPIUsageStore{fakeStore: base}
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/model-api-usage", nil)
+	request.Header.Set("Authorization", "Bearer tenant-token")
+	response := httptest.NewRecorder()
+	(API{Store: usage, Authenticator: usage}).Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+}

--- a/internal/domain/model_api_usage.go
+++ b/internal/domain/model_api_usage.go
@@ -1,0 +1,56 @@
+package domain
+
+import "time"
+
+// HostedModelAPIUsageSnapshot is a bounded, tenant-scoped projection of
+// funded hosted Model API supplier attempts. It intentionally excludes
+// latency, error, and content fields because the hosted billing journal does
+// not record those observations.
+type HostedModelAPIUsageSnapshot struct {
+	WindowStart   time.Time                   `json:"window_start"`
+	WindowEnd     time.Time                   `json:"window_end"`
+	BucketSeconds int                         `json:"bucket_seconds"`
+	Currency      string                      `json:"currency"`
+	Summary       HostedModelAPIUsageSummary  `json:"summary"`
+	Models        []HostedModelAPIUsageModel  `json:"models"`
+	Series        []HostedModelAPIUsageBucket `json:"series"`
+	Evidence      HostedModelAPIUsageEvidence `json:"evidence"`
+}
+
+// HostedModelAPIUsageSummary reports the current settlement state of supplier
+// attempts transmitted during the requested window. Token totals are null
+// when no settled row contains token evidence.
+type HostedModelAPIUsageSummary struct {
+	TransmittedRequests           int64  `json:"transmitted_requests"`
+	SettledRequests               int64  `json:"settled_requests"`
+	InFlightRequests              int64  `json:"in_flight_requests"`
+	PendingReconciliationRequests int64  `json:"pending_reconciliation_requests"`
+	ConfirmedNoChargeRequests     int64  `json:"confirmed_no_charge_requests"`
+	TokenUsageSamples             int64  `json:"token_usage_samples"`
+	SettlementEntries             int64  `json:"settlement_entries"`
+	InputTokens                   *int64 `json:"input_tokens"`
+	OutputTokens                  *int64 `json:"output_tokens"`
+	SettledSpendMicrousd          int64  `json:"settled_spend_microusd"`
+}
+
+type HostedModelAPIUsageModel struct {
+	ProductID       string                     `json:"product_id"`
+	LatestRequestAt time.Time                  `json:"latest_request_at"`
+	Usage           HostedModelAPIUsageSummary `json:"usage"`
+}
+
+type HostedModelAPIUsageBucket struct {
+	StartedAt time.Time                  `json:"started_at"`
+	Usage     HostedModelAPIUsageSummary `json:"usage"`
+}
+
+type HostedModelAPIUsageEvidence struct {
+	Source                 string     `json:"source"`
+	RequestScope           string     `json:"request_scope"`
+	LatestRequestAt        *time.Time `json:"latest_request_at"`
+	TokenUsageComplete     bool       `json:"token_usage_complete"`
+	ReconciliationComplete bool       `json:"reconciliation_complete"`
+	ContentRecorded        bool       `json:"content_recorded"`
+	Available              []string   `json:"available"`
+	Unavailable            []string   `json:"unavailable"`
+}

--- a/internal/store/model_api_usage.go
+++ b/internal/store/model_api_usage.go
@@ -1,0 +1,150 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/domain"
+)
+
+const hostedModelAPIUsageAggregates = `COUNT(*),COUNT(*) FILTER(WHERE r.state='settled'),COUNT(*) FILTER(WHERE r.state IN ('transmitted','response_started')),COUNT(*) FILTER(WHERE r.state='pending_reconciliation'),COUNT(*) FILTER(WHERE r.state='released'),COUNT(*) FILTER(WHERE r.input_tokens IS NOT NULL AND r.output_tokens IS NOT NULL),COUNT(l.id),COALESCE(SUM(r.input_tokens),0),COALESCE(SUM(r.output_tokens),0),COALESCE(SUM(-l.amount_microusd),0)`
+
+// HostedModelAPIUsage returns billing-journal evidence for supplier attempts
+// transmitted in the requested window. Supplier identities and private route
+// data never cross this customer-facing boundary.
+func (s *Store) HostedModelAPIUsage(ctx context.Context, tenant, product string, window, bucket time.Duration) (domain.HostedModelAPIUsageSnapshot, error) {
+	if err := validateHostedModelAPIUsageQuery(tenant, product, window, bucket); err != nil {
+		return domain.HostedModelAPIUsageSnapshot{}, err
+	}
+	end := time.Now().UTC()
+	start := end.Add(-window)
+	out := domain.HostedModelAPIUsageSnapshot{
+		WindowStart: start, WindowEnd: end, BucketSeconds: int(bucket.Seconds()), Currency: "USD",
+		Models: []domain.HostedModelAPIUsageModel{}, Series: []domain.HostedModelAPIUsageBucket{},
+		Evidence: domain.HostedModelAPIUsageEvidence{
+			Source: "model_api_usage_reservations+model_api_usage_ledger", RequestScope: "funded_supplier_attempts",
+			ContentRecorded: false, Available: []string{"requests", "reconciliation_state", "settled_spend"},
+			Unavailable: []string{"errors", "latency", "ttft"},
+		},
+	}
+	filter, args := hostedModelAPIUsageFilter(tenant, product, start, end)
+	rows, err := s.QueryContext(ctx, `SELECT r.product_id,`+hostedModelAPIUsageAggregates+`,MAX(r.transmitted_at) FROM model_api_usage_reservations r LEFT JOIN model_api_usage_ledger l ON l.customer_tenant_id=r.customer_tenant_id AND l.reservation_id=r.id AND l.kind='settlement' `+filter+` GROUP BY r.product_id ORDER BY r.product_id`, args...)
+	if err != nil {
+		return domain.HostedModelAPIUsageSnapshot{}, err
+	}
+	for rows.Next() {
+		var item domain.HostedModelAPIUsageModel
+		var inputTokens, outputTokens int64
+		if err = rows.Scan(&item.ProductID, &item.Usage.TransmittedRequests, &item.Usage.SettledRequests, &item.Usage.InFlightRequests, &item.Usage.PendingReconciliationRequests, &item.Usage.ConfirmedNoChargeRequests, &item.Usage.TokenUsageSamples, &item.Usage.SettlementEntries, &inputTokens, &outputTokens, &item.Usage.SettledSpendMicrousd, &item.LatestRequestAt); err != nil {
+			rows.Close()
+			return domain.HostedModelAPIUsageSnapshot{}, err
+		}
+		item.LatestRequestAt = item.LatestRequestAt.UTC()
+		setHostedModelAPITokenTotals(&item.Usage, inputTokens, outputTokens)
+		mergeHostedModelAPIUsage(&out.Summary, item.Usage)
+		if out.Evidence.LatestRequestAt == nil || item.LatestRequestAt.After(*out.Evidence.LatestRequestAt) {
+			latest := item.LatestRequestAt
+			out.Evidence.LatestRequestAt = &latest
+		}
+		out.Models = append(out.Models, item)
+	}
+	if err = rows.Close(); err != nil {
+		return domain.HostedModelAPIUsageSnapshot{}, err
+	}
+	if err = rows.Err(); err != nil {
+		return domain.HostedModelAPIUsageSnapshot{}, err
+	}
+
+	seriesArgs := append([]any{int(bucket.Seconds())}, args...)
+	rows, err = s.QueryContext(ctx, `SELECT date_bin((? * INTERVAL '1 second'),r.transmitted_at,TIMESTAMPTZ '1970-01-01'),`+hostedModelAPIUsageAggregates+` FROM model_api_usage_reservations r LEFT JOIN model_api_usage_ledger l ON l.customer_tenant_id=r.customer_tenant_id AND l.reservation_id=r.id AND l.kind='settlement' `+filter+` GROUP BY 1 ORDER BY 1`, seriesArgs...)
+	if err != nil {
+		return domain.HostedModelAPIUsageSnapshot{}, err
+	}
+	series := make(map[int64]domain.HostedModelAPIUsageBucket)
+	for rows.Next() {
+		var item domain.HostedModelAPIUsageBucket
+		var inputTokens, outputTokens int64
+		if err = rows.Scan(&item.StartedAt, &item.Usage.TransmittedRequests, &item.Usage.SettledRequests, &item.Usage.InFlightRequests, &item.Usage.PendingReconciliationRequests, &item.Usage.ConfirmedNoChargeRequests, &item.Usage.TokenUsageSamples, &item.Usage.SettlementEntries, &inputTokens, &outputTokens, &item.Usage.SettledSpendMicrousd); err != nil {
+			rows.Close()
+			return domain.HostedModelAPIUsageSnapshot{}, err
+		}
+		item.StartedAt = item.StartedAt.UTC()
+		setHostedModelAPITokenTotals(&item.Usage, inputTokens, outputTokens)
+		series[item.StartedAt.Unix()] = item
+	}
+	if err = rows.Close(); err != nil {
+		return domain.HostedModelAPIUsageSnapshot{}, err
+	}
+	if err = rows.Err(); err != nil {
+		return domain.HostedModelAPIUsageSnapshot{}, err
+	}
+	seconds := int64(bucket.Seconds())
+	first := time.Unix((start.Unix()/seconds)*seconds, 0).UTC()
+	last := time.Unix((end.Unix()/seconds)*seconds, 0).UTC()
+	for stamp := first; !stamp.After(last); stamp = stamp.Add(bucket) {
+		item, ok := series[stamp.Unix()]
+		if !ok {
+			item.StartedAt = stamp
+		}
+		out.Series = append(out.Series, item)
+	}
+	out.Evidence.TokenUsageComplete = out.Summary.TransmittedRequests == out.Summary.TokenUsageSamples+out.Summary.ConfirmedNoChargeRequests
+	out.Evidence.ReconciliationComplete = out.Evidence.TokenUsageComplete && out.Summary.SettledRequests == out.Summary.SettlementEntries
+	if out.Summary.TokenUsageSamples > 0 {
+		out.Evidence.Available = append(out.Evidence.Available, "tokens")
+	} else {
+		out.Evidence.Unavailable = append(out.Evidence.Unavailable, "tokens")
+	}
+	return out, nil
+}
+
+func validateHostedModelAPIUsageQuery(tenant, product string, window, bucket time.Duration) error {
+	if strings.TrimSpace(tenant) == "" {
+		return errors.New("tenant is required")
+	}
+	if product != strings.TrimSpace(product) || len(product) > 256 {
+		return errors.New("model filter must be trimmed and at most 256 characters")
+	}
+	if window < time.Minute || window > 30*24*time.Hour || bucket < time.Minute || bucket > 24*time.Hour || bucket > window || (window+bucket-1)/bucket+1 > 500 {
+		return errors.New("hosted Model API usage requires a 1 minute..30 day window, a 1 minute..24 hour bucket, and at most 500 buckets")
+	}
+	return nil
+}
+
+func hostedModelAPIUsageFilter(tenant, product string, start, end time.Time) (string, []any) {
+	query := `WHERE r.customer_tenant_id=? AND r.transmitted_at IS NOT NULL AND r.transmitted_at>=? AND r.transmitted_at<=?`
+	args := []any{tenant, start, end}
+	if product != "" {
+		query += ` AND r.product_id=?`
+		args = append(args, product)
+	}
+	return query, args
+}
+
+func setHostedModelAPITokenTotals(summary *domain.HostedModelAPIUsageSummary, input, output int64) {
+	if summary.TokenUsageSamples == 0 {
+		return
+	}
+	summary.InputTokens, summary.OutputTokens = &input, &output
+}
+
+func mergeHostedModelAPIUsage(total *domain.HostedModelAPIUsageSummary, item domain.HostedModelAPIUsageSummary) {
+	total.TransmittedRequests += item.TransmittedRequests
+	total.SettledRequests += item.SettledRequests
+	total.InFlightRequests += item.InFlightRequests
+	total.PendingReconciliationRequests += item.PendingReconciliationRequests
+	total.ConfirmedNoChargeRequests += item.ConfirmedNoChargeRequests
+	total.TokenUsageSamples += item.TokenUsageSamples
+	total.SettlementEntries += item.SettlementEntries
+	total.SettledSpendMicrousd += item.SettledSpendMicrousd
+	if item.InputTokens != nil && item.OutputTokens != nil {
+		if total.InputTokens == nil {
+			input, output := int64(0), int64(0)
+			total.InputTokens, total.OutputTokens = &input, &output
+		}
+		*total.InputTokens += *item.InputTokens
+		*total.OutputTokens += *item.OutputTokens
+	}
+}

--- a/internal/store/model_api_usage_test.go
+++ b/internal/store/model_api_usage_test.go
@@ -1,0 +1,56 @@
+package store
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/domain"
+)
+
+func TestHostedModelAPIUsageFilterAlwaysScopesTenantAndPublicProduct(t *testing.T) {
+	start, end := time.Now().Add(-time.Hour), time.Now()
+	query, args := hostedModelAPIUsageFilter("tenant-a", "glm-5.2", start, end)
+	if !strings.Contains(query, "r.customer_tenant_id=?") || !strings.Contains(query, "r.product_id=?") {
+		t.Fatalf("usage query is not tenant and product scoped: %s", query)
+	}
+	if len(args) != 4 || args[0] != "tenant-a" || args[3] != "glm-5.2" {
+		t.Fatalf("unexpected filter args: %#v", args)
+	}
+	if !strings.Contains(hostedModelAPIUsageAggregates, "COUNT(l.id)") || !strings.Contains(hostedModelAPIUsageAggregates, "SUM(-l.amount_microusd)") {
+		t.Fatalf("settled spend must come from settlement ledger evidence: %s", hostedModelAPIUsageAggregates)
+	}
+}
+
+func TestHostedModelAPIUsageValidationIsBounded(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		tenant, product string
+		window, bucket  time.Duration
+	}{
+		{"missing tenant", "", "", time.Hour, time.Minute},
+		{"untrimmed product", "tenant", " model", time.Hour, time.Minute},
+		{"long window", "tenant", "", 31 * 24 * time.Hour, time.Hour},
+		{"too many buckets", "tenant", "", 24 * time.Hour, time.Minute},
+	} {
+		if err := validateHostedModelAPIUsageQuery(test.tenant, test.product, test.window, test.bucket); err == nil {
+			t.Fatalf("%s unexpectedly passed validation", test.name)
+		}
+	}
+	if err := validateHostedModelAPIUsageQuery("tenant", "glm-5.2", 24*time.Hour, 15*time.Minute); err != nil {
+		t.Fatalf("valid query failed: %v", err)
+	}
+}
+
+func TestMergeHostedModelAPIUsagePreservesUnknownTokens(t *testing.T) {
+	var total domain.HostedModelAPIUsageSummary
+	mergeHostedModelAPIUsage(&total, domain.HostedModelAPIUsageSummary{TransmittedRequests: 1, PendingReconciliationRequests: 1})
+	if total.InputTokens != nil || total.OutputTokens != nil {
+		t.Fatalf("unknown token totals became zero: %#v", total)
+	}
+	input, output := int64(100), int64(25)
+	mergeHostedModelAPIUsage(&total, domain.HostedModelAPIUsageSummary{TransmittedRequests: 1, SettledRequests: 1, TokenUsageSamples: 1, SettlementEntries: 1, InputTokens: &input, OutputTokens: &output, SettledSpendMicrousd: 99})
+	if total.InputTokens == nil || *total.InputTokens != 100 || total.OutputTokens == nil || *total.OutputTokens != 25 || total.SettledSpendMicrousd != 99 {
+		t.Fatalf("settled evidence did not merge: %#v", total)
+	}
+}

--- a/sdk/python/src/infercrane/generated/api.py
+++ b/sdk/python/src/infercrane/generated/api.py
@@ -71,6 +71,10 @@ class ControlAPI:
         path = f"/model-api-catalog/{quote(id, safe='')}"
         return cast(dict[str, Any], self._transport.request("GET", path))
 
+    def get_hosted_model_a_p_i_usage(self) -> dict[str, Any]:
+        path = "/model-api-usage"
+        return cast(dict[str, Any], self._transport.request("GET", path))
+
     def publish_model_a_p_i_product(self, *, body: dict[str, Any]) -> dict[str, Any]:
         path = "/admin/model-api/products"
         return cast(dict[str, Any], self._transport.request("POST", path, body=body))

--- a/sdk/typescript/src/generated/api.ts
+++ b/sdk/typescript/src/generated/api.ts
@@ -78,6 +78,11 @@ export class ControlApi {
     return this.transport.request('GET', path) as Promise<Record<string, JsonValue>>;
   }
 
+  getHostedModelAPIUsage(): Promise<Record<string, JsonValue>> {
+    const path = '/model-api-usage';
+    return this.transport.request('GET', path) as Promise<Record<string, JsonValue>>;
+  }
+
   publishModelAPIProduct(body: JsonValue): Promise<Record<string, JsonValue>> {
     const path = '/admin/model-api/products';
     return this.transport.request('POST', path, { body }) as Promise<Record<string, JsonValue>>;


### PR DESCRIPTION
## Summary
- expose tenant-scoped hosted Model API usage and settlement evidence
- aggregate requests, tokens, reconciliation state, and settled spend without recording content
- keep unavailable latency/error evidence explicit

## Validation
- go test ./...
- git diff --check