### PR TITLE
Fix optional max_tokens in hosted Model APIs

### DIFF
--- a/internal/modelapirouting/runtime_test.go
+++ b/internal/modelapirouting/runtime_test.go
@@ -144,6 +144,32 @@ func strictProxyRequest(stream bool) ProxyRequest {
 	}
 }
 
+func TestNormalizeStrictRequestAppliesPortableOutputBoundWhenOmitted(t *testing.T) {
+	request := strictProxyRequest(false)
+	delete(request.Payload, "max_tokens")
+
+	normalized, err := normalizeStrictRequest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if normalized.MaxOutputTokens == nil || *normalized.MaxOutputTokens != strictDefaultMaxOutputTokens {
+		t.Fatalf("max output tokens=%v, want %d", normalized.MaxOutputTokens, strictDefaultMaxOutputTokens)
+	}
+}
+
+func TestNormalizeStrictRequestPreservesExplicitOutputBound(t *testing.T) {
+	request := strictProxyRequest(false)
+	request.Payload["max_tokens"] = float64(37)
+
+	normalized, err := normalizeStrictRequest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if normalized.MaxOutputTokens == nil || *normalized.MaxOutputTokens != 37 {
+		t.Fatalf("max output tokens=%v, want 37", normalized.MaxOutputTokens)
+	}
+}
+
 func TestStrictRuntimeResolvesCredentialPerRequestAndRewritesBufferedResponse(t *testing.T) {
 	calls := 0
 	transport := routingRoundTripperFunc(func(request *http.Request) (*http.Response, error) {

--- a/internal/modelapirouting/strict_runtime.go
+++ b/internal/modelapirouting/strict_runtime.go
@@ -22,6 +22,12 @@ type strictChatPayload struct {
 	Stream      bool                `json:"stream,omitempty"`
 }
 
+// strictDefaultMaxOutputTokens keeps an omitted OpenAI-compatible max_tokens
+// request bounded before reservation and supplier transmission. It matches the
+// smallest currently qualified hosted route limit (the provisional Qwen
+// serverless recipe), so the public default remains portable across targets.
+const strictDefaultMaxOutputTokens = 512
+
 type strictChatMessage struct {
 	Role    string `json:"role"`
 	Content string `json:"content"`
@@ -43,6 +49,10 @@ func normalizeStrictRequest(request ProxyRequest) (supplieradapter.Request, erro
 	}
 	if request.Operation != "chat" || payload.Model != request.ProductID {
 		return supplieradapter.Request{}, errors.New("request operation or public model does not match the strict route")
+	}
+	if payload.MaxTokens == nil {
+		maximum := strictDefaultMaxOutputTokens
+		payload.MaxTokens = &maximum
 	}
 	normalized := supplieradapter.Request{
 		ID: request.RequestID, Operation: supplieradapter.OperationChatCompletions, ModelID: request.ProductID,


### PR DESCRIPTION
## Summary
- apply a bounded 512-token default when OpenAI-compatible `max_tokens` is omitted
- preserve explicit customer limits
- cover the exact copy-paste request regression

## Verification
- `go test ./...`

This keeps reservation and supplier transmission bounded while making the documented minimal Chat Completions request work.