### PR TITLE
fix: version DeepSeek production renewals safely

### DIFF
--- a/tools/model-api-production-release/main.go
+++ b/tools/model-api-production-release/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -8,22 +9,30 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/infercrane/infercrane/internal/modelapiproduct"
 	"github.com/infercrane/infercrane/internal/modelapisupply"
 	"github.com/infercrane/infercrane/internal/store"
+	"github.com/infercrane/infercrane/internal/supplieradapter"
 )
 
 const (
-	productID       = "deepseek-v4-flash"
+	productID       = supplieradapter.DeepSeekV4FlashModelID
 	offerID         = "deepseek-direct-v4-flash"
-	offerVersion    = int64(1)
-	supplyPlanID    = "supply-deepseek-v4-flash-production-r1"
-	retailRateID    = "deepseek-v4-flash-rate-1"
-	retailVersion   = 1
 	productionTerms = "https://api-docs.deepseek.com/quick_start/pricing"
 )
+
+type releaseConfig struct {
+	QualificationPath   string
+	CredentialReference string
+	OperatorWorkspaceID string
+	ServingPlanID       string
+	CustomerWorkspaceID string
+	OutputDirectory     string
+	ReleaseVersion      int
+}
 
 type qualificationManifest struct {
 	OfferID      string                               `json:"offer_id"`
@@ -33,28 +42,45 @@ type qualificationManifest struct {
 
 func main() {
 	var qualificationPath, credentialReference, operatorWorkspaceID, servingPlanID, customerWorkspaceID, outputDirectory string
+	var releaseVersion int
 	flag.StringVar(&qualificationPath, "qualification", "", "secret-free qualification manifest from model-api-qualifier")
 	flag.StringVar(&credentialReference, "credential-reference", "", "tenant-scoped secret reference id")
 	flag.StringVar(&operatorWorkspaceID, "operator-workspace", "", "platform operator workspace id")
 	flag.StringVar(&servingPlanID, "serving-plan", "", "existing operator-owned serving plan id")
 	flag.StringVar(&customerWorkspaceID, "customer-workspace", "", "customer workspace receiving the production canary entitlement")
 	flag.StringVar(&outputDirectory, "output-directory", "", "directory for generated production manifests")
+	flag.IntVar(&releaseVersion, "release-version", 0, "positive immutable offer and retail-rate revision")
 	flag.Parse()
-	if qualificationPath == "" || credentialReference == "" || operatorWorkspaceID == "" || servingPlanID == "" || customerWorkspaceID == "" || outputDirectory == "" {
-		fatal(errors.New("--qualification, --credential-reference, --operator-workspace, --serving-plan, --customer-workspace, and --output-directory are required"))
+	if qualificationPath == "" || credentialReference == "" || operatorWorkspaceID == "" || servingPlanID == "" || customerWorkspaceID == "" || outputDirectory == "" || releaseVersion <= 0 {
+		fatal(errors.New("--qualification, --credential-reference, --operator-workspace, --serving-plan, --customer-workspace, --output-directory, and a positive --release-version are required"))
 	}
-
-	qualification := readQualification(qualificationPath)
-	now := time.Now().UTC().Truncate(time.Microsecond)
-	if err := validateQualification(now, qualification); err != nil {
+	if err := runRelease(releaseConfig{
+		QualificationPath: qualificationPath, CredentialReference: credentialReference,
+		OperatorWorkspaceID: operatorWorkspaceID, ServingPlanID: servingPlanID,
+		CustomerWorkspaceID: customerWorkspaceID, OutputDirectory: outputDirectory,
+		ReleaseVersion: releaseVersion,
+	}, time.Now().UTC().Truncate(time.Microsecond)); err != nil {
 		fatal(err)
 	}
-	if err := os.MkdirAll(outputDirectory, 0o700); err != nil {
-		fatal(fmt.Errorf("create output directory: %w", err))
+}
+
+func runRelease(cfg releaseConfig, now time.Time) error {
+	qualification, err := readQualification(cfg.QualificationPath)
+	if err != nil {
+		return err
 	}
-	if err := os.Chmod(outputDirectory, 0o700); err != nil {
-		fatal(fmt.Errorf("protect output directory: %w", err))
+	if err := validateQualification(now, int64(cfg.ReleaseVersion), qualification); err != nil {
+		return err
 	}
+	if err := os.MkdirAll(cfg.OutputDirectory, 0o700); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	if err := os.Chmod(cfg.OutputDirectory, 0o700); err != nil {
+		return fmt.Errorf("protect output directory: %w", err)
+	}
+
+	releaseSuffix := fmt.Sprintf("r%d", cfg.ReleaseVersion)
+	retailRateID := fmt.Sprintf("%s-rate-%d", productID, cfg.ReleaseVersion)
 
 	contextWindow := int64(1_000_000)
 	evidenceUntil := qualification.Evidence.ValidUntil.UTC()
@@ -83,7 +109,7 @@ func main() {
 	rate, err := modelapiproduct.NewRetailRate(modelapiproduct.RetailRateDraft{
 		ID:                       retailRateID,
 		ProductID:                productID,
-		Version:                  retailVersion,
+		Version:                  cfg.ReleaseVersion,
 		InputMicrousdPerMillion:  550_000,
 		OutputMicrousdPerMillion: 1_650_000,
 		PublishedAt:              now.Add(-2 * time.Minute),
@@ -92,22 +118,22 @@ func main() {
 		PublicProvenance:         modelapiproduct.CustomerRetailRateProvenance,
 	})
 	if err != nil {
-		fatal(err)
+		return err
 	}
 
 	costInput, costOutput := int64(440_000), int64(1_320_000)
 	offer := modelapisupply.Offer{
 		ID:                  offerID,
-		Version:             offerVersion,
-		OperatorTenantID:    operatorWorkspaceID,
+		Version:             int64(cfg.ReleaseVersion),
+		OperatorTenantID:    cfg.OperatorWorkspaceID,
 		ProductID:           productID,
-		Supplier:            "deepseek",
-		Adapter:             "openai",
-		SupplierModelID:     productID,
+		Supplier:            supplieradapter.DeepSeekSupplier,
+		Adapter:             supplieradapter.DeepSeekAdapterName,
+		SupplierModelID:     supplieradapter.DeepSeekV4FlashModelID,
 		Protocol:            "openai",
 		TupleKey:            qualification.Evidence.TupleKey,
 		Region:              "global",
-		CredentialReference: credentialReference,
+		CredentialReference: cfg.CredentialReference,
 		State:               modelapisupply.OfferActive,
 		Capabilities:        []string{"chat-completions", "streaming"},
 		Access:              "ready",
@@ -129,12 +155,12 @@ func main() {
 		},
 	}
 	if err := offer.Validate(); err != nil {
-		fatal(err)
+		return err
 	}
 
 	plan := store.SupplyPlanDraft{
-		ID:               supplyPlanID,
-		OperatorTenantID: operatorWorkspaceID,
+		ID:               "supply-deepseek-v4-flash-production-" + releaseSuffix,
+		OperatorTenantID: cfg.OperatorWorkspaceID,
 		ProductID:        productID,
 		Request: modelapisupply.Request{
 			ModelID:                productID,
@@ -151,48 +177,58 @@ func main() {
 			At:                     now,
 		},
 		Candidates: []store.SupplyCandidateReference{{
-			CandidateID:       "candidate-deepseek-direct-v4-flash-production-r1",
+			CandidateID:       "candidate-deepseek-direct-v4-flash-production-" + releaseSuffix,
 			OfferID:           offerID,
-			OfferVersion:      offerVersion,
+			OfferVersion:      int64(cfg.ReleaseVersion),
 			QualificationID:   qualification.Evidence.ID,
-			RetailRateVersion: retailVersion,
+			RetailRateVersion: cfg.ReleaseVersion,
 		}},
 	}
 
 	publication := modelapiproduct.OperatorPublication{
 		SchemaVersion:       modelapiproduct.OperatorProjectionSchemaVersion,
 		ProductID:           productID,
-		OperatorWorkspaceID: operatorWorkspaceID,
-		ServingPlanID:       servingPlanID,
-		SupplyPlanID:        supplyPlanID,
+		OperatorWorkspaceID: cfg.OperatorWorkspaceID,
+		ServingPlanID:       cfg.ServingPlanID,
+		SupplyPlanID:        plan.ID,
 		Qualification: modelapiproduct.RouteQualification{
 			State:         modelapiproduct.QualificationQualified,
 			EvidenceID:    qualification.Evidence.ID,
 			EvidenceUntil: &evidenceUntil,
 		},
 		RetailRate: &rate,
+		UpdatedAt:  now,
 	}
 
 	availableProduct := product
 	availableProduct.Availability = modelapiproduct.AvailabilityAvailable
+	if err := availableProduct.Validate(); err != nil {
+		return err
+	}
+	if err := publication.ValidateAt(availableProduct, now); err != nil {
+		return err
+	}
 	createdAt := now
 	validFrom := now.Add(-time.Minute)
 	validUntil := evidenceUntil
 	entitlement := modelapiproduct.ProductEntitlement{
 		SchemaVersion:       modelapiproduct.EntitlementSchemaVersion,
-		ID:                  "entitlement-" + customerWorkspaceID + "-" + productID,
-		CustomerWorkspaceID: customerWorkspaceID,
+		ID:                  "entitlement-" + cfg.CustomerWorkspaceID + "-" + productID,
+		CustomerWorkspaceID: cfg.CustomerWorkspaceID,
 		ProductID:           productID,
-		OperatorWorkspaceID: operatorWorkspaceID,
-		ServingPlanID:       servingPlanID,
+		OperatorWorkspaceID: cfg.OperatorWorkspaceID,
+		ServingPlanID:       cfg.ServingPlanID,
 		RetailRateID:        retailRateID,
-		RetailRateVersion:   retailVersion,
+		RetailRateVersion:   cfg.ReleaseVersion,
 		State:               modelapiproduct.EntitlementActive,
 		Limits:              modelapiproduct.CustomerLimits{MaxRequestMicrousd: int64Pointer(2_000_000)},
 		ValidFrom:           validFrom,
 		ValidUntil:          &validUntil,
 		CreatedAt:           createdAt,
 		UpdatedAt:           createdAt,
+	}
+	if err := entitlement.Validate(); err != nil {
+		return err
 	}
 
 	manifests := []struct {
@@ -209,27 +245,28 @@ func main() {
 		{"08-canary-entitlement.json", entitlement},
 	}
 	for _, manifest := range manifests {
-		if err := writeManifest(filepath.Join(outputDirectory, manifest.name), manifest.value); err != nil {
-			fatal(err)
+		if err := writeManifest(filepath.Join(cfg.OutputDirectory, manifest.name), manifest.value); err != nil {
+			return err
 		}
 	}
-	fmt.Printf("generated %d protected manifests in %s\n", len(manifests), outputDirectory)
+	fmt.Printf("generated %d protected manifests in %s\n", len(manifests), cfg.OutputDirectory)
+	return nil
 }
 
-func readQualification(path string) qualificationManifest {
+func readQualification(path string) (qualificationManifest, error) {
 	body, err := os.ReadFile(path)
 	if err != nil {
-		fatal(fmt.Errorf("read qualification: %w", err))
+		return qualificationManifest{}, fmt.Errorf("read qualification: %w", err)
 	}
 	var manifest qualificationManifest
 	if err := json.Unmarshal(body, &manifest); err != nil {
-		fatal(fmt.Errorf("decode qualification: %w", err))
+		return qualificationManifest{}, fmt.Errorf("decode qualification: %w", err)
 	}
-	return manifest
+	return manifest, nil
 }
 
-func validateQualification(now time.Time, manifest qualificationManifest) error {
-	if manifest.OfferID != offerID || manifest.OfferVersion != offerVersion {
+func validateQualification(now time.Time, releaseVersion int64, manifest qualificationManifest) error {
+	if manifest.OfferID != offerID || manifest.OfferVersion != releaseVersion {
 		return errors.New("qualification does not match the immutable production offer revision")
 	}
 	if err := manifest.Evidence.Validate(); err != nil {
@@ -240,6 +277,15 @@ func validateQualification(now time.Time, manifest qualificationManifest) error 
 	}
 	if manifest.Evidence.TupleKey != "deepseek|deepseek-v4-flash|openai|global" {
 		return errors.New("qualification tuple does not match the production DeepSeek route")
+	}
+	expectedOrigin := fmt.Sprintf("%x", sha256.Sum256([]byte(supplieradapter.DeepSeekBaseURL)))
+	for _, pin := range []string{
+		"revision=" + supplieradapter.DeepSeekV4FlashRevision,
+		"target_origin_sha256=" + expectedOrigin,
+	} {
+		if !slices.Contains(splitScope(manifest.Evidence.Scope), pin) {
+			return fmt.Errorf("qualification scope is missing exact %s pin", pin)
+		}
 	}
 	for _, capability := range []string{"chat-completions", "streaming"} {
 		if !slices.Contains(manifest.Evidence.Capabilities, capability) {
@@ -258,10 +304,22 @@ func writeManifest(path string, value any) error {
 		return fmt.Errorf("encode %s: %w", path, err)
 	}
 	body = append(body, '\n')
-	if err := os.WriteFile(path, body, 0o600); err != nil {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}
+	if _, err = file.Write(body); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	if err = file.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", path, err)
+	}
 	return os.Chmod(path, 0o600)
+}
+
+func splitScope(scope string) []string {
+	return slices.DeleteFunc(strings.Split(scope, ";"), func(value string) bool { return value == "" })
 }
 
 func int64Pointer(value int64) *int64 { return &value }

--- a/tools/model-api-production-release/main_test.go
+++ b/tools/model-api-production-release/main_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/infercrane/infercrane/internal/modelapiproduct"
+	"github.com/infercrane/infercrane/internal/modelapisupply"
+	"github.com/infercrane/infercrane/internal/store"
+	"github.com/infercrane/infercrane/internal/supplieradapter"
+)
+
+func TestRunReleaseBuildsImmutableRevisionTwo(t *testing.T) {
+	now := time.Date(2026, 9, 3, 16, 30, 0, 0, time.UTC)
+	qualificationPath := writeTestQualification(t, now, 2)
+	outputDirectory := filepath.Join(t.TempDir(), "release")
+	cfg := releaseConfig{
+		QualificationPath:   qualificationPath,
+		CredentialReference: "secret-reference",
+		OperatorWorkspaceID: "operator-workspace",
+		ServingPlanID:       "serving-plan",
+		CustomerWorkspaceID: "customer-workspace",
+		OutputDirectory:     outputDirectory,
+		ReleaseVersion:      2,
+	}
+	if err := runRelease(cfg, now); err != nil {
+		t.Fatal(err)
+	}
+
+	var rate modelapiproduct.RetailRate
+	readTestManifest(t, filepath.Join(outputDirectory, "02-retail-rate.json"), &rate)
+	if rate.ID != "deepseek-v4-flash-rate-2" || rate.Version != 2 {
+		t.Fatalf("unexpected rate identity: %s v%d", rate.ID, rate.Version)
+	}
+
+	var offer modelapisupply.Offer
+	readTestManifest(t, filepath.Join(outputDirectory, "03-supplier-offer.json"), &offer)
+	if offer.ID != offerID || offer.Version != 2 || offer.Adapter != supplieradapter.DeepSeekAdapterName {
+		t.Fatalf("unexpected offer: %#v", offer)
+	}
+
+	var plan store.SupplyPlanDraft
+	readTestManifest(t, filepath.Join(outputDirectory, "05-supply-plan.json"), &plan)
+	if plan.ID != "supply-deepseek-v4-flash-production-r2" || len(plan.Candidates) != 1 || plan.Candidates[0].CandidateID != "candidate-deepseek-direct-v4-flash-production-r2" || plan.Candidates[0].OfferVersion != 2 || plan.Candidates[0].RetailRateVersion != 2 {
+		t.Fatalf("unexpected supply plan: %#v", plan)
+	}
+
+	var publication modelapiproduct.OperatorPublication
+	readTestManifest(t, filepath.Join(outputDirectory, "06-publication.json"), &publication)
+	if publication.SupplyPlanID != plan.ID || publication.RetailRate == nil || publication.RetailRate.Version != 2 {
+		t.Fatalf("unexpected publication: %#v", publication)
+	}
+
+	var entitlement modelapiproduct.ProductEntitlement
+	readTestManifest(t, filepath.Join(outputDirectory, "08-canary-entitlement.json"), &entitlement)
+	if entitlement.ID != "entitlement-customer-workspace-deepseek-v4-flash" || entitlement.RetailRateID != rate.ID || entitlement.RetailRateVersion != 2 {
+		t.Fatalf("unexpected entitlement: %#v", entitlement)
+	}
+
+	entries, err := os.ReadDir(outputDirectory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 8 {
+		t.Fatalf("expected 8 manifests, got %d", len(entries))
+	}
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("%s mode = %o", entry.Name(), info.Mode().Perm())
+		}
+	}
+	if err := runRelease(cfg, now); err == nil || !strings.Contains(err.Error(), "file exists") {
+		t.Fatalf("expected exclusive-write failure, got %v", err)
+	}
+}
+
+func TestValidateQualificationRejectsWrongRevisionOrExpiredEvidence(t *testing.T) {
+	now := time.Date(2026, 9, 3, 16, 30, 0, 0, time.UTC)
+	manifest := testQualification(now, 2)
+	if err := validateQualification(now, 2, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	wrongVersion := manifest
+	wrongVersion.OfferVersion = 1
+	if err := validateQualification(now, 2, wrongVersion); err == nil {
+		t.Fatal("expected immutable offer version mismatch")
+	}
+
+	wrongRevision := manifest
+	wrongRevision.Evidence.Scope = strings.ReplaceAll(wrongRevision.Evidence.Scope, supplieradapter.DeepSeekV4FlashRevision, "different-revision")
+	if err := validateQualification(now, 2, wrongRevision); err == nil {
+		t.Fatal("expected exact revision mismatch")
+	}
+
+	expired := manifest
+	expired.Evidence.ValidUntil = now.Add(30 * time.Minute)
+	if err := validateQualification(now, 2, expired); err == nil {
+		t.Fatal("expected minimum-currentness failure")
+	}
+}
+
+func writeTestQualification(t *testing.T, now time.Time, version int64) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "qualification.json")
+	body, err := json.Marshal(testQualification(now, version))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func testQualification(now time.Time, version int64) qualificationManifest {
+	origin := sha256.Sum256([]byte(supplieradapter.DeepSeekBaseURL))
+	ttft, output := 700.0, 40.0
+	return qualificationManifest{
+		OfferID: offerID, OfferVersion: version,
+		Evidence: modelapisupply.QualificationEvidence{
+			ID: "deepseek-qualification-r2", State: modelapisupply.QualificationQualified,
+			TupleKey: "deepseek|deepseek-v4-flash|openai|global", Protocol: "openai", Region: "global",
+			Capabilities: []string{"chat-completions", "streaming"},
+			Scope:        "deepseek-mvp:inventory+buffered-chat-completions+streaming-chat-completions;revision=" + supplieradapter.DeepSeekV4FlashRevision + ";target_origin_sha256=" + stringHex(origin[:]),
+			EvidenceRef:  "github://infercrane/qualification-evidence/test.json", EvidenceDigest: "sha256:test",
+			ObservedAt: now.Add(-time.Minute), ValidUntil: now.Add(24 * time.Hour), SampleCount: 6,
+			TTFTP95MS: &ttft, OutputTokensP5: &output,
+		},
+	}
+}
+
+func stringHex(value []byte) string {
+	const alphabet = "0123456789abcdef"
+	out := make([]byte, len(value)*2)
+	for i, current := range value {
+		out[2*i], out[2*i+1] = alphabet[current>>4], alphabet[current&0x0f]
+	}
+	return string(out)
+}
+
+func readTestManifest(t *testing.T, path string, destination any) {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = json.Unmarshal(body, destination); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

- make DeepSeek production releases accept an explicit immutable release version
- derive new offer, retail-rate, supply-plan, and candidate revision identities without overwriting v1
- bind release validation to the exact DeepSeek model revision and qualified target-origin digest
- use the strict DeepSeek adapter and fail if protected output artifacts already exist
- validate publication/product/entitlement contracts before writing manifests
- add focused regression coverage for r2 identity, expiry, revision pins, file modes, and exclusive writes

## Validation

- `go test ./...`
- live supplier qualification: 3 buffered + 3 streaming samples, `max_tokens=512`, all passed
- qualified revision: `DeepSeek-V4-Flash-0731`
- evidence current until `2026-09-04T16:14:25.742732Z`
- durable secret-free evidence: private `infercrane/qualification-evidence`, path `model-api/deepseek-v4-flash/r2/20260903T161418Z-raw.json`

## Production outcome

The r2 rate, offer, qualification, supply plan, publication, product projection, and existing customer entitlement were published through the control API. No application deployment was required because production already contains and configures the strict DeepSeek adapter.

Existing customer-key checks passed after publication:

- buffered HTTP 200 with exact visible response and terminal usage
- streaming HTTP 200 with exact visible response, one `[DONE]`, and terminal usage
- catalog callable and authorized at retail rate v2
- 2/2 requests reconciled; 20 input tokens, 8 output tokens, 26 microusd settled; zero pending/in-flight

This evidence remains intentionally time-bounded; expiry checks were not weakened.