### PR TITLE
Add dormant Hugging Face router adapter for MVP catalog

### DIFF
--- a/cmd/infercrane/main.go
+++ b/cmd/infercrane/main.go
@@ -4347,8 +4347,12 @@ func serve(parent context.Context, cfg config.Config, s *store.Store) error {
 		if resolverErr != nil {
 			return fmt.Errorf("configure hosted Model API targets: %w", resolverErr)
 		}
+		// MVP funding boundary: adapters may exist without publishing catalog
+		// products. Only one customer-callable model is intentionally funded and
+		// qualified until InferCrane can fund compute for the full catalog.
 		supplierAdapters, adapterErr := supplieradapter.NewRegistry(
 			supplieradapter.NewDeepSeekAdapter(client),
+			supplieradapter.NewHuggingFaceRouterAdapter(client),
 			supplieradapter.NewRunPodVLLMAdapter(client),
 		)
 		if adapterErr != nil {

--- a/internal/modelapiqualification/qualification.go
+++ b/internal/modelapiqualification/qualification.go
@@ -1,5 +1,5 @@
-// Package modelapiqualification builds deterministic qualification evidence
-// for one exact hosted Model API target.
+// Package modelapiqualification builds deterministic, time-bounded
+// qualification evidence for one provider-bound Model API target.
 package modelapiqualification
 
 import (
@@ -22,9 +22,11 @@ const (
 	nanosecondsPerSec = int64(time.Second)
 )
 
-// Target is the exact supplier tuple proven by a qualification run. TupleKey
-// is the opaque key already carried by an immutable supplier offer; the other
-// fields make the key's meaning auditable instead of relying on convention.
+// Target is the provider-bound supplier tuple observed by a qualification run.
+// TupleKey is the opaque key already carried by an immutable supplier offer;
+// the other fields make the key's meaning auditable instead of relying on
+// convention. A routed provider tuple is not proof of its private runtime or
+// model revision, so evidence is always limited to MaximumValidity.
 type Target struct {
 	TupleKey        string   `json:"tuple_key"`
 	Supplier        string   `json:"supplier"`

--- a/internal/modelapirouting/directory.go
+++ b/internal/modelapirouting/directory.go
@@ -75,6 +75,7 @@ type Candidate struct {
 	OfferVersion                                                 int64
 	Protocol, Supplier, SupplierModelID                          string
 	TargetBindingID, TargetBindingDigest                         string `json:"-"`
+	BillingPrincipal                                             string `json:"-"`
 	Operations                                                   []string
 	Endpoint, Credential                                         string `json:"-"`
 	Adapter, CredentialReference                                 string `json:"-"`
@@ -131,6 +132,7 @@ type CandidateSource struct {
 	CredentialReference  string `json:"-"`
 	EndpointReference    string `json:"-"`
 	EndpointConfigDigest string `json:"-"`
+	BillingPrincipal     string `json:"-"`
 }
 
 // Lease pins an immutable route generation and retail contract for one

--- a/internal/modelapirouting/publisher.go
+++ b/internal/modelapirouting/publisher.go
@@ -212,8 +212,8 @@ func (p *Publisher) PublishOnce(ctx context.Context) error {
 					}
 					target, resolveErr = boundResolver.ResolveBoundHostedModelReference(ctx, source.Publication.OperatorTenantID, candidate.Supplier, candidateSource.Adapter, candidateSource.CredentialReference, candidateSource.EndpointReference, candidateSource.EndpointConfigDigest)
 				} else {
-					if candidateSource.Adapter == supplieradapter.RunPodVLLMAdapterName {
-						return errors.New("RunPod hosted candidate requires a current immutable target binding")
+					if supplieradapter.RequiresImmutableTargetBinding(candidateSource.Adapter) {
+						return errors.New("hosted candidate requires a current immutable target binding")
 					}
 					target, resolveErr = referenceResolver.ResolveHostedModelReference(ctx, source.Publication.OperatorTenantID, candidate.Supplier, candidateSource.Adapter, candidateSource.CredentialReference)
 				}

--- a/internal/modelapirouting/publisher.go
+++ b/internal/modelapirouting/publisher.go
@@ -197,7 +197,11 @@ func (p *Publisher) PublishOnce(ctx context.Context) error {
 			if strings.TrimSpace(candidateSource.Adapter) == "" || strings.TrimSpace(candidateSource.CredentialReference) == "" {
 				return errors.New("published hosted candidate lacks adapter or credential reference")
 			}
+			if supplieradapter.RequiresBillingPrincipal(candidateSource.Adapter) && strings.TrimSpace(candidateSource.BillingPrincipal) == "" {
+				return errors.New("published hosted candidate lacks an immutable billing principal")
+			}
 			candidate := candidateSource.Candidate
+			candidate.BillingPrincipal = candidateSource.BillingPrincipal
 			if _, strict := p.Adapters.Lookup(candidateSource.Adapter); strict {
 				referenceResolver, ok := p.Resolver.(ReferenceTargetResolver)
 				if !ok {

--- a/internal/modelapirouting/publisher_test.go
+++ b/internal/modelapirouting/publisher_test.go
@@ -217,6 +217,7 @@ func TestPublisherKeepsRoutedInferenceDormantWithoutImmutableTargetBinding(t *te
 	if err != nil {
 		t.Fatal(err)
 	}
+	candidateSource.BillingPrincipal = "infercrane"
 	resolver, err := NewRegistryTargetResolver(map[string]string{endpointReference: supplieradapter.HuggingFaceRouterBaseURL}, &referenceStoreFake{}, &secretValueFailIfResolved{})
 	if err != nil {
 		t.Fatal(err)
@@ -231,11 +232,16 @@ func TestPublisherKeepsRoutedInferenceDormantWithoutImmutableTargetBinding(t *te
 	candidateSource.Candidate.TargetBindingDigest = "sha256:" + strings.Repeat("a", 64)
 	candidateSource.EndpointReference = endpointReference
 	candidateSource.EndpointConfigDigest = digest
+	candidateSource.BillingPrincipal = ""
+	if err = publisher.PublishOnce(context.Background()); err == nil {
+		t.Fatal("routed inference route without a pinned billing principal was published")
+	}
+	candidateSource.BillingPrincipal = "infercrane"
 	if err = publisher.PublishOnce(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	lease, err := directory.Acquire("customer", "glm-5.3")
-	if err != nil || lease.Candidates[0].Endpoint != supplieradapter.HuggingFaceRouterBaseURL || lease.Candidates[0].TargetBindingID != "binding-hf-1" {
+	if err != nil || lease.Candidates[0].Endpoint != supplieradapter.HuggingFaceRouterBaseURL || lease.Candidates[0].TargetBindingID != "binding-hf-1" || lease.Candidates[0].BillingPrincipal != "infercrane" {
 		t.Fatalf("bound routed inference route=%#v err=%v", lease, err)
 	}
 }

--- a/internal/modelapirouting/publisher_test.go
+++ b/internal/modelapirouting/publisher_test.go
@@ -204,6 +204,42 @@ func TestPublisherRequiresAndVerifiesRunPodTargetBinding(t *testing.T) {
 	}
 }
 
+func TestPublisherKeepsRoutedInferenceDormantWithoutImmutableTargetBinding(t *testing.T) {
+	now := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
+	source := sourceFixture(now, "customer")
+	candidateSource := &source.Candidates[0]
+	candidateSource.Candidate.Supplier = supplieradapter.HuggingFaceSupplier
+	candidateSource.Candidate.SupplierModelID = "Qwen/Qwen3-8B:together"
+	candidateSource.Adapter = supplieradapter.HuggingFaceRouterAdapterName
+	candidateSource.CredentialReference = "router-reference"
+	endpointReference := supplieradapter.HuggingFaceSupplier + "/" + supplieradapter.HuggingFaceRouterAdapterName
+	digest, err := modelapitarget.EndpointConfigDigest(endpointReference, supplieradapter.HuggingFaceRouterBaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver, err := NewRegistryTargetResolver(map[string]string{endpointReference: supplieradapter.HuggingFaceRouterBaseURL}, &referenceStoreFake{}, &secretValueFailIfResolved{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	directory := NewDirectory()
+	directory.now = func() time.Time { return now }
+	publisher := &Publisher{Store: &sourceStoreFake{sources: []RouteSource{source}}, Resolver: resolver, Adapters: supplieradapter.DefaultRegistry(), Directory: directory, Now: func() time.Time { return now }}
+	if err = publisher.PublishOnce(context.Background()); err == nil {
+		t.Fatal("routed inference route without an immutable target binding was published")
+	}
+	candidateSource.Candidate.TargetBindingID = "binding-hf-1"
+	candidateSource.Candidate.TargetBindingDigest = "sha256:" + strings.Repeat("a", 64)
+	candidateSource.EndpointReference = endpointReference
+	candidateSource.EndpointConfigDigest = digest
+	if err = publisher.PublishOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := directory.Acquire("customer", "glm-5.3")
+	if err != nil || lease.Candidates[0].Endpoint != supplieradapter.HuggingFaceRouterBaseURL || lease.Candidates[0].TargetBindingID != "binding-hf-1" {
+		t.Fatalf("bound routed inference route=%#v err=%v", lease, err)
+	}
+}
+
 func TestPublisherRetainsPreviousGenerationOnSourceOrSecretFailure(t *testing.T) {
 	now := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
 	directory := NewDirectory()

--- a/internal/modelapirouting/runtime_test.go
+++ b/internal/modelapirouting/runtime_test.go
@@ -157,6 +157,7 @@ func strictHuggingFaceRuntimeFixture(t *testing.T, billing *billingFake, transpo
 	route.Candidates[0].Credential = ""
 	route.Candidates[0].Adapter = supplieradapter.HuggingFaceRouterAdapterName
 	route.Candidates[0].CredentialReference = "router-secret-reference"
+	route.Candidates[0].BillingPrincipal = "infercrane"
 	directory := NewDirectory()
 	directory.now = func() time.Time { return now }
 	if err := directory.Publish([]PublishedRoute{route}); err != nil {

--- a/internal/modelapirouting/runtime_test.go
+++ b/internal/modelapirouting/runtime_test.go
@@ -144,6 +144,32 @@ func strictProxyRequest(stream bool) ProxyRequest {
 	}
 }
 
+func strictHuggingFaceRuntimeFixture(t *testing.T, billing *billingFake, transport http.RoundTripper, credentials *hostedCredentialFake) *Runtime {
+	t.Helper()
+	now := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
+	route := routeFixture(now, "customer")
+	for _, product := range []*string{&route.Entitlement.ProductID, &route.Publication.ProductID, &route.Rate.ProductID, &route.Candidates[0].ProductID} {
+		*product = "qwen3-8b"
+	}
+	route.Candidates[0].Supplier = supplieradapter.HuggingFaceSupplier
+	route.Candidates[0].SupplierModelID = "Qwen/Qwen3-8B:together"
+	route.Candidates[0].Endpoint = supplieradapter.HuggingFaceRouterBaseURL
+	route.Candidates[0].Credential = ""
+	route.Candidates[0].Adapter = supplieradapter.HuggingFaceRouterAdapterName
+	route.Candidates[0].CredentialReference = "router-secret-reference"
+	directory := NewDirectory()
+	directory.now = func() time.Time { return now }
+	if err := directory.Publish([]PublishedRoute{route}); err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{Transport: transport}
+	registry, err := supplieradapter.NewRegistry(supplieradapter.NewHuggingFaceRouterAdapter(client))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &Runtime{Routes: directory, Billing: billing, Client: client, Adapters: registry, Credentials: credentials, now: func() time.Time { return now }}
+}
+
 func TestStrictRuntimeResolvesCredentialPerRequestAndRewritesBufferedResponse(t *testing.T) {
 	calls := 0
 	transport := routingRoundTripperFunc(func(request *http.Request) (*http.Response, error) {
@@ -177,6 +203,49 @@ func TestStrictRuntimeResolvesCredentialPerRequestAndRewritesBufferedResponse(t 
 	}
 	if billing.transmitted != 1 || billing.responseStarted != 1 || len(billing.settlements) != 1 || *billing.settlements[0].InputTokens != 19 || *billing.settlements[0].OutputTokens != 5 {
 		t.Fatalf("strict billing=%#v", billing)
+	}
+}
+
+func TestStrictRuntimeNeverExposesRoutedSupplierIdentity(t *testing.T) {
+	transport := routingRoundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if request.URL.String() != supplieradapter.HuggingFaceRouterBaseURL+"/chat/completions" || !strings.Contains(string(body), `"model":"Qwen/Qwen3-8B:together"`) {
+			t.Fatalf("private routed request=%s body=%s", request.URL, body)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"application/json"}, "Inference-Id": {"private-router-request"}},
+			Request:    request,
+			Body: io.NopCloser(strings.NewReader(`{
+				"id":"private-completion","model":"Qwen/Qwen3-8B",
+				"choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],
+				"usage":{"prompt_tokens":7,"completion_tokens":1}
+			}`)),
+		}, nil
+	})
+	billing := &billingFake{}
+	runtime := strictHuggingFaceRuntimeFixture(t, billing, transport, &hostedCredentialFake{credential: []byte("private-router-secret")})
+	recorder := httptest.NewRecorder()
+	runtime.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil), ProxyRequest{
+		TenantID: "customer", ProductID: "qwen3-8b", Operation: "chat", Resource: "chat/completions", RequestID: "public-request", TraceParent: "trace",
+		Payload: map[string]any{
+			"model": "qwen3-8b", "messages": []any{map[string]any{"role": "user", "content": "Hello"}}, "max_tokens": float64(256), "stream": false,
+		},
+	})
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	publicBody := recorder.Body.String()
+	for _, privateValue := range []string{"HuggingFace", "huggingface", "Qwen/", "together", "private-router", "private-completion"} {
+		if strings.Contains(publicBody, privateValue) {
+			t.Fatalf("private supplier value %q escaped in %s", privateValue, publicBody)
+		}
+	}
+	if !strings.Contains(publicBody, `"id":"public-request"`) || !strings.Contains(publicBody, `"model":"qwen3-8b"`) || !strings.Contains(publicBody, `"content":"hello"`) {
+		t.Fatalf("public response=%s", publicBody)
 	}
 }
 

--- a/internal/modelapirouting/strict_runtime.go
+++ b/internal/modelapirouting/strict_runtime.go
@@ -131,7 +131,7 @@ func (rt *Runtime) serveStrictBuffered(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 	usage := routingUsage(status, response.Usage)
-	body, err := publicBufferedResponse(request.ProductID, response)
+	body, err := publicBufferedResponse(request.RequestID, request.ProductID, response)
 	if err != nil {
 		rt.observeCandidate(candidateID, false)
 		rt.settleStrict(request, reservationID, usage)
@@ -269,7 +269,7 @@ func intToken(value *int64) *int {
 	return &converted
 }
 
-func publicBufferedResponse(publicModel string, response supplieradapter.Response) ([]byte, error) {
+func publicBufferedResponse(requestID, publicModel string, response supplieradapter.Response) ([]byte, error) {
 	choices := make([]map[string]any, 0, len(response.Choices))
 	for _, choice := range response.Choices {
 		if choice.Message == nil || len(choice.Message.Content) != 1 || choice.Message.Content[0].Type != "text" {
@@ -281,7 +281,7 @@ func publicBufferedResponse(publicModel string, response supplieradapter.Respons
 		})
 	}
 	return json.Marshal(map[string]any{
-		"id": response.ID, "object": "chat.completion", "model": publicModel, "choices": choices, "usage": publicUsage(response.Usage),
+		"id": requestID, "object": "chat.completion", "model": publicModel, "choices": choices, "usage": publicUsage(response.Usage),
 	})
 }
 

--- a/internal/modelapirouting/strict_runtime.go
+++ b/internal/modelapirouting/strict_runtime.go
@@ -72,7 +72,7 @@ func (r scopedCredentialResolver) Resolve(ctx context.Context, reference string)
 func (rt *Runtime) serveStrictCandidate(w http.ResponseWriter, r *http.Request, request ProxyRequest, lease Lease, candidate Candidate, reservation Reservation, adapter supplieradapter.Adapter, normalized supplieradapter.Request, now func() time.Time) {
 	target := supplieradapter.Target{
 		Supplier: candidate.Supplier, BaseURL: candidate.Endpoint, SupplierModelID: candidate.SupplierModelID,
-		Region: "global", CredentialReference: candidate.CredentialReference,
+		Region: "global", CredentialReference: candidate.CredentialReference, BillingPrincipal: candidate.BillingPrincipal,
 	}
 	upstream, err := adapter.BuildRequest(r.Context(), target, normalized, scopedCredentialResolver{resolver: rt.Credentials, operator: lease.Publication.OperatorTenantID})
 	if err != nil {

--- a/internal/modelapisupply/offer.go
+++ b/internal/modelapisupply/offer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/infercrane/infercrane/internal/modelapiproduct"
+	"github.com/infercrane/infercrane/internal/modelapiqualification"
 )
 
 const (
@@ -42,8 +43,9 @@ type CommercialAuthorization struct {
 	ValidUntil time.Time `json:"valid_until,omitempty"`
 }
 
-// QualificationEvidence is valid only for its exact immutable tuple and
-// stated protocol, region, and capabilities.
+// QualificationEvidence is valid only for its provider-bound offer tuple,
+// stated protocol, region, capabilities, and observation window. It does not
+// claim an upstream runtime or model revision that the supplier cannot prove.
 type QualificationEvidence struct {
 	ID             string    `json:"id"`
 	State          string    `json:"state"`
@@ -189,6 +191,9 @@ func validateQualification(evidence QualificationEvidence) error {
 	}
 	if evidence.State == QualificationQualified && (evidence.ObservedAt.IsZero() || evidence.ValidUntil.IsZero() || !evidence.ValidUntil.After(evidence.ObservedAt)) {
 		return errors.New("qualified evidence requires an increasing validity window")
+	}
+	if evidence.State == QualificationQualified && evidence.ValidUntil.Sub(evidence.ObservedAt) > modelapiqualification.MaximumValidity {
+		return fmt.Errorf("qualified evidence validity cannot exceed %s", modelapiqualification.MaximumValidity)
 	}
 	if !evidence.ObservedAt.IsZero() && !evidence.ValidUntil.IsZero() && !evidence.ValidUntil.After(evidence.ObservedAt) {
 		return errors.New("qualification evidence validity window must increase")

--- a/internal/modelapisupply/offer_test.go
+++ b/internal/modelapisupply/offer_test.go
@@ -111,6 +111,11 @@ func TestOfferValidationRejectsRawOrIncompleteCommercialData(t *testing.T) {
 	if err := offer.Validate(); err == nil {
 		t.Fatal("commercial authorization without terms reference was accepted")
 	}
+	offer = completeOffer(at)
+	offer.Qualification.ValidUntil = offer.Qualification.ObservedAt.Add(24*time.Hour + time.Nanosecond)
+	if err := offer.Validate(); err == nil {
+		t.Fatal("qualification evidence beyond the measured maximum validity was accepted")
+	}
 }
 
 func completeOffer(at time.Time) Offer {

--- a/internal/modelapitarget/binding.go
+++ b/internal/modelapitarget/binding.go
@@ -43,6 +43,8 @@ func (kind Kind) Valid() bool {
 // Binding pins every execution-relevant identity needed to reconstruct a
 // target choice. EndpointReference is an opaque, secret-free registry key;
 // EndpointConfigDigest proves which immutable adapter configuration it names.
+// BillingPrincipal pins a non-secret supplier account separately from a
+// rotatable credential reference when the adapter supports that distinction.
 type Binding struct {
 	SchemaVersion        string    `json:"schema_version"`
 	ID                   string    `json:"id"`
@@ -55,6 +57,7 @@ type Binding struct {
 	SupplierModelID      string    `json:"supplier_model_id"`
 	EndpointReference    string    `json:"endpoint_reference"`
 	EndpointConfigDigest string    `json:"endpoint_config_digest"`
+	BillingPrincipal     string    `json:"billing_principal,omitempty"`
 	Region               string    `json:"region"`
 	ValidFrom            time.Time `json:"valid_from"`
 	ValidUntil           time.Time `json:"valid_until"`
@@ -76,6 +79,7 @@ type Draft struct {
 	SupplierModelID      string
 	EndpointReference    string
 	EndpointConfigDigest string
+	BillingPrincipal     string
 	Region               string
 	ValidFrom            time.Time
 	ValidUntil           time.Time
@@ -95,6 +99,7 @@ func NewBinding(draft Draft) (Binding, error) {
 		SupplierModelID:      draft.SupplierModelID,
 		EndpointReference:    draft.EndpointReference,
 		EndpointConfigDigest: draft.EndpointConfigDigest,
+		BillingPrincipal:     draft.BillingPrincipal,
 		Region:               draft.Region,
 		ValidFrom:            draft.ValidFrom.UTC(),
 		ValidUntil:           draft.ValidUntil.UTC(),
@@ -157,7 +162,10 @@ func EndpointConfigDigest(endpointReference, endpoint string) (string, error) {
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
-var sha256Pattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+var (
+	sha256Pattern           = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	billingPrincipalPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+)
 
 func (binding Binding) validateFields() error {
 	if binding.SchemaVersion != SchemaVersion {
@@ -181,6 +189,9 @@ func (binding Binding) validateFields() error {
 	if !sha256Pattern.MatchString(binding.EndpointConfigDigest) {
 		return errors.New("target binding endpoint config digest must be a lowercase sha256 digest")
 	}
+	if binding.BillingPrincipal != "" && (!billingPrincipalPattern.MatchString(binding.BillingPrincipal) || strings.TrimSpace(binding.BillingPrincipal) != binding.BillingPrincipal) {
+		return errors.New("target binding billing principal must be a canonical account identifier")
+	}
 	if binding.CreatedAt.IsZero() || binding.ValidFrom.IsZero() || binding.ValidUntil.IsZero() || binding.CreatedAt.After(binding.ValidFrom) || !binding.ValidUntil.After(binding.ValidFrom) {
 		return errors.New("target binding needs ordered created_at, valid_from, and valid_until timestamps")
 	}
@@ -200,6 +211,7 @@ func (binding Binding) canonicalDigest() (string, error) {
 		SupplierModelID      string    `json:"supplier_model_id"`
 		EndpointReference    string    `json:"endpoint_reference"`
 		EndpointConfigDigest string    `json:"endpoint_config_digest"`
+		BillingPrincipal     string    `json:"billing_principal,omitempty"`
 		Region               string    `json:"region"`
 		ValidFrom            time.Time `json:"valid_from"`
 		ValidUntil           time.Time `json:"valid_until"`
@@ -208,7 +220,7 @@ func (binding Binding) canonicalDigest() (string, error) {
 		SchemaVersion: binding.SchemaVersion, ID: binding.ID, OperatorTenantID: binding.OperatorTenantID,
 		ProductID: binding.ProductID, Kind: binding.Kind, OfferID: binding.OfferID, OfferVersion: binding.OfferVersion,
 		Adapter: binding.Adapter, SupplierModelID: binding.SupplierModelID, EndpointReference: binding.EndpointReference,
-		EndpointConfigDigest: binding.EndpointConfigDigest, Region: binding.Region, ValidFrom: binding.ValidFrom.UTC(),
+		EndpointConfigDigest: binding.EndpointConfigDigest, BillingPrincipal: binding.BillingPrincipal, Region: binding.Region, ValidFrom: binding.ValidFrom.UTC(),
 		ValidUntil: binding.ValidUntil.UTC(), CreatedAt: binding.CreatedAt.UTC(),
 	}
 	body, err := json.Marshal(contract)

--- a/internal/modelapitarget/binding_test.go
+++ b/internal/modelapitarget/binding_test.go
@@ -68,6 +68,26 @@ func TestBindingNormalizesTimesBeforeDigesting(t *testing.T) {
 	}
 }
 
+func TestBindingPinsOptionalBillingPrincipalInContractDigest(t *testing.T) {
+	draft := validDraft(KindUpstream)
+	withoutPrincipal, err := NewBinding(draft)
+	if err != nil {
+		t.Fatal(err)
+	}
+	draft.BillingPrincipal = "infercrane"
+	withPrincipal, err := NewBinding(draft)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withPrincipal.ContractDigest == withoutPrincipal.ContractDigest {
+		t.Fatal("billing principal was not covered by the immutable contract digest")
+	}
+	draft.BillingPrincipal = " bad payer "
+	if _, err = NewBinding(draft); err == nil {
+		t.Fatal("non-canonical billing principal was accepted")
+	}
+}
+
 func TestEndpointConfigDigestPinsReferenceAndURL(t *testing.T) {
 	digest, err := EndpointConfigDigest("runpod/runpod-vllm-openai", "https://api.runpod.ai/v2/abc123/openai/")
 	if err != nil {

--- a/internal/store/migrations/066_model_api_billing_principal.sql
+++ b/internal/store/migrations/066_model_api_billing_principal.sql
@@ -1,0 +1,6 @@
+-- Pin the supplier-side billing account separately from a rotatable API token.
+-- Existing non-Hugging-Face bindings remain valid with an empty value; routed
+-- Hugging Face publication fails closed until a new binding names its payer.
+ALTER TABLE model_api_target_bindings
+  ADD COLUMN billing_principal TEXT NOT NULL DEFAULT ''
+    CHECK(billing_principal='' OR billing_principal ~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$');

--- a/internal/store/model_api_route_publication.go
+++ b/internal/store/model_api_route_publication.go
@@ -139,12 +139,12 @@ func publishedModelAPICandidates(ctx context.Context, tx *tx, at time.Time, sour
 	rows, err := tx.QueryContext(ctx, `SELECT c.candidate_id,c.offer_id,c.offer_version,c.qualification_id,c.retail_rate_card_id,c.retail_rate_version,c.disposition,c.position,c.traffic_weight_bps,
 		o.supplier,o.adapter,o.supplier_model_id,o.protocol,o.tuple_key,o.region,o.credential_reference,o.state,o.capabilities_json::text,o.access_state,o.availability_state,o.health_state,o.observed_at,o.cost_valid_until,o.commercial_state,o.commercial_valid_until,
 		q.id,q.state,q.tuple_key,q.protocol,q.region,q.capabilities_json::text,q.evidence_ref,q.evidence_digest,q.observed_at,q.valid_until,
-		b.binding_count,b.id,b.endpoint_reference,b.endpoint_config_digest,b.contract_digest,b.valid_until
+		b.binding_count,b.id,b.endpoint_reference,b.endpoint_config_digest,b.billing_principal,b.contract_digest,b.valid_until
 	FROM model_api_supply_plan_candidates c
 	JOIN model_api_supplier_offers o ON o.id=c.offer_id AND o.version=c.offer_version AND o.managed_product_id=c.managed_product_id
 	JOIN model_api_supply_qualifications q ON q.id=c.qualification_id AND q.offer_id=c.offer_id AND q.offer_version=c.offer_version
 	LEFT JOIN LATERAL (
-		SELECT count(*) AS binding_count,min(id) AS id,min(endpoint_reference) AS endpoint_reference,min(endpoint_config_digest) AS endpoint_config_digest,min(contract_digest) AS contract_digest,min(valid_until) AS valid_until
+		SELECT count(*) AS binding_count,min(id) AS id,min(endpoint_reference) AS endpoint_reference,min(endpoint_config_digest) AS endpoint_config_digest,min(billing_principal) AS billing_principal,min(contract_digest) AS contract_digest,min(valid_until) AS valid_until
 		FROM model_api_target_bindings
 		WHERE operator_tenant_id=o.operator_tenant_id AND managed_product_id=o.managed_product_id AND offer_id=o.id AND offer_version=o.version
 			AND adapter=o.adapter AND supplier_model_id=o.supplier_model_id AND region=o.region AND valid_from<=? AND valid_until>?
@@ -162,7 +162,7 @@ func publishedModelAPICandidates(ctx context.Context, tx *tx, at time.Time, sour
 		var qualificationID, rateID, disposition, offerState, access, availability, health, qualificationState string
 		var region, offerCapabilitiesJSON, qualificationTuple, qualificationProtocol, qualificationRegion, qualificationCapabilitiesJSON string
 		var evidenceRef, evidenceDigest sql.NullString
-		var bindingID, endpointReference, endpointConfigDigest, bindingDigest sql.NullString
+		var bindingID, endpointReference, endpointConfigDigest, billingPrincipal, bindingDigest sql.NullString
 		var position int
 		var bindingCount int
 		var observed, costUntil, commercialUntil, qualificationObserved, qualificationUntil, bindingUntil sql.NullTime
@@ -171,7 +171,7 @@ func publishedModelAPICandidates(ctx context.Context, tx *tx, at time.Time, sour
 		if err = rows.Scan(&candidate.ID, &candidate.OfferID, &candidate.OfferVersion, &qualificationID, &rateID, &candidateRateVersion, &disposition, &position, &candidate.TrafficWeightBPS,
 			&candidate.Supplier, &item.Adapter, &candidate.SupplierModelID, &candidate.Protocol, &candidate.CompatibilityKey, &region, &item.CredentialReference, &offerState, &offerCapabilitiesJSON, &access, &availability, &health, &observed, &costUntil, &commercialState, &commercialUntil,
 			&candidate.QualificationEvidenceID, &qualificationState, &qualificationTuple, &qualificationProtocol, &qualificationRegion, &qualificationCapabilitiesJSON, &evidenceRef, &evidenceDigest, &qualificationObserved, &qualificationUntil,
-			&bindingCount, &bindingID, &endpointReference, &endpointConfigDigest, &bindingDigest, &bindingUntil); err != nil {
+			&bindingCount, &bindingID, &endpointReference, &endpointConfigDigest, &billingPrincipal, &bindingDigest, &bindingUntil); err != nil {
 			return nil, err
 		}
 		candidate.ProductID, candidate.OperatorTenantID = source.Entitlement.ProductID, source.Entitlement.OperatorTenantID
@@ -197,11 +197,12 @@ func publishedModelAPICandidates(ctx context.Context, tx *tx, at time.Time, sour
 			return nil, fmt.Errorf("hosted candidate %q has ambiguous current target bindings", candidate.ID)
 		}
 		if bindingCount == 1 {
-			if !bindingID.Valid || !endpointReference.Valid || !endpointConfigDigest.Valid || !bindingDigest.Valid || !bindingUntil.Valid {
+			if !bindingID.Valid || !endpointReference.Valid || !endpointConfigDigest.Valid || !billingPrincipal.Valid || !bindingDigest.Valid || !bindingUntil.Valid {
 				return nil, fmt.Errorf("hosted candidate %q has an incomplete target binding", candidate.ID)
 			}
 			candidate.TargetBindingID, candidate.TargetBindingDigest = bindingID.String, bindingDigest.String
 			item.EndpointReference, item.EndpointConfigDigest = endpointReference.String, endpointConfigDigest.String
+			item.BillingPrincipal = billingPrincipal.String
 		} else if supplieradapter.RequiresImmutableTargetBinding(item.Adapter) {
 			return nil, fmt.Errorf("hosted candidate %q has no current immutable target binding", candidate.ID)
 		}

--- a/internal/store/model_api_route_publication.go
+++ b/internal/store/model_api_route_publication.go
@@ -202,8 +202,8 @@ func publishedModelAPICandidates(ctx context.Context, tx *tx, at time.Time, sour
 			}
 			candidate.TargetBindingID, candidate.TargetBindingDigest = bindingID.String, bindingDigest.String
 			item.EndpointReference, item.EndpointConfigDigest = endpointReference.String, endpointConfigDigest.String
-		} else if item.Adapter == supplieradapter.RunPodVLLMAdapterName {
-			return nil, fmt.Errorf("hosted RunPod candidate %q has no current immutable target binding", candidate.ID)
+		} else if supplieradapter.RequiresImmutableTargetBinding(item.Adapter) {
+			return nil, fmt.Errorf("hosted candidate %q has no current immutable target binding", candidate.ID)
 		}
 		candidate.Operations = append([]string(nil), operations...)
 		candidate.Qualified, candidate.Available = true, true

--- a/internal/store/model_api_routes.go
+++ b/internal/store/model_api_routes.go
@@ -101,8 +101,8 @@ func (s *Store) ReserveModelAPIUsage(ctx context.Context, request modelapiroutin
 		if err != nil || bindingCount != 1 {
 			return modelapirouting.Reservation{}, fmt.Errorf("%w: immutable target binding changed before billing authorization", ErrConflict)
 		}
-	} else if offer.Adapter == supplieradapter.RunPodVLLMAdapterName {
-		return modelapirouting.Reservation{}, fmt.Errorf("%w: RunPod usage requires an immutable target binding", ErrConflict)
+	} else if supplieradapter.RequiresImmutableTargetBinding(offer.Adapter) {
+		return modelapirouting.Reservation{}, fmt.Errorf("%w: hosted usage requires an immutable target binding", ErrConflict)
 	}
 
 	var balance, reserved, debt int64

--- a/internal/store/model_api_target_bindings.go
+++ b/internal/store/model_api_target_bindings.go
@@ -9,9 +9,10 @@ import (
 	"time"
 
 	"github.com/infercrane/infercrane/internal/modelapitarget"
+	"github.com/infercrane/infercrane/internal/supplieradapter"
 )
 
-const modelAPITargetBindingSelect = `SELECT schema_version,id,operator_tenant_id,managed_product_id,target_kind,offer_id,offer_version,adapter,supplier_model_id,endpoint_reference,endpoint_config_digest,region,valid_from,valid_until,created_at,contract_digest FROM model_api_target_bindings`
+const modelAPITargetBindingSelect = `SELECT schema_version,id,operator_tenant_id,managed_product_id,target_kind,offer_id,offer_version,adapter,supplier_model_id,endpoint_reference,endpoint_config_digest,billing_principal,region,valid_from,valid_until,created_at,contract_digest FROM model_api_target_bindings`
 
 // PublishModelAPITargetBinding stores one immutable execution contract. Exact
 // replays are idempotent; changing any pinned field requires a new binding ID.
@@ -21,6 +22,9 @@ func (s *Store) PublishModelAPITargetBinding(ctx context.Context, operatorTenant
 	}
 	if err := binding.Validate(); err != nil {
 		return modelapitarget.Binding{}, err
+	}
+	if supplieradapter.RequiresBillingPrincipal(binding.Adapter) && binding.BillingPrincipal == "" {
+		return modelapitarget.Binding{}, errors.New("hosted target binding requires an immutable billing principal")
 	}
 	if err := requirePostgresSafeTargetBindingTimes(binding); err != nil {
 		return modelapitarget.Binding{}, err
@@ -32,9 +36,9 @@ func (s *Store) PublishModelAPITargetBinding(ctx context.Context, operatorTenant
 	if offer.ProductID != binding.ProductID || offer.Adapter != binding.Adapter || offer.SupplierModelID != binding.SupplierModelID || offer.Region != binding.Region {
 		return modelapitarget.Binding{}, errors.New("target binding must exactly match the pinned supplier offer revision")
 	}
-	result, err := s.ExecContext(ctx, `INSERT INTO model_api_target_bindings(schema_version,id,operator_tenant_id,managed_product_id,target_kind,offer_id,offer_version,adapter,supplier_model_id,endpoint_reference,endpoint_config_digest,region,valid_from,valid_until,created_at,contract_digest) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(id) DO NOTHING`,
+	result, err := s.ExecContext(ctx, `INSERT INTO model_api_target_bindings(schema_version,id,operator_tenant_id,managed_product_id,target_kind,offer_id,offer_version,adapter,supplier_model_id,endpoint_reference,endpoint_config_digest,billing_principal,region,valid_from,valid_until,created_at,contract_digest) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(id) DO NOTHING`,
 		binding.SchemaVersion, binding.ID, operatorTenant, binding.ProductID, binding.Kind, binding.OfferID, binding.OfferVersion,
-		binding.Adapter, binding.SupplierModelID, binding.EndpointReference, binding.EndpointConfigDigest, binding.Region,
+		binding.Adapter, binding.SupplierModelID, binding.EndpointReference, binding.EndpointConfigDigest, binding.BillingPrincipal, binding.Region,
 		binding.ValidFrom.UTC(), binding.ValidUntil.UTC(), binding.CreatedAt.UTC(), binding.ContractDigest)
 	if err != nil {
 		return modelapitarget.Binding{}, err
@@ -102,7 +106,7 @@ func scanModelAPITargetBinding(row interface{ Scan(...any) error }) (modelapitar
 	var binding modelapitarget.Binding
 	err := row.Scan(&binding.SchemaVersion, &binding.ID, &binding.OperatorTenantID, &binding.ProductID, &binding.Kind,
 		&binding.OfferID, &binding.OfferVersion, &binding.Adapter, &binding.SupplierModelID, &binding.EndpointReference,
-		&binding.EndpointConfigDigest, &binding.Region, &binding.ValidFrom, &binding.ValidUntil, &binding.CreatedAt, &binding.ContractDigest)
+		&binding.EndpointConfigDigest, &binding.BillingPrincipal, &binding.Region, &binding.ValidFrom, &binding.ValidUntil, &binding.CreatedAt, &binding.ContractDigest)
 	if errors.Is(err, sql.ErrNoRows) {
 		return modelapitarget.Binding{}, ErrNotFound
 	}

--- a/internal/store/model_api_target_bindings_test.go
+++ b/internal/store/model_api_target_bindings_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/infercrane/infercrane/internal/modelapisupply"
 	"github.com/infercrane/infercrane/internal/modelapitarget"
+	"github.com/infercrane/infercrane/internal/supplieradapter"
 )
 
 func TestModelAPITargetBindingRepositoryRejectsInvalidInputsBeforeDatabaseAccess(t *testing.T) {
@@ -30,6 +31,18 @@ func TestModelAPITargetBindingRepositoryRejectsInvalidInputsBeforeDatabaseAccess
 	}
 	if _, err = s.CurrentModelAPITargetBindings(ctx, "operator-a", binding.ProductID, time.Time{}); err == nil {
 		t.Fatal("zero evaluation time was not rejected before database access")
+	}
+	huggingFaceBinding, err := modelapitarget.NewBinding(modelapitarget.Draft{
+		ID: "binding-hf", OperatorTenantID: "operator-a", ProductID: "glm-5.2", Kind: modelapitarget.KindUpstream,
+		OfferID: "offer-1", OfferVersion: 1, Adapter: supplieradapter.HuggingFaceRouterAdapterName, SupplierModelID: "Qwen/Qwen3-8B:together",
+		EndpointReference: "huggingface/huggingface-router-openai", EndpointConfigDigest: "sha256:" + strings.Repeat("c", 64), Region: "global",
+		CreatedAt: now, ValidFrom: now.Add(time.Minute), ValidUntil: now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = s.PublishModelAPITargetBinding(ctx, "operator-a", huggingFaceBinding); err == nil || !strings.Contains(err.Error(), "billing principal") {
+		t.Fatalf("Hugging Face binding without a pinned payer was accepted: %v", err)
 	}
 
 	draft := modelapitarget.Draft{
@@ -82,11 +95,16 @@ func TestModelAPITargetBindingsPersistExactImmutableOfferRevisions(t *testing.T)
 
 	bindings := make([]modelapitarget.Binding, 0, 4)
 	for index, kind := range []modelapitarget.Kind{modelapitarget.KindUpstream, modelapitarget.KindServerlessGPU, modelapitarget.KindDedicated, modelapitarget.KindBYOC} {
+		billingPrincipal := ""
+		if index == 0 {
+			billingPrincipal = "billing-account"
+		}
 		binding, bindingErr := modelapitarget.NewBinding(modelapitarget.Draft{
 			ID: fmt.Sprintf("target-binding-%d-%s", index, suffix), OperatorTenantID: operator, ProductID: product.ID, Kind: kind,
 			OfferID: offer.ID, OfferVersion: offer.Version, Adapter: offer.Adapter, SupplierModelID: offer.SupplierModelID,
 			EndpointReference: fmt.Sprintf("endpoint-registry/%s/%d", kind, index), EndpointConfigDigest: "sha256:" + strings.Repeat(fmt.Sprint(index+1), 64), Region: offer.Region,
-			CreatedAt: now, ValidFrom: now.Add(time.Minute), ValidUntil: now.Add(time.Hour),
+			BillingPrincipal: billingPrincipal,
+			CreatedAt:        now, ValidFrom: now.Add(time.Minute), ValidUntil: now.Add(time.Hour),
 		})
 		if bindingErr != nil {
 			t.Fatal(bindingErr)

--- a/internal/supplieradapter/contracts.go
+++ b/internal/supplieradapter/contracts.go
@@ -44,12 +44,15 @@ const (
 
 // Target is an operator-owned supplier route. CredentialReference names a
 // secret-manager entry; it must never contain the secret itself.
+// BillingPrincipal pins the non-secret supplier account charged by adapters
+// whose credentials may be rotated independently of their billing owner.
 type Target struct {
 	Supplier            string
 	BaseURL             string
 	SupplierModelID     string
 	Region              string
 	CredentialReference string
+	BillingPrincipal    string
 }
 
 // CredentialResolver resolves a reference only inside the trusted adapter

--- a/internal/supplieradapter/huggingface_router.go
+++ b/internal/supplieradapter/huggingface_router.go
@@ -27,8 +27,9 @@ const (
 )
 
 var (
-	huggingFaceRepositoryPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,95}/[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
-	huggingFaceProviderPattern   = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,63}$`)
+	huggingFaceRepositoryPattern       = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,95}/[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+	huggingFaceProviderPattern         = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,63}$`)
+	huggingFaceBillingPrincipalPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
 )
 
 type huggingFaceExpectedModel struct {
@@ -118,6 +119,7 @@ func (a *HuggingFaceRouterAdapter) BuildRequest(ctx context.Context, target Targ
 		return nil, internalBeforeTransmission("supplier request could not be constructed", err)
 	}
 	upstream.Header.Set("Authorization", "Bearer "+string(credentialValue))
+	upstream.Header.Set("X-HF-Bill-To", target.BillingPrincipal)
 	upstream.Header.Set("Content-Type", "application/json")
 	if request.Stream {
 		upstream.Header.Set("Accept", "text/event-stream")
@@ -325,6 +327,9 @@ func validateHuggingFaceTarget(target Target) (string, string, error) {
 	}
 	if strings.TrimSpace(target.CredentialReference) == "" {
 		return "", "", errors.New("target credential reference is required")
+	}
+	if !huggingFaceBillingPrincipalPattern.MatchString(target.BillingPrincipal) {
+		return "", "", errors.New("target must pin one canonical Hugging Face billing principal")
 	}
 	return repository, provider, nil
 }

--- a/internal/supplieradapter/huggingface_router.go
+++ b/internal/supplieradapter/huggingface_router.go
@@ -23,6 +23,7 @@ const (
 	HuggingFaceRouterMaxRequestBytes     = 4 << 20
 	HuggingFaceRouterMaxResponseBytes    = 8 << 20
 	HuggingFaceRouterMaxStreamEventBytes = 1 << 20
+	huggingFaceProbeMaxOutputTokens      = 4
 )
 
 var (
@@ -38,8 +39,10 @@ type huggingFaceExpectedModel struct {
 type huggingFaceExpectedModelKey struct{}
 
 // HuggingFaceRouterAdapter implements a narrow OpenAI-compatible contract.
-// Every executable target must pin <repository>:<provider>; automatic routing
-// policies are useful for discovery but are deliberately forbidden here.
+// Every executable target must bind <repository>:<provider>; automatic routing
+// policies are useful for discovery but are deliberately forbidden here. This
+// provider binding does not prove an upstream model revision, quantization, or
+// runtime. Those remain time-bounded qualification facts.
 type HuggingFaceRouterAdapter struct {
 	client *http.Client
 	now    func() time.Time
@@ -131,13 +134,15 @@ func (a *HuggingFaceRouterAdapter) DecodeResponse(_ context.Context, response *h
 		return Response{}, huggingFaceProtocolFailure("supplier response is missing", "", nil)
 	}
 	requestID := huggingFaceSupplierRequestID(response.Header)
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		if response.Body != nil {
+			defer response.Body.Close()
+			_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
+		}
+		return Response{}, normalizeHuggingFaceHTTPError(response.StatusCode, response.Header, requestID)
+	}
 	if response.Body == nil {
 		return Response{}, huggingFaceProtocolFailure("supplier response body is missing", requestID, nil)
-	}
-	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
-		defer response.Body.Close()
-		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
-		return Response{}, normalizeHuggingFaceHTTPError(response.StatusCode, response.Header, requestID)
 	}
 	expected, ok := expectedHuggingFaceModel(response)
 	if !ok {
@@ -192,13 +197,15 @@ func (a *HuggingFaceRouterAdapter) OpenStream(_ context.Context, response *http.
 		return nil, huggingFaceProtocolFailure("supplier response is missing", "", nil)
 	}
 	requestID := huggingFaceSupplierRequestID(response.Header)
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		if response.Body != nil {
+			defer response.Body.Close()
+			_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
+		}
+		return nil, normalizeHuggingFaceHTTPError(response.StatusCode, response.Header, requestID)
+	}
 	if response.Body == nil {
 		return nil, huggingFaceProtocolFailure("supplier response body is missing", requestID, nil)
-	}
-	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
-		defer response.Body.Close()
-		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
-		return nil, normalizeHuggingFaceHTTPError(response.StatusCode, response.Header, requestID)
 	}
 	expected, ok := expectedHuggingFaceModel(response)
 	if !ok {
@@ -214,84 +221,48 @@ func (a *HuggingFaceRouterAdapter) OpenStream(_ context.Context, response *http.
 }
 
 func (a *HuggingFaceRouterAdapter) Probe(ctx context.Context, target Target, credentials CredentialResolver) (Observation, error) {
-	repository, provider, err := validateHuggingFaceTarget(target)
-	if err != nil {
+	// Probe is a bounded, billable qualification action, not a readiness check.
+	// Callers must schedule it explicitly and reconcile its operator-owned cost.
+	if _, _, err := validateHuggingFaceTarget(target); err != nil {
 		return Observation{}, invalidRequest(err.Error())
 	}
-	if credentials == nil {
-		return Observation{}, internalBeforeTransmission("supplier credential resolver is unavailable", nil)
+	observedAt := time.Now().UTC()
+	if a.now != nil {
+		observedAt = a.now().UTC()
 	}
-	credential, err := credentials.Resolve(ctx, target.CredentialReference)
+	temperature := 0.0
+	maximum := huggingFaceProbeMaxOutputTokens
+	request, err := a.BuildRequest(ctx, target, Request{
+		ID:        fmt.Sprintf("infercrane-hf-probe-%d", observedAt.UnixNano()),
+		Operation: OperationChatCompletions,
+		ModelID:   target.SupplierModelID,
+		Messages: []Message{{
+			Role:    "user",
+			Content: []ContentPart{{Type: "text", Text: "Reply with OK."}},
+		}},
+		MaxOutputTokens: &maximum,
+		Temperature:     &temperature,
+		Stream:          false,
+	}, credentials)
 	if err != nil {
-		return Observation{}, internalBeforeTransmission("supplier credential could not be resolved", err)
+		return Observation{}, err
 	}
-	defer clear(credential)
-	credentialValue := bytes.TrimSpace(credential)
-	if len(credentialValue) == 0 || !safeIdentifier(string(credentialValue)) {
-		return Observation{}, internalBeforeTransmission("supplier credential is invalid", nil)
-	}
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, HuggingFaceRouterBaseURL+"/models", nil)
-	if err != nil {
-		return Observation{}, internalBeforeTransmission("supplier inventory probe could not be constructed", err)
-	}
-	request.Header.Set("Authorization", "Bearer "+string(credentialValue))
-	request.Header.Set("Accept", "application/json")
 	response, err := a.client.Do(request)
 	if err != nil {
-		return Observation{}, &Error{Code: ErrorTransport, Message: "supplier inventory probe failed", Retry: RetrySameOffer, Billing: BillingNoChargeConfirmed, Cause: err}
+		// A transport failure cannot prove whether the router accepted and billed
+		// the request. Keep it ambiguous so callers cannot retry automatically.
+		return Observation{}, &Error{Code: ErrorTransport, Message: "supplier completion probe failed", Retry: RetryOtherOffer, Billing: BillingAmbiguous, Cause: err}
 	}
-	if response == nil || response.Body == nil {
-		return Observation{}, huggingFaceProtocolFailure("supplier inventory response body is missing", "", nil)
+	if _, err = a.DecodeResponse(ctx, response); err != nil {
+		return Observation{}, err
 	}
-	requestID := huggingFaceSupplierRequestID(response.Header)
-	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
-		defer response.Body.Close()
-		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
-		normalized := normalizeHuggingFaceHTTPError(response.StatusCode, response.Header, requestID)
-		normalized.Billing = BillingNoChargeConfirmed
-		return Observation{}, normalized
-	}
-	defer response.Body.Close()
-	body, err := readBounded(response.Body, 2<<20)
-	if err != nil {
-		return Observation{}, huggingFaceProtocolFailure("supplier inventory response exceeded the safe byte limit", requestID, err)
-	}
-	var inventory struct {
-		Data []struct {
-			ID        string `json:"id"`
-			Providers []struct {
-				Provider string `json:"provider"`
-				Status   string `json:"status"`
-			} `json:"providers"`
-		} `json:"data"`
-	}
-	if err = json.Unmarshal(body, &inventory); err != nil {
-		return Observation{}, huggingFaceProtocolFailure("supplier inventory response was malformed", requestID, err)
-	}
-	matchCount := 0
-	for _, item := range inventory.Data {
-		if item.ID != repository {
-			continue
-		}
-		for _, candidate := range item.Providers {
-			if candidate.Provider == provider && candidate.Status == "live" {
-				matchCount++
-			}
-		}
-	}
-	availability := "unavailable"
-	items := []InventoryItem(nil)
-	if matchCount == 1 {
-		availability = "available"
-		items = []InventoryItem{{SupplierModelID: target.SupplierModelID, Region: target.Region, Available: true}}
-	}
-	now := time.Now
-	if a.now != nil {
-		now = a.now
-	}
+	// The public /v1/models inventory is discovery metadata and does not
+	// authenticate a token. A successful, decoded completion proves the exact
+	// credential + provider-bound request contract used for publication.
 	return Observation{
-		Access: "authorized", Availability: availability, Health: "healthy", ObservedAt: now().UTC(),
-		RateLimit: huggingFaceRateLimit(response.Header, now()), Inventory: items,
+		Access: "authorized", Availability: "available", Health: "healthy", ObservedAt: observedAt,
+		RateLimit: huggingFaceRateLimit(response.Header, observedAt),
+		Inventory: []InventoryItem{{SupplierModelID: target.SupplierModelID, Region: target.Region, Available: true}},
 	}, nil
 }
 
@@ -432,6 +403,14 @@ func huggingFaceSupplierRequestID(header http.Header) string {
 
 func normalizeHuggingFaceHTTPError(status int, header http.Header, requestID string) *Error {
 	code, message, retry := ErrorInternal, "supplier request failed", RetryNever
+	billing := BillingAmbiguous
+	// Hugging Face's provider contract bills completed requests only when the
+	// provider response status is 2xx or 3xx. A received 4xx/5xx therefore
+	// proves no charge at this router boundary; transport failures remain
+	// ambiguous because no status was received.
+	if status >= http.StatusBadRequest && status <= 599 {
+		billing = BillingNoChargeConfirmed
+	}
 	switch status {
 	case http.StatusBadRequest, http.StatusUnprocessableEntity:
 		code, message = ErrorInvalidRequest, "supplier rejected the request"
@@ -452,7 +431,7 @@ func normalizeHuggingFaceHTTPError(status int, header http.Header, requestID str
 	}
 	return &Error{
 		Code: code, Message: message, HTTPStatus: status, SupplierRequestID: requestID,
-		Retry: retry, RetryAfter: parseRetryAfter(header.Get("Retry-After"), time.Now()), Billing: BillingAmbiguous,
+		Retry: retry, RetryAfter: parseRetryAfter(header.Get("Retry-After"), time.Now()), Billing: billing,
 	}
 }
 

--- a/internal/supplieradapter/huggingface_router.go
+++ b/internal/supplieradapter/huggingface_router.go
@@ -1,0 +1,469 @@
+package supplieradapter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	HuggingFaceRouterAdapterName         = "huggingface-router-openai"
+	HuggingFaceSupplier                  = "huggingface"
+	HuggingFaceRouterBaseURL             = "https://router.huggingface.co/v1"
+	HuggingFaceRouterMaxOutputTokens     = 32_768
+	HuggingFaceRouterMaxRequestBytes     = 4 << 20
+	HuggingFaceRouterMaxResponseBytes    = 8 << 20
+	HuggingFaceRouterMaxStreamEventBytes = 1 << 20
+)
+
+var (
+	huggingFaceRepositoryPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,95}/[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+	huggingFaceProviderPattern   = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,63}$`)
+)
+
+type huggingFaceExpectedModel struct {
+	pinned     string
+	repository string
+}
+
+type huggingFaceExpectedModelKey struct{}
+
+// HuggingFaceRouterAdapter implements a narrow OpenAI-compatible contract.
+// Every executable target must pin <repository>:<provider>; automatic routing
+// policies are useful for discovery but are deliberately forbidden here.
+type HuggingFaceRouterAdapter struct {
+	client *http.Client
+	now    func() time.Time
+}
+
+var _ Adapter = (*HuggingFaceRouterAdapter)(nil)
+
+func NewHuggingFaceRouterAdapter(client *http.Client) *HuggingFaceRouterAdapter {
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	strictClient := *client
+	strictClient.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	return &HuggingFaceRouterAdapter{client: &strictClient, now: time.Now}
+}
+
+func (*HuggingFaceRouterAdapter) Name() string { return HuggingFaceRouterAdapterName }
+
+func (a *HuggingFaceRouterAdapter) BuildRequest(ctx context.Context, target Target, request Request, credentials CredentialResolver) (*http.Request, error) {
+	repository, _, err := validateHuggingFaceTarget(target)
+	if err != nil {
+		return nil, invalidRequest(err.Error())
+	}
+	if err = validateHuggingFaceRequest(request); err != nil {
+		return nil, invalidRequest(err.Error())
+	}
+	if credentials == nil {
+		return nil, internalBeforeTransmission("supplier credential resolver is unavailable", nil)
+	}
+	credential, err := credentials.Resolve(ctx, target.CredentialReference)
+	if err != nil {
+		return nil, internalBeforeTransmission("supplier credential could not be resolved", err)
+	}
+	defer clear(credential)
+	credentialValue := bytes.TrimSpace(credential)
+	if len(credentialValue) == 0 || !safeIdentifier(string(credentialValue)) {
+		return nil, internalBeforeTransmission("supplier credential is invalid", nil)
+	}
+
+	type wireMessage struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	payload := struct {
+		Model         string          `json:"model"`
+		Messages      []wireMessage   `json:"messages"`
+		MaxTokens     int             `json:"max_tokens"`
+		Temperature   *float64        `json:"temperature,omitempty"`
+		Stream        bool            `json:"stream"`
+		StreamOptions map[string]bool `json:"stream_options,omitempty"`
+	}{
+		Model: target.SupplierModelID, Messages: make([]wireMessage, 0, len(request.Messages)),
+		MaxTokens: *request.MaxOutputTokens, Temperature: request.Temperature, Stream: request.Stream,
+	}
+	if request.Stream {
+		payload.StreamOptions = map[string]bool{"include_usage": true}
+	}
+	for _, message := range request.Messages {
+		payload.Messages = append(payload.Messages, wireMessage{Role: message.Role, Content: message.Content[0].Text})
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, internalBeforeTransmission("supplier request could not be encoded", err)
+	}
+	if len(body) > HuggingFaceRouterMaxRequestBytes {
+		return nil, invalidRequest("normalized request exceeds the routed inference MVP byte limit")
+	}
+
+	expected := huggingFaceExpectedModel{pinned: target.SupplierModelID, repository: repository}
+	requestContext := context.WithValue(ctx, huggingFaceExpectedModelKey{}, expected)
+	upstream, err := http.NewRequestWithContext(requestContext, http.MethodPost, HuggingFaceRouterBaseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return nil, internalBeforeTransmission("supplier request could not be constructed", err)
+	}
+	upstream.Header.Set("Authorization", "Bearer "+string(credentialValue))
+	upstream.Header.Set("Content-Type", "application/json")
+	if request.Stream {
+		upstream.Header.Set("Accept", "text/event-stream")
+	} else {
+		upstream.Header.Set("Accept", "application/json")
+	}
+	upstream.Header.Set("X-Request-ID", request.ID)
+	upstream.Header.Set("User-Agent", "InferCrane/1 supplier-adapter")
+	return upstream, nil
+}
+
+func (a *HuggingFaceRouterAdapter) DecodeResponse(_ context.Context, response *http.Response) (Response, error) {
+	if response == nil {
+		return Response{}, huggingFaceProtocolFailure("supplier response is missing", "", nil)
+	}
+	requestID := huggingFaceSupplierRequestID(response.Header)
+	if response.Body == nil {
+		return Response{}, huggingFaceProtocolFailure("supplier response body is missing", requestID, nil)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		defer response.Body.Close()
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
+		return Response{}, normalizeHuggingFaceHTTPError(response.StatusCode, response.Header, requestID)
+	}
+	expected, ok := expectedHuggingFaceModel(response)
+	if !ok {
+		response.Body.Close()
+		return Response{}, huggingFaceProtocolFailure("supplier response lost its expected model identity", requestID, nil)
+	}
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || !strings.EqualFold(mediaType, "application/json") {
+		response.Body.Close()
+		return Response{}, huggingFaceProtocolFailure("supplier response content type is invalid", requestID, err)
+	}
+	defer response.Body.Close()
+	body, err := readBounded(response.Body, HuggingFaceRouterMaxResponseBytes)
+	if err != nil {
+		return Response{}, huggingFaceProtocolFailure("supplier response exceeded the safe byte limit", requestID, err)
+	}
+	var raw struct {
+		ID      string `json:"id"`
+		Model   string `json:"model"`
+		Choices []struct {
+			Index        int     `json:"index"`
+			FinishReason *string `json:"finish_reason"`
+			Message      struct {
+				Role    string  `json:"role"`
+				Content *string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+		Usage *huggingFaceUsage `json:"usage"`
+	}
+	if err = json.Unmarshal(body, &raw); err != nil {
+		return Response{}, huggingFaceProtocolFailure("supplier returned malformed JSON", requestID, err)
+	}
+	if strings.TrimSpace(raw.ID) == "" || !expected.accepts(raw.Model) || len(raw.Choices) != 1 || raw.Choices[0].Index != 0 {
+		return Response{}, huggingFaceProtocolFailure("supplier response identity or choices did not match the qualified contract", requestID, nil)
+	}
+	choice := raw.Choices[0]
+	if choice.Message.Role != "assistant" || choice.Message.Content == nil || choice.FinishReason == nil || !validHuggingFaceFinishReason(*choice.FinishReason) {
+		return Response{}, huggingFaceProtocolFailure("supplier response choice did not match the qualified contract", requestID, nil)
+	}
+	usage := normalizeHuggingFaceUsage(raw.Usage)
+	if err = validateHuggingFaceUsage(usage); err != nil || usage.State != UsageComplete {
+		return Response{}, huggingFaceProtocolFailure("supplier response did not include complete valid usage", requestID, err)
+	}
+	return Response{
+		ID: raw.ID, ModelID: expected.pinned, SupplierRequestID: requestID, Usage: usage,
+		Choices: []Choice{{Index: choice.Index, Message: &Message{Role: "assistant", Content: []ContentPart{{Type: "text", Text: *choice.Message.Content}}}, FinishReason: *choice.FinishReason}},
+	}, nil
+}
+
+func (a *HuggingFaceRouterAdapter) OpenStream(_ context.Context, response *http.Response) (Stream, error) {
+	if response == nil {
+		return nil, huggingFaceProtocolFailure("supplier response is missing", "", nil)
+	}
+	requestID := huggingFaceSupplierRequestID(response.Header)
+	if response.Body == nil {
+		return nil, huggingFaceProtocolFailure("supplier response body is missing", requestID, nil)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		defer response.Body.Close()
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
+		return nil, normalizeHuggingFaceHTTPError(response.StatusCode, response.Header, requestID)
+	}
+	expected, ok := expectedHuggingFaceModel(response)
+	if !ok {
+		response.Body.Close()
+		return nil, huggingFaceProtocolFailure("supplier stream lost its expected model identity", requestID, nil)
+	}
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || !strings.EqualFold(mediaType, "text/event-stream") {
+		response.Body.Close()
+		return nil, huggingFaceProtocolFailure("supplier stream content type is invalid", requestID, err)
+	}
+	return newHuggingFaceRouterStream(response.Body, requestID, expected), nil
+}
+
+func (a *HuggingFaceRouterAdapter) Probe(ctx context.Context, target Target, credentials CredentialResolver) (Observation, error) {
+	repository, provider, err := validateHuggingFaceTarget(target)
+	if err != nil {
+		return Observation{}, invalidRequest(err.Error())
+	}
+	if credentials == nil {
+		return Observation{}, internalBeforeTransmission("supplier credential resolver is unavailable", nil)
+	}
+	credential, err := credentials.Resolve(ctx, target.CredentialReference)
+	if err != nil {
+		return Observation{}, internalBeforeTransmission("supplier credential could not be resolved", err)
+	}
+	defer clear(credential)
+	credentialValue := bytes.TrimSpace(credential)
+	if len(credentialValue) == 0 || !safeIdentifier(string(credentialValue)) {
+		return Observation{}, internalBeforeTransmission("supplier credential is invalid", nil)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, HuggingFaceRouterBaseURL+"/models", nil)
+	if err != nil {
+		return Observation{}, internalBeforeTransmission("supplier inventory probe could not be constructed", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+string(credentialValue))
+	request.Header.Set("Accept", "application/json")
+	response, err := a.client.Do(request)
+	if err != nil {
+		return Observation{}, &Error{Code: ErrorTransport, Message: "supplier inventory probe failed", Retry: RetrySameOffer, Billing: BillingNoChargeConfirmed, Cause: err}
+	}
+	if response == nil || response.Body == nil {
+		return Observation{}, huggingFaceProtocolFailure("supplier inventory response body is missing", "", nil)
+	}
+	requestID := huggingFaceSupplierRequestID(response.Header)
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		defer response.Body.Close()
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
+		normalized := normalizeHuggingFaceHTTPError(response.StatusCode, response.Header, requestID)
+		normalized.Billing = BillingNoChargeConfirmed
+		return Observation{}, normalized
+	}
+	defer response.Body.Close()
+	body, err := readBounded(response.Body, 2<<20)
+	if err != nil {
+		return Observation{}, huggingFaceProtocolFailure("supplier inventory response exceeded the safe byte limit", requestID, err)
+	}
+	var inventory struct {
+		Data []struct {
+			ID        string `json:"id"`
+			Providers []struct {
+				Provider string `json:"provider"`
+				Status   string `json:"status"`
+			} `json:"providers"`
+		} `json:"data"`
+	}
+	if err = json.Unmarshal(body, &inventory); err != nil {
+		return Observation{}, huggingFaceProtocolFailure("supplier inventory response was malformed", requestID, err)
+	}
+	matchCount := 0
+	for _, item := range inventory.Data {
+		if item.ID != repository {
+			continue
+		}
+		for _, candidate := range item.Providers {
+			if candidate.Provider == provider && candidate.Status == "live" {
+				matchCount++
+			}
+		}
+	}
+	availability := "unavailable"
+	items := []InventoryItem(nil)
+	if matchCount == 1 {
+		availability = "available"
+		items = []InventoryItem{{SupplierModelID: target.SupplierModelID, Region: target.Region, Available: true}}
+	}
+	now := time.Now
+	if a.now != nil {
+		now = a.now
+	}
+	return Observation{
+		Access: "authorized", Availability: availability, Health: "healthy", ObservedAt: now().UTC(),
+		RateLimit: huggingFaceRateLimit(response.Header, now()), Inventory: items,
+	}, nil
+}
+
+type huggingFaceUsage struct {
+	PromptTokens        *int64 `json:"prompt_tokens"`
+	CompletionTokens    *int64 `json:"completion_tokens"`
+	PromptTokensDetails *struct {
+		CachedTokens *int64 `json:"cached_tokens"`
+	} `json:"prompt_tokens_details"`
+	CompletionTokensDetails *struct {
+		ReasoningTokens *int64 `json:"reasoning_tokens"`
+	} `json:"completion_tokens_details"`
+}
+
+func normalizeHuggingFaceUsage(raw *huggingFaceUsage) Usage {
+	if raw == nil {
+		return Usage{State: UsageAbsent}
+	}
+	state := UsagePartial
+	if raw.PromptTokens != nil && raw.CompletionTokens != nil {
+		state = UsageComplete
+	}
+	var cached, reasoning *int64
+	if raw.PromptTokensDetails != nil {
+		cached = raw.PromptTokensDetails.CachedTokens
+	}
+	if raw.CompletionTokensDetails != nil {
+		reasoning = raw.CompletionTokensDetails.ReasoningTokens
+	}
+	return Usage{State: state, InputTokens: raw.PromptTokens, OutputTokens: raw.CompletionTokens, CachedInput: cached, ReasoningTokens: reasoning}
+}
+
+func validateHuggingFaceUsage(usage Usage) error {
+	if err := usage.Validate(); err != nil {
+		return err
+	}
+	if usage.CachedInput != nil && usage.InputTokens != nil && *usage.CachedInput > *usage.InputTokens {
+		return errors.New("cached input tokens exceed input tokens")
+	}
+	if usage.ReasoningTokens != nil && usage.OutputTokens != nil && *usage.ReasoningTokens > *usage.OutputTokens {
+		return errors.New("reasoning tokens exceed output tokens")
+	}
+	return nil
+}
+
+func validateHuggingFaceTarget(target Target) (string, string, error) {
+	if target.Supplier != HuggingFaceSupplier {
+		return "", "", errors.New("target is not a routed inference contract")
+	}
+	parsed, err := url.Parse(strings.TrimSpace(target.BaseURL))
+	if err != nil || parsed.Scheme != "https" || parsed.Host != "router.huggingface.co" || parsed.Path != "/v1" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.RawPath != "" {
+		return "", "", errors.New("target must use the exact qualified routed inference base URL")
+	}
+	repository, provider, ok := splitPinnedHuggingFaceModel(target.SupplierModelID)
+	if !ok {
+		return "", "", errors.New("target model must pin one exact repository and provider")
+	}
+	if target.Region != "global" {
+		return "", "", errors.New("routed inference MVP target region must be global")
+	}
+	if strings.TrimSpace(target.CredentialReference) == "" {
+		return "", "", errors.New("target credential reference is required")
+	}
+	return repository, provider, nil
+}
+
+func splitPinnedHuggingFaceModel(model string) (string, string, bool) {
+	if strings.TrimSpace(model) != model || strings.Count(model, ":") != 1 {
+		return "", "", false
+	}
+	repository, provider, _ := strings.Cut(model, ":")
+	if !huggingFaceRepositoryPattern.MatchString(repository) || !huggingFaceProviderPattern.MatchString(provider) {
+		return "", "", false
+	}
+	switch provider {
+	case "fastest", "cheapest", "preferred", "auto":
+		return "", "", false
+	}
+	return repository, provider, true
+}
+
+func validateHuggingFaceRequest(request Request) error {
+	if err := request.Validate(); err != nil {
+		return err
+	}
+	if request.Operation != OperationChatCompletions {
+		return errors.New("routed inference MVP supports Chat Completions only")
+	}
+	if request.MaxOutputTokens == nil || *request.MaxOutputTokens > HuggingFaceRouterMaxOutputTokens {
+		return fmt.Errorf("max output tokens must be set and cannot exceed %d for the MVP", HuggingFaceRouterMaxOutputTokens)
+	}
+	if len(request.Messages) > 256 {
+		return errors.New("routed inference MVP accepts at most 256 messages")
+	}
+	if len(request.Tools) != 0 || len(request.ResponseFormat) != 0 {
+		return errors.New("routed inference MVP does not yet accept tools or response formats")
+	}
+	for index, message := range request.Messages {
+		if message.Role != "system" && message.Role != "user" && message.Role != "assistant" {
+			return fmt.Errorf("message %d has an unsupported role", index)
+		}
+		if message.Name != "" || len(message.Content) != 1 || message.Content[0].Type != "text" || strings.TrimSpace(message.Content[0].Text) == "" || message.Content[0].ImageURL != "" {
+			return fmt.Errorf("message %d must contain exactly one non-empty text part and no name", index)
+		}
+	}
+	return nil
+}
+
+func validHuggingFaceFinishReason(value string) bool {
+	return oneOf(value, "stop", "length", "content_filter")
+}
+
+func expectedHuggingFaceModel(response *http.Response) (huggingFaceExpectedModel, bool) {
+	if response == nil || response.Request == nil {
+		return huggingFaceExpectedModel{}, false
+	}
+	value, ok := response.Request.Context().Value(huggingFaceExpectedModelKey{}).(huggingFaceExpectedModel)
+	if !ok || value.pinned == "" || value.repository == "" {
+		return huggingFaceExpectedModel{}, false
+	}
+	repository, _, valid := splitPinnedHuggingFaceModel(value.pinned)
+	return value, valid && repository == value.repository
+}
+
+func (model huggingFaceExpectedModel) accepts(value string) bool {
+	return value == model.pinned || value == model.repository
+}
+
+func huggingFaceSupplierRequestID(header http.Header) string {
+	for _, name := range []string{"Inference-Id", "X-Request-ID"} {
+		value := strings.TrimSpace(header.Get(name))
+		if value != "" && len(value) <= 256 && safeIdentifier(value) {
+			return value
+		}
+	}
+	return ""
+}
+
+func normalizeHuggingFaceHTTPError(status int, header http.Header, requestID string) *Error {
+	code, message, retry := ErrorInternal, "supplier request failed", RetryNever
+	switch status {
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		code, message = ErrorInvalidRequest, "supplier rejected the request"
+	case http.StatusUnauthorized:
+		code, message = ErrorAuthentication, "supplier authentication failed"
+	case http.StatusForbidden:
+		code, message = ErrorAuthorization, "supplier authorization failed"
+	case http.StatusNotFound:
+		code, message = ErrorUnavailable, "qualified supplier route is unavailable"
+	case http.StatusTooManyRequests:
+		code, message, retry = ErrorRateLimited, "supplier rate limit was reached", RetryOtherOffer
+	case http.StatusRequestTimeout, http.StatusGatewayTimeout:
+		code, message, retry = ErrorTimeout, "supplier request timed out", RetryOtherOffer
+	default:
+		if status >= http.StatusInternalServerError {
+			code, message, retry = ErrorUnavailable, "supplier is temporarily unavailable", RetryOtherOffer
+		}
+	}
+	return &Error{
+		Code: code, Message: message, HTTPStatus: status, SupplierRequestID: requestID,
+		Retry: retry, RetryAfter: parseRetryAfter(header.Get("Retry-After"), time.Now()), Billing: BillingAmbiguous,
+	}
+}
+
+func huggingFaceProtocolFailure(message, requestID string, cause error) *Error {
+	return &Error{Code: ErrorProtocol, Message: message, HTTPStatus: http.StatusBadGateway, SupplierRequestID: requestID, Retry: RetryNever, Billing: BillingAmbiguous, Cause: cause}
+}
+
+func huggingFaceRateLimit(header http.Header, now time.Time) RateLimit {
+	return RateLimit{
+		RequestsRemaining: parseOptionalInt64(header.Get("X-RateLimit-Remaining-Requests")),
+		TokensRemaining:   parseOptionalInt64(header.Get("X-RateLimit-Remaining-Tokens")),
+		ResetAt:           parseOptionalReset(header.Get("X-RateLimit-Reset"), now),
+	}
+}

--- a/internal/supplieradapter/huggingface_router_stream.go
+++ b/internal/supplieradapter/huggingface_router_stream.go
@@ -47,7 +47,9 @@ func (s *huggingFaceRouterStream) Next(ctx context.Context) (StreamEvent, error)
 			s.done = true
 			return StreamEvent{}, huggingFaceStreamFailure("supplier stream ended before its terminal marker", s.requestID, io.ErrUnexpectedEOF)
 		}
-		line := s.scanner.Text()
+		// bufio.Scanner removes '\n' but preserves the '\r' in valid CRLF SSE
+		// framing. Normalize only that framing byte; payload data remains exact.
+		line := strings.TrimSuffix(s.scanner.Text(), "\r")
 		if line == "" {
 			if len(s.data) == 0 {
 				continue

--- a/internal/supplieradapter/huggingface_router_stream.go
+++ b/internal/supplieradapter/huggingface_router_stream.go
@@ -1,0 +1,177 @@
+package supplieradapter
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+)
+
+type huggingFaceRouterStream struct {
+	body      io.ReadCloser
+	scanner   *bufio.Scanner
+	requestID string
+	expected  huggingFaceExpectedModel
+	response  string
+	data      []string
+	finished  bool
+	usageSeen bool
+	done      bool
+}
+
+func newHuggingFaceRouterStream(body io.ReadCloser, requestID string, expected huggingFaceExpectedModel) *huggingFaceRouterStream {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 64<<10), HuggingFaceRouterMaxStreamEventBytes)
+	return &huggingFaceRouterStream{body: body, scanner: scanner, requestID: requestID, expected: expected}
+}
+
+func (s *huggingFaceRouterStream) Next(ctx context.Context) (StreamEvent, error) {
+	if s == nil || s.done {
+		return StreamEvent{}, io.EOF
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			s.done = true
+			return StreamEvent{}, huggingFaceStreamFailure("supplier stream was cancelled", s.requestID, err)
+		}
+		if !s.scanner.Scan() {
+			if err := s.scanner.Err(); err != nil {
+				s.done = true
+				return StreamEvent{}, huggingFaceStreamFailure("supplier stream framing failed", s.requestID, err)
+			}
+			if len(s.data) != 0 {
+				return s.parseEvent()
+			}
+			s.done = true
+			return StreamEvent{}, huggingFaceStreamFailure("supplier stream ended before its terminal marker", s.requestID, io.ErrUnexpectedEOF)
+		}
+		line := s.scanner.Text()
+		if line == "" {
+			if len(s.data) == 0 {
+				continue
+			}
+			return s.parseEvent()
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		if line == "data" {
+			s.data = append(s.data, "")
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			s.data = append(s.data, strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+		}
+	}
+}
+
+func (s *huggingFaceRouterStream) parseEvent() (StreamEvent, error) {
+	payload := strings.Join(s.data, "\n")
+	s.data = s.data[:0]
+	if payload == "[DONE]" {
+		s.done = true
+		if !s.finished || !s.usageSeen {
+			return StreamEvent{}, huggingFaceStreamFailure("supplier stream ended without a finish reason and complete usage", s.requestID, nil)
+		}
+		return StreamEvent{}, io.EOF
+	}
+	if s.usageSeen {
+		s.done = true
+		return StreamEvent{}, huggingFaceStreamFailure("supplier stream continued after terminal usage", s.requestID, nil)
+	}
+	var raw struct {
+		ID      string `json:"id"`
+		Model   string `json:"model"`
+		Choices []struct {
+			Index        int     `json:"index"`
+			FinishReason *string `json:"finish_reason"`
+			Delta        struct {
+				Content *string `json:"content"`
+			} `json:"delta"`
+		} `json:"choices"`
+		Usage *huggingFaceUsage `json:"usage"`
+	}
+	if err := json.Unmarshal([]byte(payload), &raw); err != nil {
+		s.done = true
+		return StreamEvent{}, huggingFaceStreamFailure("supplier stream contained malformed JSON", s.requestID, err)
+	}
+	if strings.TrimSpace(raw.ID) == "" || !s.expected.accepts(raw.Model) {
+		s.done = true
+		return StreamEvent{}, huggingFaceStreamFailure("supplier stream did not match the qualified model contract", s.requestID, nil)
+	}
+	if s.response == "" {
+		s.response = raw.ID
+	} else if raw.ID != s.response {
+		s.done = true
+		return StreamEvent{}, huggingFaceStreamFailure("supplier stream response identity changed", s.requestID, nil)
+	}
+
+	event := StreamEvent{Type: StreamEventContent, SupplierRequestID: s.requestID}
+	if len(raw.Choices) > 1 {
+		s.done = true
+		return StreamEvent{}, huggingFaceStreamFailure("supplier stream returned multiple choices", s.requestID, nil)
+	}
+	if len(raw.Choices) == 1 {
+		if s.finished {
+			s.done = true
+			return StreamEvent{}, huggingFaceStreamFailure("supplier stream continued after its finish reason", s.requestID, nil)
+		}
+		choice := raw.Choices[0]
+		if choice.Index != 0 {
+			s.done = true
+			return StreamEvent{}, huggingFaceStreamFailure("supplier stream choice index was invalid", s.requestID, nil)
+		}
+		event.ChoiceIndex = choice.Index
+		if choice.Delta.Content != nil {
+			event.TextDelta = *choice.Delta.Content
+		}
+		if choice.FinishReason != nil {
+			if !validHuggingFaceFinishReason(*choice.FinishReason) {
+				s.done = true
+				return StreamEvent{}, huggingFaceStreamFailure("supplier stream finish reason was invalid", s.requestID, nil)
+			}
+			s.finished = true
+			event.Type = StreamEventFinish
+			event.FinishReason = *choice.FinishReason
+		}
+	} else if raw.Usage == nil {
+		s.done = true
+		return StreamEvent{}, huggingFaceStreamFailure("supplier stream event had neither a choice nor usage", s.requestID, nil)
+	}
+
+	if raw.Usage != nil {
+		usage := normalizeHuggingFaceUsage(raw.Usage)
+		if len(raw.Choices) != 0 || !s.finished {
+			s.done = true
+			return StreamEvent{}, huggingFaceStreamFailure("supplier stream usage was not terminal", s.requestID, nil)
+		}
+		if err := validateHuggingFaceUsage(usage); err != nil || usage.State != UsageComplete {
+			s.done = true
+			return StreamEvent{}, huggingFaceStreamFailure("supplier stream contained invalid terminal usage", s.requestID, err)
+		}
+		s.usageSeen = true
+		event.Type = StreamEventUsage
+		event.Usage = &usage
+	}
+	return event, nil
+}
+
+func (s *huggingFaceRouterStream) Close() error {
+	if s == nil || s.body == nil {
+		return nil
+	}
+	s.done = true
+	return s.body.Close()
+}
+
+func huggingFaceStreamFailure(message, requestID string, cause error) *Error {
+	code := ErrorProtocol
+	if errors.Is(cause, context.Canceled) {
+		code = ErrorCancelled
+	} else if errors.Is(cause, context.DeadlineExceeded) {
+		code = ErrorTimeout
+	}
+	return &Error{Code: code, Message: message, SupplierRequestID: requestID, Retry: RetryNever, Billing: BillingAmbiguous, ResponseStarted: true, Cause: cause}
+}

--- a/internal/supplieradapter/huggingface_router_test.go
+++ b/internal/supplieradapter/huggingface_router_test.go
@@ -1,0 +1,279 @@
+package supplieradapter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type huggingFaceCredentialResolverFunc func(context.Context, string) ([]byte, error)
+
+func (f huggingFaceCredentialResolverFunc) Resolve(ctx context.Context, reference string) ([]byte, error) {
+	return f(ctx, reference)
+}
+
+type huggingFaceRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f huggingFaceRoundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func huggingFaceTarget() Target {
+	return Target{
+		Supplier: HuggingFaceSupplier, BaseURL: HuggingFaceRouterBaseURL,
+		SupplierModelID: "Qwen/Qwen3-8B:together", Region: "global", CredentialReference: "secret://hf/router",
+	}
+}
+
+func huggingFaceRequest() Request {
+	maximum := 4096
+	temperature := 0.3
+	return Request{
+		ID: "request-1", Operation: OperationChatCompletions, ModelID: "infercrane/qwen3-8b",
+		Messages: []Message{
+			{Role: "system", Content: []ContentPart{{Type: "text", Text: "Be concise."}}},
+			{Role: "user", Content: []ContentPart{{Type: "text", Text: "Hello"}}},
+		},
+		MaxOutputTokens: &maximum, Temperature: &temperature, Stream: true,
+	}
+}
+
+func huggingFaceResponseRequest(model string) *http.Request {
+	repository, _, _ := splitPinnedHuggingFaceModel(model)
+	ctx := context.WithValue(context.Background(), huggingFaceExpectedModelKey{}, huggingFaceExpectedModel{pinned: model, repository: repository})
+	request, _ := http.NewRequestWithContext(ctx, http.MethodPost, HuggingFaceRouterBaseURL+"/chat/completions", nil)
+	return request
+}
+
+func TestHuggingFaceRouterBuildRequestPinsExactProvider(t *testing.T) {
+	credential := []byte("hf_secret")
+	request, err := NewHuggingFaceRouterAdapter(nil).BuildRequest(context.Background(), huggingFaceTarget(), huggingFaceRequest(), huggingFaceCredentialResolverFunc(func(_ context.Context, reference string) ([]byte, error) {
+		if reference != "secret://hf/router" {
+			t.Fatalf("credential reference=%q", reference)
+		}
+		return credential, nil
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.Method != http.MethodPost || request.URL.String() != HuggingFaceRouterBaseURL+"/chat/completions" {
+		t.Fatalf("upstream request=%s %s", request.Method, request.URL)
+	}
+	if request.Header.Get("Authorization") != "Bearer hf_secret" || request.Header.Get("Accept") != "text/event-stream" || request.Header.Get("X-Request-ID") != "request-1" {
+		t.Fatalf("upstream headers=%#v", request.Header)
+	}
+	for index, value := range credential {
+		if value != 0 {
+			t.Fatalf("resolved credential byte %d was not cleared", index)
+		}
+	}
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err = json.Unmarshal(body, &payload); err != nil {
+		t.Fatal(err)
+	}
+	streamOptions, _ := payload["stream_options"].(map[string]any)
+	if payload["model"] != "Qwen/Qwen3-8B:together" || payload["stream"] != true || streamOptions["include_usage"] != true {
+		t.Fatalf("wire payload=%s", body)
+	}
+	if strings.Contains(string(body), "infercrane/qwen3-8b") || strings.Contains(string(body), "hf_secret") {
+		t.Fatalf("public identity or credential leaked into supplier body: %s", body)
+	}
+}
+
+func TestHuggingFaceRouterRejectsAutomaticProviderPolicies(t *testing.T) {
+	resolve := huggingFaceCredentialResolverFunc(func(context.Context, string) ([]byte, error) { return []byte("secret"), nil })
+	for _, model := range []string{
+		"Qwen/Qwen3-8B", "Qwen/Qwen3-8B:fastest", "Qwen/Qwen3-8B:cheapest",
+		"Qwen/Qwen3-8B:preferred", "Qwen/Qwen3-8B:auto", "Qwen/Qwen3-8B:together:fastest",
+	} {
+		t.Run(model, func(t *testing.T) {
+			target := huggingFaceTarget()
+			target.SupplierModelID = model
+			_, err := NewHuggingFaceRouterAdapter(nil).BuildRequest(context.Background(), target, huggingFaceRequest(), resolve)
+			var normalized *Error
+			if !errors.As(err, &normalized) || normalized.Code != ErrorInvalidRequest || normalized.Billing != BillingNotTransmitted {
+				t.Fatalf("model=%q error=%#v", model, err)
+			}
+		})
+	}
+}
+
+func TestHuggingFaceRouterFailsClosedOutsideQualifiedMVP(t *testing.T) {
+	resolve := huggingFaceCredentialResolverFunc(func(context.Context, string) ([]byte, error) { return []byte("secret"), nil })
+	tests := map[string]struct {
+		target Target
+		mutate func(*Request)
+	}{
+		"wrong host":           {target: Target{Supplier: HuggingFaceSupplier, BaseURL: "https://proxy.example/v1", SupplierModelID: "Qwen/Qwen3-8B:together", Region: "global", CredentialReference: "secret"}},
+		"wrong path":           {target: Target{Supplier: HuggingFaceSupplier, BaseURL: "https://router.huggingface.co", SupplierModelID: "Qwen/Qwen3-8B:together", Region: "global", CredentialReference: "secret"}},
+		"wrong region":         {target: Target{Supplier: HuggingFaceSupplier, BaseURL: HuggingFaceRouterBaseURL, SupplierModelID: "Qwen/Qwen3-8B:together", Region: "us-east", CredentialReference: "secret"}},
+		"responses":            {target: huggingFaceTarget(), mutate: func(request *Request) { request.Operation = OperationResponses }},
+		"missing output bound": {target: huggingFaceTarget(), mutate: func(request *Request) { request.MaxOutputTokens = nil }},
+		"tools": {target: huggingFaceTarget(), mutate: func(request *Request) {
+			request.Tools = []Tool{{Name: "search", InputSchema: json.RawMessage(`{"type":"object"}`)}}
+		}},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			request := huggingFaceRequest()
+			if test.mutate != nil {
+				test.mutate(&request)
+			}
+			_, err := NewHuggingFaceRouterAdapter(nil).BuildRequest(context.Background(), test.target, request, resolve)
+			var normalized *Error
+			if !errors.As(err, &normalized) || normalized.Code != ErrorInvalidRequest || normalized.SafeToRetry() {
+				t.Fatalf("error=%#v", err)
+			}
+		})
+	}
+}
+
+func TestHuggingFaceRouterDecodeRequiresExactIdentityAndCompleteUsage(t *testing.T) {
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": {"application/json; charset=utf-8"}, "Inference-Id": {"private-inference-id"}},
+		Request:    huggingFaceResponseRequest("Qwen/Qwen3-8B:together"),
+		Body: io.NopCloser(strings.NewReader(`{
+			"id":"chatcmpl-1","model":"Qwen/Qwen3-8B",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":19,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":11},"completion_tokens_details":{"reasoning_tokens":2}}
+		}`)),
+	}
+	decoded, err := NewHuggingFaceRouterAdapter(nil).DecodeResponse(context.Background(), response)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded.ID != "chatcmpl-1" || decoded.ModelID != "Qwen/Qwen3-8B:together" || decoded.SupplierRequestID != "private-inference-id" || decoded.Choices[0].Message.Content[0].Text != "hello" {
+		t.Fatalf("decoded response=%+v", decoded)
+	}
+	if decoded.Usage.State != UsageComplete || *decoded.Usage.InputTokens != 19 || *decoded.Usage.OutputTokens != 5 || *decoded.Usage.CachedInput != 11 || *decoded.Usage.ReasoningTokens != 2 {
+		t.Fatalf("decoded usage=%+v", decoded.Usage)
+	}
+
+	for name, body := range map[string]string{
+		"wrong model":   `{"id":"chatcmpl-1","model":"Qwen/Other","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`,
+		"missing usage": `{"id":"chatcmpl-1","model":"Qwen/Qwen3-8B","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}`,
+		"invalid usage": `{"id":"chatcmpl-1","model":"Qwen/Qwen3-8B","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"prompt_tokens_details":{"cached_tokens":2}}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewHuggingFaceRouterAdapter(nil).DecodeResponse(context.Background(), &http.Response{
+				StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {"application/json"}}, Request: huggingFaceResponseRequest("Qwen/Qwen3-8B:together"), Body: io.NopCloser(strings.NewReader(body)),
+			})
+			var normalized *Error
+			if !errors.As(err, &normalized) || normalized.Code != ErrorProtocol || normalized.Billing != BillingAmbiguous {
+				t.Fatalf("error=%#v", err)
+			}
+		})
+	}
+}
+
+func TestHuggingFaceRouterHTTPErrorIsSanitizedAndAmbiguous(t *testing.T) {
+	response := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{"Retry-After": {"7"}, "Inference-Id": {"private-request"}},
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"raw supplier detail must not escape"}}`)),
+	}
+	_, err := NewHuggingFaceRouterAdapter(nil).DecodeResponse(context.Background(), response)
+	var normalized *Error
+	if !errors.As(err, &normalized) {
+		t.Fatalf("error=%#v", err)
+	}
+	if normalized.Code != ErrorRateLimited || normalized.Retry != RetryOtherOffer || normalized.RetryAfter != 7*time.Second || normalized.SupplierRequestID != "private-request" || normalized.Billing != BillingAmbiguous || normalized.SafeToRetry() {
+		t.Fatalf("normalized error=%+v", normalized)
+	}
+	if strings.Contains(normalized.Error(), "raw supplier") {
+		t.Fatal("raw supplier body escaped the adapter boundary")
+	}
+}
+
+func TestHuggingFaceRouterStreamRequiresFinishUsageAndDone(t *testing.T) {
+	body := "data: {\"id\":\"chatcmpl-1\",\"model\":\"Qwen/Qwen3-8B\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hel\"},\"finish_reason\":null}]}\n\n" +
+		"data: {\"id\":\"chatcmpl-1\",\"model\":\"Qwen/Qwen3-8B\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"lo\"},\"finish_reason\":\"stop\"}]}\n\n" +
+		"data: {\"id\":\"chatcmpl-1\",\"model\":\"Qwen/Qwen3-8B\",\"choices\":[],\"usage\":{\"prompt_tokens\":8,\"completion_tokens\":2,\"prompt_tokens_details\":{\"cached_tokens\":3}}}\n\n" +
+		"data: [DONE]\n\n"
+	stream, err := NewHuggingFaceRouterAdapter(nil).OpenStream(context.Background(), &http.Response{
+		StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {"text/event-stream; charset=utf-8"}, "Inference-Id": {"stream-1"}},
+		Request: huggingFaceResponseRequest("Qwen/Qwen3-8B:together"), Body: io.NopCloser(strings.NewReader(body)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+	first, err := stream.Next(context.Background())
+	if err != nil || first.Type != StreamEventContent || first.TextDelta != "hel" {
+		t.Fatalf("first=%+v err=%v", first, err)
+	}
+	finish, err := stream.Next(context.Background())
+	if err != nil || finish.Type != StreamEventFinish || finish.TextDelta != "lo" || finish.FinishReason != "stop" {
+		t.Fatalf("finish=%+v err=%v", finish, err)
+	}
+	usage, err := stream.Next(context.Background())
+	if err != nil || usage.Type != StreamEventUsage || usage.Usage == nil || usage.Usage.State != UsageComplete || *usage.Usage.CachedInput != 3 || usage.SupplierRequestID != "stream-1" {
+		t.Fatalf("usage=%+v err=%v", usage, err)
+	}
+	if _, err = stream.Next(context.Background()); !errors.Is(err, io.EOF) {
+		t.Fatalf("terminal err=%v", err)
+	}
+}
+
+func TestHuggingFaceRouterStreamFailsClosedWhenIncomplete(t *testing.T) {
+	for name, body := range map[string]string{
+		"missing usage":       "data: {\"id\":\"chatcmpl-1\",\"model\":\"Qwen/Qwen3-8B\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n",
+		"wrong model":         "data: {\"id\":\"chatcmpl-1\",\"model\":\"Qwen/Other\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"wrong\"},\"finish_reason\":null}]}\n\n",
+		"usage before finish": "data: {\"id\":\"chatcmpl-1\",\"model\":\"Qwen/Qwen3-8B\",\"choices\":[],\"usage\":{\"prompt_tokens\":8,\"completion_tokens\":2}}\n\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			stream, err := NewHuggingFaceRouterAdapter(nil).OpenStream(context.Background(), &http.Response{
+				StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {"text/event-stream"}}, Request: huggingFaceResponseRequest("Qwen/Qwen3-8B:together"), Body: io.NopCloser(strings.NewReader(body)),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer stream.Close()
+			for {
+				_, err = stream.Next(context.Background())
+				if err != nil {
+					break
+				}
+			}
+			var normalized *Error
+			if !errors.As(err, &normalized) || normalized.Code != ErrorProtocol || normalized.Billing != BillingAmbiguous || !normalized.ResponseStarted {
+				t.Fatalf("error=%#v", err)
+			}
+		})
+	}
+}
+
+func TestHuggingFaceRouterProbeRequiresPinnedProviderToBeLive(t *testing.T) {
+	client := &http.Client{Transport: huggingFaceRoundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.String() != HuggingFaceRouterBaseURL+"/models" || request.Header.Get("Authorization") != "Bearer hf_secret" {
+			t.Fatalf("probe request=%s headers=%#v", request.URL, request.Header)
+		}
+		header := make(http.Header)
+		header.Set("X-RateLimit-Remaining-Requests", "17")
+		header.Set("Inference-Id", "probe-1")
+		return &http.Response{
+			StatusCode: http.StatusOK, Header: header,
+			Body: io.NopCloser(strings.NewReader(`{"object":"list","data":[{"id":"Qwen/Qwen3-8B","providers":[{"provider":"together","status":"live"},{"provider":"other","status":"live"}]}]}`)),
+		}, nil
+	})}
+	adapter := NewHuggingFaceRouterAdapter(client)
+	observedAt := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	adapter.now = func() time.Time { return observedAt }
+	observation, err := adapter.Probe(context.Background(), huggingFaceTarget(), huggingFaceCredentialResolverFunc(func(context.Context, string) ([]byte, error) { return []byte("hf_secret"), nil }))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observation.Access != "authorized" || observation.Availability != "available" || observation.Health != "healthy" || !observation.ObservedAt.Equal(observedAt) || len(observation.Inventory) != 1 || observation.Inventory[0].SupplierModelID != "Qwen/Qwen3-8B:together" || observation.RateLimit.RequestsRemaining == nil || *observation.RateLimit.RequestsRemaining != 17 {
+		t.Fatalf("observation=%+v", observation)
+	}
+}

--- a/internal/supplieradapter/huggingface_router_test.go
+++ b/internal/supplieradapter/huggingface_router_test.go
@@ -26,7 +26,7 @@ func (f huggingFaceRoundTripperFunc) RoundTrip(request *http.Request) (*http.Res
 func huggingFaceTarget() Target {
 	return Target{
 		Supplier: HuggingFaceSupplier, BaseURL: HuggingFaceRouterBaseURL,
-		SupplierModelID: "Qwen/Qwen3-8B:together", Region: "global", CredentialReference: "secret://hf/router",
+		SupplierModelID: "Qwen/Qwen3-8B:together", Region: "global", CredentialReference: "secret://hf/router", BillingPrincipal: "infercrane",
 	}
 }
 
@@ -64,7 +64,7 @@ func TestHuggingFaceRouterBuildRequestPinsExactProvider(t *testing.T) {
 	if request.Method != http.MethodPost || request.URL.String() != HuggingFaceRouterBaseURL+"/chat/completions" {
 		t.Fatalf("upstream request=%s %s", request.Method, request.URL)
 	}
-	if request.Header.Get("Authorization") != "Bearer hf_secret" || request.Header.Get("Accept") != "text/event-stream" || request.Header.Get("X-Request-ID") != "request-1" {
+	if request.Header.Get("Authorization") != "Bearer hf_secret" || request.Header.Get("Accept") != "text/event-stream" || request.Header.Get("X-Request-ID") != "request-1" || request.Header.Get("X-HF-Bill-To") != "infercrane" {
 		t.Fatalf("upstream headers=%#v", request.Header)
 	}
 	for index, value := range credential {
@@ -116,6 +116,8 @@ func TestHuggingFaceRouterFailsClosedOutsideQualifiedMVP(t *testing.T) {
 		"wrong host":           {target: Target{Supplier: HuggingFaceSupplier, BaseURL: "https://proxy.example/v1", SupplierModelID: "Qwen/Qwen3-8B:together", Region: "global", CredentialReference: "secret"}},
 		"wrong path":           {target: Target{Supplier: HuggingFaceSupplier, BaseURL: "https://router.huggingface.co", SupplierModelID: "Qwen/Qwen3-8B:together", Region: "global", CredentialReference: "secret"}},
 		"wrong region":         {target: Target{Supplier: HuggingFaceSupplier, BaseURL: HuggingFaceRouterBaseURL, SupplierModelID: "Qwen/Qwen3-8B:together", Region: "us-east", CredentialReference: "secret"}},
+		"missing payer":        {target: Target{Supplier: HuggingFaceSupplier, BaseURL: HuggingFaceRouterBaseURL, SupplierModelID: "Qwen/Qwen3-8B:together", Region: "global", CredentialReference: "secret"}},
+		"malformed payer":      {target: Target{Supplier: HuggingFaceSupplier, BaseURL: HuggingFaceRouterBaseURL, SupplierModelID: "Qwen/Qwen3-8B:together", Region: "global", CredentialReference: "secret", BillingPrincipal: "bad payer"}},
 		"responses":            {target: huggingFaceTarget(), mutate: func(request *Request) { request.Operation = OperationResponses }},
 		"missing output bound": {target: huggingFaceTarget(), mutate: func(request *Request) { request.MaxOutputTokens = nil }},
 		"tools": {target: huggingFaceTarget(), mutate: func(request *Request) {
@@ -255,7 +257,7 @@ func TestHuggingFaceRouterStreamFailsClosedWhenIncomplete(t *testing.T) {
 
 func TestHuggingFaceRouterProbeProvesCredentialAndProviderBoundCompletion(t *testing.T) {
 	client := &http.Client{Transport: huggingFaceRoundTripperFunc(func(request *http.Request) (*http.Response, error) {
-		if request.Method != http.MethodPost || request.URL.String() != HuggingFaceRouterBaseURL+"/chat/completions" || request.Header.Get("Authorization") != "Bearer hf_secret" || request.Header.Get("Accept") != "application/json" {
+		if request.Method != http.MethodPost || request.URL.String() != HuggingFaceRouterBaseURL+"/chat/completions" || request.Header.Get("Authorization") != "Bearer hf_secret" || request.Header.Get("Accept") != "application/json" || request.Header.Get("X-HF-Bill-To") != "infercrane" {
 			t.Fatalf("probe request=%s headers=%#v", request.URL, request.Header)
 		}
 		body, err := io.ReadAll(request.Body)

--- a/internal/supplieradapter/huggingface_router_test.go
+++ b/internal/supplieradapter/huggingface_router_test.go
@@ -176,7 +176,7 @@ func TestHuggingFaceRouterDecodeRequiresExactIdentityAndCompleteUsage(t *testing
 	}
 }
 
-func TestHuggingFaceRouterHTTPErrorIsSanitizedAndAmbiguous(t *testing.T) {
+func TestHuggingFaceRouterReceivedErrorIsNoChargeAndRetryable(t *testing.T) {
 	response := &http.Response{
 		StatusCode: http.StatusTooManyRequests,
 		Header:     http.Header{"Retry-After": {"7"}, "Inference-Id": {"private-request"}},
@@ -187,7 +187,7 @@ func TestHuggingFaceRouterHTTPErrorIsSanitizedAndAmbiguous(t *testing.T) {
 	if !errors.As(err, &normalized) {
 		t.Fatalf("error=%#v", err)
 	}
-	if normalized.Code != ErrorRateLimited || normalized.Retry != RetryOtherOffer || normalized.RetryAfter != 7*time.Second || normalized.SupplierRequestID != "private-request" || normalized.Billing != BillingAmbiguous || normalized.SafeToRetry() {
+	if normalized.Code != ErrorRateLimited || normalized.Retry != RetryOtherOffer || normalized.RetryAfter != 7*time.Second || normalized.SupplierRequestID != "private-request" || normalized.Billing != BillingNoChargeConfirmed || !normalized.SafeToRetry() {
 		t.Fatalf("normalized error=%+v", normalized)
 	}
 	if strings.Contains(normalized.Error(), "raw supplier") {
@@ -195,11 +195,11 @@ func TestHuggingFaceRouterHTTPErrorIsSanitizedAndAmbiguous(t *testing.T) {
 	}
 }
 
-func TestHuggingFaceRouterStreamRequiresFinishUsageAndDone(t *testing.T) {
-	body := "data: {\"id\":\"chatcmpl-1\",\"model\":\"Qwen/Qwen3-8B\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hel\"},\"finish_reason\":null}]}\n\n" +
-		"data: {\"id\":\"chatcmpl-1\",\"model\":\"Qwen/Qwen3-8B\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"lo\"},\"finish_reason\":\"stop\"}]}\n\n" +
-		"data: {\"id\":\"chatcmpl-1\",\"model\":\"Qwen/Qwen3-8B\",\"choices\":[],\"usage\":{\"prompt_tokens\":8,\"completion_tokens\":2,\"prompt_tokens_details\":{\"cached_tokens\":3}}}\n\n" +
-		"data: [DONE]\n\n"
+func TestHuggingFaceRouterStreamRequiresFinishUsageAndDoneWithCRLF(t *testing.T) {
+	body := "data: {\"id\":\"chatcmpl-1\",\"model\":\"Qwen/Qwen3-8B\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hel\"},\"finish_reason\":null}]}\r\n\r\n" +
+		"data: {\"id\":\"chatcmpl-1\",\"model\":\"Qwen/Qwen3-8B\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"lo\"},\"finish_reason\":\"stop\"}]}\r\n\r\n" +
+		"data: {\"id\":\"chatcmpl-1\",\"model\":\"Qwen/Qwen3-8B\",\"choices\":[],\"usage\":{\"prompt_tokens\":8,\"completion_tokens\":2,\"prompt_tokens_details\":{\"cached_tokens\":3}}}\r\n\r\n" +
+		"data: [DONE]\r\n\r\n"
 	stream, err := NewHuggingFaceRouterAdapter(nil).OpenStream(context.Background(), &http.Response{
 		StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {"text/event-stream; charset=utf-8"}, "Inference-Id": {"stream-1"}},
 		Request: huggingFaceResponseRequest("Qwen/Qwen3-8B:together"), Body: io.NopCloser(strings.NewReader(body)),
@@ -253,17 +253,29 @@ func TestHuggingFaceRouterStreamFailsClosedWhenIncomplete(t *testing.T) {
 	}
 }
 
-func TestHuggingFaceRouterProbeRequiresPinnedProviderToBeLive(t *testing.T) {
+func TestHuggingFaceRouterProbeProvesCredentialAndProviderBoundCompletion(t *testing.T) {
 	client := &http.Client{Transport: huggingFaceRoundTripperFunc(func(request *http.Request) (*http.Response, error) {
-		if request.URL.String() != HuggingFaceRouterBaseURL+"/models" || request.Header.Get("Authorization") != "Bearer hf_secret" {
+		if request.Method != http.MethodPost || request.URL.String() != HuggingFaceRouterBaseURL+"/chat/completions" || request.Header.Get("Authorization") != "Bearer hf_secret" || request.Header.Get("Accept") != "application/json" {
 			t.Fatalf("probe request=%s headers=%#v", request.URL, request.Header)
+		}
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var payload map[string]any
+		if err = json.Unmarshal(body, &payload); err != nil {
+			t.Fatal(err)
+		}
+		if payload["model"] != "Qwen/Qwen3-8B:together" || payload["stream"] != false || payload["max_tokens"] != float64(huggingFaceProbeMaxOutputTokens) || payload["stream_options"] != nil {
+			t.Fatalf("probe payload=%s", body)
 		}
 		header := make(http.Header)
 		header.Set("X-RateLimit-Remaining-Requests", "17")
 		header.Set("Inference-Id", "probe-1")
+		header.Set("Content-Type", "application/json")
 		return &http.Response{
-			StatusCode: http.StatusOK, Header: header,
-			Body: io.NopCloser(strings.NewReader(`{"object":"list","data":[{"id":"Qwen/Qwen3-8B","providers":[{"provider":"together","status":"live"},{"provider":"other","status":"live"}]}]}`)),
+			StatusCode: http.StatusOK, Header: header, Request: request,
+			Body: io.NopCloser(strings.NewReader(`{"id":"probe-response","model":"Qwen/Qwen3-8B","choices":[{"index":0,"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":1}}`)),
 		}, nil
 	})}
 	adapter := NewHuggingFaceRouterAdapter(client)
@@ -275,5 +287,36 @@ func TestHuggingFaceRouterProbeRequiresPinnedProviderToBeLive(t *testing.T) {
 	}
 	if observation.Access != "authorized" || observation.Availability != "available" || observation.Health != "healthy" || !observation.ObservedAt.Equal(observedAt) || len(observation.Inventory) != 1 || observation.Inventory[0].SupplierModelID != "Qwen/Qwen3-8B:together" || observation.RateLimit.RequestsRemaining == nil || *observation.RateLimit.RequestsRemaining != 17 {
 		t.Fatalf("observation=%+v", observation)
+	}
+}
+
+func TestHuggingFaceRouterProbeRejectsInvalidCredentialViaCompletion(t *testing.T) {
+	client := &http.Client{Transport: huggingFaceRoundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Request:    request,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"invalid token"}`)),
+		}, nil
+	})}
+	_, err := NewHuggingFaceRouterAdapter(client).Probe(context.Background(), huggingFaceTarget(), huggingFaceCredentialResolverFunc(func(context.Context, string) ([]byte, error) {
+		return []byte("hf_invalid"), nil
+	}))
+	var normalized *Error
+	if !errors.As(err, &normalized) || normalized.Code != ErrorAuthentication || normalized.Billing != BillingNoChargeConfirmed || normalized.SafeToRetry() {
+		t.Fatalf("error=%#v", err)
+	}
+}
+
+func TestHuggingFaceRouterProbeTransportFailureKeepsBillingAmbiguous(t *testing.T) {
+	client := &http.Client{Transport: huggingFaceRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, context.DeadlineExceeded
+	})}
+	_, err := NewHuggingFaceRouterAdapter(client).Probe(context.Background(), huggingFaceTarget(), huggingFaceCredentialResolverFunc(func(context.Context, string) ([]byte, error) {
+		return []byte("hf_secret"), nil
+	}))
+	var normalized *Error
+	if !errors.As(err, &normalized) || normalized.Code != ErrorTransport || normalized.Billing != BillingAmbiguous || normalized.SafeToRetry() {
+		t.Fatalf("error=%#v", err)
 	}
 }

--- a/internal/supplieradapter/registry.go
+++ b/internal/supplieradapter/registry.go
@@ -58,3 +58,10 @@ func RequiresImmutableTargetBinding(adapter string) bool {
 		return false
 	}
 }
+
+// RequiresBillingPrincipal identifies adapters whose supplier-side payer must
+// be pinned separately from the credential reference. This prevents a secret
+// rotation from silently moving spend to another account.
+func RequiresBillingPrincipal(adapter string) bool {
+	return strings.TrimSpace(adapter) == HuggingFaceRouterAdapterName
+}

--- a/internal/supplieradapter/registry.go
+++ b/internal/supplieradapter/registry.go
@@ -40,9 +40,21 @@ func (r *Registry) Lookup(name string) (Adapter, bool) {
 }
 
 func DefaultRegistry() *Registry {
-	registry, err := NewRegistry(NewDeepSeekAdapter(nil), NewRunPodVLLMAdapter(nil))
+	registry, err := NewRegistry(NewDeepSeekAdapter(nil), NewHuggingFaceRouterAdapter(nil), NewRunPodVLLMAdapter(nil))
 	if err != nil {
 		panic(err)
 	}
 	return registry
+}
+
+// RequiresImmutableTargetBinding identifies adapters whose execution identity
+// includes operator-selected infrastructure or a routed provider. Their exact
+// endpoint and model/provider tuple must be committed before publication.
+func RequiresImmutableTargetBinding(adapter string) bool {
+	switch strings.TrimSpace(adapter) {
+	case HuggingFaceRouterAdapterName, RunPodVLLMAdapterName:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/supplieradapter/registry_test.go
+++ b/internal/supplieradapter/registry_test.go
@@ -47,3 +47,9 @@ func TestRoutedAndSelfHostedAdaptersRequireImmutableTargets(t *testing.T) {
 		}
 	}
 }
+
+func TestOnlyHuggingFaceRouterRequiresExplicitBillingPrincipal(t *testing.T) {
+	if !RequiresBillingPrincipal(HuggingFaceRouterAdapterName) || RequiresBillingPrincipal(DeepSeekAdapterName) || RequiresBillingPrincipal(RunPodVLLMAdapterName) {
+		t.Fatal("billing principal requirement does not match supplier billing semantics")
+	}
+}

--- a/internal/supplieradapter/registry_test.go
+++ b/internal/supplieradapter/registry_test.go
@@ -27,7 +27,23 @@ func TestDefaultRegistryContainsQualifiedHostedAdapters(t *testing.T) {
 	if _, ok := registry.Lookup(RunPodVLLMAdapterName); !ok {
 		t.Fatal("RunPod vLLM adapter is absent from the default registry")
 	}
+	if _, ok := registry.Lookup(HuggingFaceRouterAdapterName); !ok {
+		t.Fatal("Hugging Face router adapter is absent from the default registry")
+	}
 	if _, ok := registry.Lookup("openai"); ok {
 		t.Fatal("unqualified generic adapter appeared in the default registry")
+	}
+}
+
+func TestRoutedAndSelfHostedAdaptersRequireImmutableTargets(t *testing.T) {
+	for _, adapter := range []string{HuggingFaceRouterAdapterName, RunPodVLLMAdapterName} {
+		if !RequiresImmutableTargetBinding(adapter) {
+			t.Fatalf("adapter %q did not require an immutable target", adapter)
+		}
+	}
+	for _, adapter := range []string{"", DeepSeekAdapterName, "unqualified"} {
+		if RequiresImmutableTargetBinding(adapter) {
+			t.Fatalf("adapter %q unexpectedly required an immutable target", adapter)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add a strict provider-bound Hugging Face Inference Providers adapter for future MVP catalog coverage.
- Require a real billable qualification probe, complete usage, and evidence valid for at most 24 hours.
- Pin the Hugging Face billing principal separately from rotatable credentials.
- Keep customer payloads supplier-neutral and require target bindings before publication.

## MVP boundary
Only the existing DeepSeek Model API remains customer-callable. This change does not add supplier credentials, publish routes or rates, or allocate compute. The broader adapter is deliberately dormant until funding, commercial approval, qualification, and a payer-bound target exist.

## Verification
- make verify
- independent backend security and reliability review
- independent live Hugging Face protocol and pricing review

## Launch blockers intentionally retained
- explicit HF Team or Enterprise billing principal and capped token
- commercial and resale approval
- exact provider-bound target and short-lived qualification
- retail rate and margin approval plus customer entitlement
- drift quarantine before customer traffic