### PR TITLE
feat: schedule Model API evidence renewal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN go mod download
 COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod version="${INFERCRANE_VERSION#v}" \
     && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.version=${version}" -o /out/infercrane ./cmd/infercrane \
+	&& CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/infercrane-model-api-qualifier ./tools/model-api-qualifier \
+	&& CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/infercrane-model-api-production-release ./tools/model-api-production-release \
+	&& CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/infercrane-model-api-mvp-release ./tools/model-api-mvp-release \
+	&& CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/infercrane-model-api-renewer ./tools/model-api-renewer \
     && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/runpod-fault-proxy ./internal/testtools/runpod-fault-proxy \
     && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/fake-vllm ./internal/testtools/fake-vllm \
     && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/fake-router ./internal/testtools/fake-router
@@ -64,6 +68,10 @@ RUN case "$TARGETARCH" in \
 	&& rm -rf /var/lib/apt/lists/* \
     && useradd --create-home --uid 10001 app
 COPY --from=builder /out/infercrane /usr/local/bin/infercrane
+COPY --from=builder /out/infercrane-model-api-qualifier /usr/local/bin/infercrane-model-api-qualifier
+COPY --from=builder /out/infercrane-model-api-production-release /usr/local/bin/infercrane-model-api-production-release
+COPY --from=builder /out/infercrane-model-api-mvp-release /usr/local/bin/infercrane-model-api-mvp-release
+COPY --from=builder /out/infercrane-model-api-renewer /usr/local/bin/infercrane-model-api-renewer
 COPY scripts/entrypoint.sh /usr/local/bin/infercrane-entrypoint
 COPY LICENSE NOTICE THIRD_PARTY_NOTICES.md packaging/container/THIRD_PARTY_COMPONENTS.md /usr/share/licenses/infercrane/
 COPY packaging/container/licenses /usr/share/licenses/infercrane/runtime-components

--- a/tools/model-api-mvp-release/README.md
+++ b/tools/model-api-mvp-release/README.md
@@ -23,6 +23,7 @@ go run ./tools/model-api-mvp-release \
   --serving-plan SERVING_PLAN_ID \
   --customer-workspace CANARY_WORKSPACE_ID \
   --commercial-terms-ref contract://zai-mvp-reviewed-2026-09 \
+  --release-version 2 \
   --output-directory ./artifacts/zai-glm-5.3-release
 ```
 

--- a/tools/model-api-mvp-release/main.go
+++ b/tools/model-api-mvp-release/main.go
@@ -52,6 +52,7 @@ type config struct {
 	CustomerWorkspaceID, OutputDirectory             string
 	Endpoint, CommercialTermsRef                     string
 	CostInput, CostOutput, RetailInput, RetailOutput int64
+	ReleaseVersion                                   int
 }
 
 func main() {
@@ -69,6 +70,7 @@ func main() {
 	flag.Int64Var(&cfg.CostOutput, "cost-output-microusd-per-million", 0, "RunPod output COGS per million tokens")
 	flag.Int64Var(&cfg.RetailInput, "retail-input-microusd-per-million", 0, "RunPod launch retail input rate")
 	flag.Int64Var(&cfg.RetailOutput, "retail-output-microusd-per-million", 0, "RunPod launch retail output rate")
+	flag.IntVar(&cfg.ReleaseVersion, "release-version", 0, "positive immutable offer and retail-rate revision")
 	flag.Parse()
 	if err := run(cfg, time.Now().UTC().Truncate(time.Microsecond)); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -81,8 +83,8 @@ func run(cfg config, now time.Time) error {
 	if err != nil {
 		return err
 	}
-	if strings.TrimSpace(cfg.QualificationPath) == "" || strings.TrimSpace(cfg.CredentialReference) == "" || strings.TrimSpace(cfg.OperatorWorkspaceID) == "" || strings.TrimSpace(cfg.ServingPlanID) == "" || strings.TrimSpace(cfg.CustomerWorkspaceID) == "" || strings.TrimSpace(cfg.OutputDirectory) == "" || strings.TrimSpace(cfg.CommercialTermsRef) == "" {
-		return errors.New("qualification, credential reference, operator workspace, serving plan, customer workspace, commercial terms reference, and output directory are required")
+	if strings.TrimSpace(cfg.QualificationPath) == "" || strings.TrimSpace(cfg.CredentialReference) == "" || strings.TrimSpace(cfg.OperatorWorkspaceID) == "" || strings.TrimSpace(cfg.ServingPlanID) == "" || strings.TrimSpace(cfg.CustomerWorkspaceID) == "" || strings.TrimSpace(cfg.OutputDirectory) == "" || strings.TrimSpace(cfg.CommercialTermsRef) == "" || cfg.ReleaseVersion <= 0 {
+		return errors.New("qualification, credential reference, operator workspace, serving plan, customer workspace, commercial terms reference, output directory, and a positive release version are required")
 	}
 	endpoint := p.DefaultEndpoint
 	if cfg.Endpoint != "" {
@@ -106,7 +108,7 @@ func run(cfg config, now time.Time) error {
 	if err != nil {
 		return err
 	}
-	if err = validateQualification(now, p, endpoint, qualification); err != nil {
+	if err = validateQualification(now, int64(cfg.ReleaseVersion), p, endpoint, qualification); err != nil {
 		return err
 	}
 	if err = os.MkdirAll(cfg.OutputDirectory, 0o700); err != nil {
@@ -131,9 +133,10 @@ func run(cfg config, now time.Time) error {
 	if err = product.Validate(); err != nil {
 		return err
 	}
-	rateID := p.ProductID + "-launch-rate-1"
+	releaseSuffix := fmt.Sprintf("r%d", cfg.ReleaseVersion)
+	rateID := fmt.Sprintf("%s-launch-rate-%d", p.ProductID, cfg.ReleaseVersion)
 	rate, err := modelapiproduct.NewRetailRate(modelapiproduct.RetailRateDraft{
-		ID: rateID, ProductID: p.ProductID, Version: 1,
+		ID: rateID, ProductID: p.ProductID, Version: cfg.ReleaseVersion,
 		InputMicrousdPerMillion: cfg.RetailInput, OutputMicrousdPerMillion: cfg.RetailOutput,
 		PublishedAt: now.Add(-2 * time.Minute), ValidFrom: now.Add(-time.Minute), ValidUntil: validUntil,
 		PublicProvenance: modelapiproduct.CustomerRetailRateProvenance,
@@ -147,7 +150,7 @@ func run(cfg config, now time.Time) error {
 		cached = int64Pointer(p.CostCached)
 	}
 	offer := modelapisupply.Offer{
-		ID: p.OfferID, Version: 1, OperatorTenantID: cfg.OperatorWorkspaceID, ProductID: p.ProductID,
+		ID: p.OfferID, Version: int64(cfg.ReleaseVersion), OperatorTenantID: cfg.OperatorWorkspaceID, ProductID: p.ProductID,
 		Supplier: p.Supplier, Adapter: p.Adapter, SupplierModelID: p.SupplierModelID, Protocol: "openai",
 		TupleKey: p.ExpectedTuple, Region: p.Region, CredentialReference: cfg.CredentialReference,
 		State: modelapisupply.OfferActive, Capabilities: []string{"chat-completions", "streaming"},
@@ -164,23 +167,23 @@ func run(cfg config, now time.Time) error {
 		return err
 	}
 	binding, err := modelapitarget.NewBinding(modelapitarget.Draft{
-		ID: "target-" + p.ProductID + "-r1", OperatorTenantID: cfg.OperatorWorkspaceID, ProductID: p.ProductID,
-		Kind: p.Kind, OfferID: p.OfferID, OfferVersion: 1, Adapter: p.Adapter, SupplierModelID: p.SupplierModelID,
+		ID: "target-" + p.ProductID + "-" + releaseSuffix, OperatorTenantID: cfg.OperatorWorkspaceID, ProductID: p.ProductID,
+		Kind: p.Kind, OfferID: p.OfferID, OfferVersion: int64(cfg.ReleaseVersion), Adapter: p.Adapter, SupplierModelID: p.SupplierModelID,
 		EndpointReference: p.EndpointReference, EndpointConfigDigest: digest, Region: p.Region,
 		CreatedAt: now.Add(-2 * time.Minute), ValidFrom: now.Add(-time.Minute), ValidUntil: validUntil,
 	})
 	if err != nil {
 		return err
 	}
-	planID := "supply-" + p.ProductID + "-launch-r1"
+	planID := "supply-" + p.ProductID + "-launch-" + releaseSuffix
 	plan := store.SupplyPlanDraft{
 		ID: planID, OperatorTenantID: cfg.OperatorWorkspaceID, ProductID: p.ProductID,
 		Request: modelapisupply.Request{ModelID: p.ProductID, Protocol: "openai", Capabilities: []string{"chat-completions", "streaming"}, Region: p.Region,
 			InputTokens: 1_000, OutputTokens: 1_000, MinimumGrossMarginBPS: 0, PricingPolicy: modelapisupply.PricingPolicyLaunchParity,
 			MaximumObservationAge: 24 * time.Hour, MaximumEvidenceAge: 24 * time.Hour,
 			MinimumEvidenceSamples: qualification.Evidence.SampleCount, MaximumFallbacks: 0, At: now},
-		Candidates: []store.SupplyCandidateReference{{CandidateID: "candidate-" + p.ProductID + "-launch-r1", OfferID: p.OfferID, OfferVersion: 1,
-			QualificationID: qualification.Evidence.ID, RetailRateVersion: 1, TrafficWeightBPS: 10_000}},
+		Candidates: []store.SupplyCandidateReference{{CandidateID: "candidate-" + p.ProductID + "-launch-" + releaseSuffix, OfferID: p.OfferID, OfferVersion: int64(cfg.ReleaseVersion),
+			QualificationID: qualification.Evidence.ID, RetailRateVersion: cfg.ReleaseVersion, TrafficWeightBPS: 10_000}},
 	}
 	publication := modelapiproduct.OperatorPublication{
 		SchemaVersion: modelapiproduct.OperatorProjectionSchemaVersion, ProductID: p.ProductID,
@@ -193,7 +196,7 @@ func run(cfg config, now time.Time) error {
 	entitlement := modelapiproduct.ProductEntitlement{
 		SchemaVersion: modelapiproduct.EntitlementSchemaVersion, ID: "entitlement-" + cfg.CustomerWorkspaceID + "-" + p.ProductID,
 		CustomerWorkspaceID: cfg.CustomerWorkspaceID, ProductID: p.ProductID, OperatorWorkspaceID: cfg.OperatorWorkspaceID,
-		ServingPlanID: cfg.ServingPlanID, RetailRateID: rateID, RetailRateVersion: 1, State: modelapiproduct.EntitlementActive,
+		ServingPlanID: cfg.ServingPlanID, RetailRateID: rateID, RetailRateVersion: cfg.ReleaseVersion, State: modelapiproduct.EntitlementActive,
 		Limits:    modelapiproduct.CustomerLimits{MaxRequestMicrousd: int64Pointer(2_000_000)},
 		ValidFrom: now.Add(-time.Minute), ValidUntil: &validUntil, CreatedAt: now, UpdatedAt: now,
 	}
@@ -260,9 +263,9 @@ func readQualification(path string) (qualificationManifest, error) {
 	return manifest, nil
 }
 
-func validateQualification(now time.Time, p profile, endpoint string, manifest qualificationManifest) error {
-	if manifest.OfferID != p.OfferID || manifest.OfferVersion != 1 {
-		return errors.New("qualification does not match the immutable launch offer revision")
+func validateQualification(now time.Time, releaseVersion int64, p profile, endpoint string, manifest qualificationManifest) error {
+	if manifest.OfferID != p.OfferID || manifest.OfferVersion != releaseVersion {
+		return errors.New("qualification does not match the immutable release offer revision")
 	}
 	if err := manifest.Evidence.Validate(); err != nil {
 		return err
@@ -278,10 +281,11 @@ func validateQualification(now time.Time, p profile, endpoint string, manifest q
 	if !manifest.Evidence.ValidUntil.After(now.Add(time.Hour)) {
 		return errors.New("qualification must remain current for at least one hour")
 	}
-	if !strings.Contains(manifest.Evidence.Scope, "revision="+p.ExpectedRevision+";") {
+	scope := splitScope(manifest.Evidence.Scope)
+	if !slices.Contains(scope, "revision="+p.ExpectedRevision) {
 		return errors.New("qualification scope does not pin the expected model revision")
 	}
-	if !strings.Contains(manifest.Evidence.Scope, "target_origin_sha256="+digestString(endpoint)) {
+	if !slices.Contains(scope, "target_origin_sha256="+digestString(endpoint)) {
 		return errors.New("qualification scope does not bind the expected supplier origin")
 	}
 	return nil
@@ -293,10 +297,22 @@ func writeManifest(path string, value any) error {
 		return fmt.Errorf("encode %s: %w", path, err)
 	}
 	body = append(body, '\n')
-	if err = os.WriteFile(path, body, 0o600); err != nil {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}
+	if _, err = file.Write(body); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	if err = file.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", path, err)
+	}
 	return os.Chmod(path, 0o600)
+}
+
+func splitScope(scope string) []string {
+	return slices.DeleteFunc(strings.Split(scope, ";"), func(value string) bool { return value == "" })
 }
 
 func int64Pointer(value int64) *int64 { return &value }

--- a/tools/model-api-mvp-release/main_test.go
+++ b/tools/model-api-mvp-release/main_test.go
@@ -22,7 +22,7 @@ func TestRunGeneratesCompleteGLMLaunchSequence(t *testing.T) {
 	err = run(config{
 		Profile: "glm-5.3", QualificationPath: qualificationPath, CredentialReference: "zai-secret-ref",
 		OperatorWorkspaceID: "operator-workspace", ServingPlanID: "serving-plan", CustomerWorkspaceID: "customer-workspace",
-		CommercialTermsRef: "contract://zai-mvp-2026-09", OutputDirectory: output,
+		CommercialTermsRef: "contract://zai-mvp-2026-09", OutputDirectory: output, ReleaseVersion: 2,
 	}, now)
 	if err != nil {
 		t.Fatal(err)
@@ -35,12 +35,20 @@ func TestRunGeneratesCompleteGLMLaunchSequence(t *testing.T) {
 		t.Fatalf("generated %d manifests, want 9", len(entries))
 	}
 	var rate struct {
-		Input  int64 `json:"input_microusd_per_million"`
-		Output int64 `json:"output_microusd_per_million"`
+		Input   int64 `json:"input_microusd_per_million"`
+		Output  int64 `json:"output_microusd_per_million"`
+		Version int   `json:"version"`
 	}
 	readJSON(t, filepath.Join(output, "02-retail-rate.json"), &rate)
-	if rate.Input != 1_400_000 || rate.Output != 4_400_000 {
+	if rate.Input != 1_400_000 || rate.Output != 4_400_000 || rate.Version != 2 {
 		t.Fatalf("unexpected launch parity rate: %+v", rate)
+	}
+	var offer struct {
+		Version int64 `json:"version"`
+	}
+	readJSON(t, filepath.Join(output, "03-supplier-offer.json"), &offer)
+	if offer.Version != 2 {
+		t.Fatalf("offer version=%d, want 2", offer.Version)
 	}
 	var binding struct {
 		Kind   string `json:"kind"`
@@ -49,6 +57,26 @@ func TestRunGeneratesCompleteGLMLaunchSequence(t *testing.T) {
 	readJSON(t, filepath.Join(output, "05-target-binding.json"), &binding)
 	if binding.Kind != "upstream" || !strings.HasPrefix(binding.Digest, "sha256:") {
 		t.Fatalf("unexpected target binding: %+v", binding)
+	}
+}
+
+func TestRunNeverOverwritesReleaseArtifacts(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	p, err := launchProfile("glm-5.2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(t.TempDir(), "release")
+	cfg := config{
+		Profile: p.Name, QualificationPath: writeTestQualification(t, now, p, p.DefaultEndpoint), CredentialReference: "zai-secret-ref",
+		OperatorWorkspaceID: "operator-workspace", ServingPlanID: "serving-plan", CustomerWorkspaceID: "customer-workspace",
+		CommercialTermsRef: "contract://zai-mvp-2026-09", OutputDirectory: output, ReleaseVersion: 2,
+	}
+	if err = run(cfg, now); err != nil {
+		t.Fatal(err)
+	}
+	if err = run(cfg, now); err == nil || !strings.Contains(err.Error(), "file exists") {
+		t.Fatalf("second release error=%v, want append-only refusal", err)
 	}
 }
 
@@ -66,7 +94,7 @@ func TestRunPodRequiresMeasuredEconomicsAndExactQualifiedOrigin(t *testing.T) {
 	cfg := config{
 		Profile: p.Name, QualificationPath: qualificationPath, CredentialReference: "runpod-secret-ref",
 		OperatorWorkspaceID: "operator-workspace", ServingPlanID: "serving-plan", CustomerWorkspaceID: "customer-workspace",
-		Endpoint: endpoint, CommercialTermsRef: "contract://runpod-mvp-2026-09", OutputDirectory: filepath.Join(t.TempDir(), "release"),
+		Endpoint: endpoint, CommercialTermsRef: "contract://runpod-mvp-2026-09", OutputDirectory: filepath.Join(t.TempDir(), "release"), ReleaseVersion: 2,
 	}
 	if err = run(cfg, now); err == nil || !strings.Contains(err.Error(), "measured COGS") {
 		t.Fatalf("missing measured economics error=%v", err)
@@ -83,7 +111,7 @@ func writeTestQualification(t *testing.T, now time.Time, p profile, endpoint str
 	t.Helper()
 	ttft, throughput := 100.0, 200.0
 	manifest := qualificationManifest{
-		OfferID: p.OfferID, OfferVersion: 1,
+		OfferID: p.OfferID, OfferVersion: 2,
 		Evidence: modelapisupply.QualificationEvidence{
 			ID: "qualification-" + p.ProductID, State: modelapisupply.QualificationQualified,
 			TupleKey: p.ExpectedTuple, Protocol: "openai", Region: p.Region,

--- a/tools/model-api-renewer/README.md
+++ b/tools/model-api-renewer/README.md
@@ -1,0 +1,80 @@
+# Scheduled Model API evidence renewal
+
+`model-api-renewer` is the smallest production renewal loop for InferCrane's
+directly operated MVP catalog:
+
+- `deepseek-v4-flash` through DeepSeek
+- `glm-5.2`, `glm-5.3`, and `glm-5.3-flash` through Z.ai
+
+It is a one-shot process, not a server. On every invocation it reads the
+current catalog evidence. If more than six hours remain, it exits without any
+supplier request. Inside the renewal window it processes profiles
+sequentially, running three buffered and three streaming samples with a
+512-token cap and the unchanged 24-hour evidence TTL. A failure leaves that
+profile unpublished and the process exits non-zero after attempting the other
+approved profiles.
+
+Supplier and control-plane credentials are read only from the Machine
+environment. They are never command arguments or evidence fields. Raw
+evidence and release manifests are append-only `0600` files beneath
+`INFERCRANE_MODEL_API_RENEWAL_STATE_DIR`; the database stores the immutable
+evidence reference and digest. The Fly Machine must therefore use
+`--rootfs-persist always`. This is acceptable for the MVP but is not a
+replicated evidence archive; move the same append-only artifacts to an
+operator-owned object store before production scale.
+
+## Required Fly secrets
+
+The scheduled Machine belongs to the same app as the control plane and
+inherits its existing Fly-only secrets:
+
+- `INFERCRANE_API_KEY`
+- `DEEPSEEK_API_KEY`
+- `ZAI_API_KEY`
+
+Do not copy these secrets into GitHub Actions or pass them with `--env`.
+
+## Create the scheduled Machine
+
+After the reviewed image is deployed, resolve its immutable image reference
+and the two existing database secret-reference IDs. Then run:
+
+```sh
+fly machine run IMAGE_REF \
+  -a infercrane-control \
+  -r fra \
+  --name infercrane-model-api-renewer \
+  --schedule hourly \
+  --restart no \
+  --rootfs-persist always \
+  --autostart=false \
+  --skip-dns-registration \
+  --vm-size shared-cpu-1x \
+  --vm-memory 512 \
+  --env INFERCRANE_URL=https://api.infercrane.com \
+  --env INFERCRANE_MODEL_API_OPERATOR_WORKSPACE=global \
+  --env INFERCRANE_MODEL_API_SERVING_PLAN=SERVING_PLAN_ID \
+  --env INFERCRANE_MODEL_API_CANARY_WORKSPACE=CANARY_WORKSPACE_ID \
+  --env INFERCRANE_MODEL_API_DEEPSEEK_CREDENTIAL_REFERENCE=DEEPSEEK_SECRET_REFERENCE_ID \
+  --env INFERCRANE_MODEL_API_ZAI_CREDENTIAL_REFERENCE=ZAI_SECRET_REFERENCE_ID \
+  infercrane-model-api-renewer
+```
+
+The image keeps its normal `infercrane-entrypoint`; because the scheduled
+command is `infercrane-model-api-renewer` rather than `infercrane serve`, the
+entrypoint immediately `exec`s the one-shot operator. The command creates no
+service and no minimum-running Machine. Inspect its first scheduled run and
+persisted evidence before relying on it:
+
+```sh
+fly machine list -a infercrane-control
+fly logs -a infercrane-control --machine MACHINE_ID
+fly machine status MACHINE_ID -a infercrane-control
+```
+
+Fly does not allow a scheduled Machine to be started manually. For a
+deliberate pre-demo renewal, create a separately reviewed one-shot Machine
+from the same immutable image and environment with `--restart no`,
+`--rootfs-persist always`, and command `infercrane-model-api-renewer --force`.
+Keep that stopped Machine until its evidence expires, then delete it. Do not
+extend the evidence TTL to avoid renewal.

--- a/tools/model-api-renewer/main.go
+++ b/tools/model-api-renewer/main.go
@@ -1,0 +1,335 @@
+// model-api-renewer is a one-shot, operator-only renewal process for the
+// directly operated MVP catalog. It is designed for a scheduled Fly Machine:
+// it normally exits without supplier traffic and qualifies sequentially only
+// when current evidence is close to expiry.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	defaultRenewBefore = 6 * time.Hour
+	qualificationTTL   = 24 * time.Hour
+	qualificationCap   = 512
+	samplesPerMode     = 3
+)
+
+type profile struct {
+	Name, ProductID, OfferID, TupleKey, Revision string
+	SupplierCredentialEnv                        string
+	CredentialReferenceEnv                       string
+	CommercialTermsRef                           string
+	ReleaseTool                                  string
+	Publication                                  []publicationStep
+}
+
+type publicationStep struct{ ContractType, Filename string }
+
+var renewalProfiles = []profile{
+	{
+		Name: "deepseek-v4-flash", ProductID: "deepseek-v4-flash", OfferID: "deepseek-direct-v4-flash",
+		TupleKey: "deepseek|deepseek-v4-flash|openai|global", Revision: "DeepSeek-V4-Flash-0731",
+		SupplierCredentialEnv:  "DEEPSEEK_API_KEY",
+		CredentialReferenceEnv: "INFERCRANE_MODEL_API_DEEPSEEK_CREDENTIAL_REFERENCE",
+		CommercialTermsRef:     "https://api-docs.deepseek.com/quick_start/pricing",
+		ReleaseTool:            "infercrane-model-api-production-release",
+		Publication: []publicationStep{
+			{"rate", "02-retail-rate.json"}, {"offer", "03-supplier-offer.json"}, {"qualification", "04-qualification.json"},
+			{"plan", "05-supply-plan.json"}, {"product", "07-product-available.json"}, {"publication", "06-publication.json"}, {"entitlement", "08-canary-entitlement.json"},
+		},
+	},
+	{
+		Name: "glm-5.2", ProductID: "glm-5.2", OfferID: "zai-glm-5-2",
+		TupleKey: "zai|glm-5.2|openai|global", Revision: "glm-5.2",
+		SupplierCredentialEnv:  "ZAI_API_KEY",
+		CredentialReferenceEnv: "INFERCRANE_MODEL_API_ZAI_CREDENTIAL_REFERENCE",
+		CommercialTermsRef:     "https://docs.z.ai/guides/llm/glm-5.2",
+		ReleaseTool:            "infercrane-model-api-mvp-release",
+		Publication:            zaiPublicationSteps(),
+	},
+	{
+		Name: "glm-5.3", ProductID: "glm-5.3", OfferID: "zai-glm-5-3",
+		TupleKey: "zai|glm-5.3|openai|global", Revision: "glm-5.3",
+		SupplierCredentialEnv:  "ZAI_API_KEY",
+		CredentialReferenceEnv: "INFERCRANE_MODEL_API_ZAI_CREDENTIAL_REFERENCE",
+		CommercialTermsRef:     "https://docs.z.ai/guides/llm/glm-5.3",
+		ReleaseTool:            "infercrane-model-api-mvp-release",
+		Publication:            zaiPublicationSteps(),
+	},
+	{
+		Name: "glm-5.3-flash", ProductID: "glm-5.3-flash", OfferID: "zai-glm-5-3-flash",
+		TupleKey: "zai|glm-5.3-flash|openai|global", Revision: "glm-5.3-flash",
+		SupplierCredentialEnv:  "ZAI_API_KEY",
+		CredentialReferenceEnv: "INFERCRANE_MODEL_API_ZAI_CREDENTIAL_REFERENCE",
+		CommercialTermsRef:     "https://docs.z.ai/guides/vlm/glm-5.3-flash",
+		ReleaseTool:            "infercrane-model-api-mvp-release",
+		Publication:            zaiPublicationSteps(),
+	},
+}
+
+func zaiPublicationSteps() []publicationStep {
+	return []publicationStep{
+		{"rate", "02-retail-rate.json"}, {"offer", "03-supplier-offer.json"}, {"qualification", "04-qualification.json"},
+		{"target-binding", "05-target-binding.json"}, {"plan", "06-supply-plan.json"}, {"product", "08-product-available.json"},
+		{"publication", "07-publication.json"}, {"entitlement", "09-canary-entitlement.json"},
+	}
+}
+
+type config struct {
+	ControlURL, APIKey                                string
+	OperatorWorkspace, ServingPlan, CustomerWorkspace string
+	MachineID, StateDirectory                         string
+	RenewBefore                                       time.Duration
+	Force                                             bool
+}
+
+type catalogResponse struct {
+	Model struct {
+		EvidenceValidUntil *time.Time `json:"evidence_valid_until"`
+		Callable           bool       `json:"callable"`
+	} `json:"model"`
+}
+
+type commandRunner func(context.Context, string, ...string) error
+
+func main() {
+	cfg := config{
+		ControlURL:        os.Getenv("INFERCRANE_URL"),
+		APIKey:            os.Getenv("INFERCRANE_API_KEY"),
+		OperatorWorkspace: os.Getenv("INFERCRANE_MODEL_API_OPERATOR_WORKSPACE"),
+		ServingPlan:       os.Getenv("INFERCRANE_MODEL_API_SERVING_PLAN"),
+		CustomerWorkspace: os.Getenv("INFERCRANE_MODEL_API_CANARY_WORKSPACE"),
+		MachineID:         os.Getenv("FLY_MACHINE_ID"),
+		StateDirectory:    os.Getenv("INFERCRANE_MODEL_API_RENEWAL_STATE_DIR"),
+		RenewBefore:       defaultRenewBefore,
+	}
+	flag.BoolVar(&cfg.Force, "force", false, "qualify all profiles even when current evidence is outside the renewal window")
+	flag.Parse()
+	if flag.NArg() != 0 {
+		fatal(errors.New("positional arguments are not accepted"))
+	}
+	if cfg.StateDirectory == "" {
+		cfg.StateDirectory = "/home/app/.local/state/infercrane/model-api-renewal"
+	}
+	if err := cfg.validate(); err != nil {
+		fatal(err)
+	}
+	for _, item := range renewalProfiles {
+		if strings.TrimSpace(os.Getenv(item.SupplierCredentialEnv)) == "" {
+			fatal(fmt.Errorf("%s is required", item.SupplierCredentialEnv))
+		}
+		if value := strings.TrimSpace(os.Getenv(item.CredentialReferenceEnv)); value == "" || strings.ContainsAny(value, "\r\n\x00") {
+			fatal(fmt.Errorf("%s is required and must be a single safe value", item.CredentialReferenceEnv))
+		}
+	}
+	for _, binary := range []string{"infercrane", "infercrane-model-api-qualifier", "infercrane-model-api-production-release", "infercrane-model-api-mvp-release"} {
+		if _, err := exec.LookPath(binary); err != nil {
+			fatal(fmt.Errorf("required operator binary %s is unavailable", binary))
+		}
+	}
+	if err := os.MkdirAll(cfg.StateDirectory, 0o700); err != nil {
+		fatal(errors.New("renewal state directory could not be created"))
+	}
+	if err := os.Chmod(cfg.StateDirectory, 0o700); err != nil {
+		fatal(errors.New("renewal state directory could not be protected"))
+	}
+	lock, err := acquireLock(filepath.Join(cfg.StateDirectory, "renewal.lock"))
+	if err != nil {
+		fatal(err)
+	}
+	defer releaseLock(lock)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 55*time.Minute)
+	defer cancel()
+	failed := false
+	for _, item := range renewalProfiles {
+		if err := renewProfile(ctx, cfg, item, time.Now().UTC(), runCommand); err != nil {
+			failed = true
+			fmt.Fprintf(os.Stderr, "renewal failed for %s: %v\n", item.Name, err)
+		}
+	}
+	if failed {
+		fatal(errors.New("one or more model API renewals failed closed"))
+	}
+}
+
+func (c config) validate() error {
+	parsed, err := url.Parse(strings.TrimSpace(c.ControlURL))
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return errors.New("INFERCRANE_URL must be an absolute HTTPS origin")
+	}
+	if strings.Trim(parsed.Path, "/") != "" {
+		return errors.New("INFERCRANE_URL must not include a path")
+	}
+	for name, value := range map[string]string{
+		"INFERCRANE_API_KEY":                      c.APIKey,
+		"INFERCRANE_MODEL_API_OPERATOR_WORKSPACE": c.OperatorWorkspace,
+		"INFERCRANE_MODEL_API_SERVING_PLAN":       c.ServingPlan,
+		"INFERCRANE_MODEL_API_CANARY_WORKSPACE":   c.CustomerWorkspace,
+		"FLY_MACHINE_ID":                          c.MachineID,
+	} {
+		if strings.TrimSpace(value) == "" || strings.ContainsAny(value, "\r\n\x00") {
+			return fmt.Errorf("%s is required and must be a single safe value", name)
+		}
+	}
+	if c.RenewBefore <= 0 || c.RenewBefore >= qualificationTTL {
+		return errors.New("renewal window must remain positive and shorter than the qualification TTL")
+	}
+	if !filepath.IsAbs(c.StateDirectory) || filepath.Clean(c.StateDirectory) == "/" {
+		return errors.New("renewal state directory must be an absolute non-root path")
+	}
+	return nil
+}
+
+func renewProfile(ctx context.Context, cfg config, item profile, now time.Time, run commandRunner) error {
+	credentialReference := strings.TrimSpace(os.Getenv(item.CredentialReferenceEnv))
+	if credentialReference == "" || strings.ContainsAny(credentialReference, "\r\n\x00") {
+		return fmt.Errorf("%s is required", item.CredentialReferenceEnv)
+	}
+	current, err := currentCatalogState(ctx, cfg, item.ProductID)
+	if err != nil {
+		return err
+	}
+	if !cfg.Force && current.Model.Callable && current.Model.EvidenceValidUntil != nil && current.Model.EvidenceValidUntil.After(now.Add(cfg.RenewBefore)) {
+		fmt.Printf("%s: current evidence is outside the renewal window; no supplier traffic sent\n", item.Name)
+		return nil
+	}
+
+	version := int(now.Unix())
+	stamp := now.UTC().Format("20060102T150405Z")
+	runDirectory := filepath.Join(cfg.StateDirectory, item.Name, stamp)
+	if err = os.MkdirAll(runDirectory, 0o700); err != nil {
+		return errors.New("immutable renewal directory could not be created")
+	}
+	if err = os.Chmod(runDirectory, 0o700); err != nil {
+		return errors.New("immutable renewal directory could not be protected")
+	}
+	rawPath := filepath.Join(runDirectory, "raw.json")
+	qualificationPath := filepath.Join(runDirectory, "qualification.json")
+	releaseDirectory := filepath.Join(runDirectory, "release")
+	evidenceRef := fmt.Sprintf("fly-machine://%s/model-api-renewal/%s/%s/raw.json", cfg.MachineID, item.Name, stamp)
+	qualificationID := fmt.Sprintf("%s-q-%s-r%d", item.OfferID, stamp, version)
+
+	qualifierArgs := []string{
+		"--profile", item.Name,
+		"--confirm-live",
+		"--offer-id", item.OfferID,
+		"--offer-version", strconv.Itoa(version),
+		"--qualification-id", qualificationID,
+		"--tuple-key", item.TupleKey,
+		"--expected-revision", item.Revision,
+		"--samples-per-mode", strconv.Itoa(samplesPerMode),
+		"--max-output-tokens", strconv.Itoa(qualificationCap),
+		"--request-timeout", "180s",
+		"--total-timeout", "12m",
+		"--valid-for", qualificationTTL.String(),
+		"--evidence-ref", evidenceRef,
+		"--evidence-output", rawPath,
+		"--qualification-output", qualificationPath,
+	}
+	fmt.Printf("%s: entering renewal window; running bounded sequential qualification\n", item.Name)
+	if err = run(ctx, "infercrane-model-api-qualifier", qualifierArgs...); err != nil {
+		return fmt.Errorf("qualification failed: %w", err)
+	}
+	releaseArgs := []string{
+		"--qualification", qualificationPath,
+		"--credential-reference", credentialReference,
+		"--operator-workspace", cfg.OperatorWorkspace,
+		"--serving-plan", cfg.ServingPlan,
+		"--customer-workspace", cfg.CustomerWorkspace,
+		"--output-directory", releaseDirectory,
+		"--release-version", strconv.Itoa(version),
+	}
+	if item.ReleaseTool == "infercrane-model-api-mvp-release" {
+		releaseArgs = append(releaseArgs, "--profile", item.Name, "--commercial-terms-ref", item.CommercialTermsRef)
+	}
+	if err = run(ctx, item.ReleaseTool, releaseArgs...); err != nil {
+		return fmt.Errorf("release generation failed: %w", err)
+	}
+	for index, step := range item.Publication {
+		manifest := filepath.Join(releaseDirectory, step.Filename)
+		if err = run(ctx, "infercrane", "model-api", "publish", step.ContractType, "--file", manifest); err != nil {
+			return fmt.Errorf("publication failed at contract %d (%s): %w", index+1, step.ContractType, err)
+		}
+	}
+	fmt.Printf("%s: qualified and published immutable release r%d\n", item.Name, version)
+	return nil
+}
+
+func currentCatalogState(ctx context.Context, cfg config, productID string) (catalogResponse, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(cfg.ControlURL, "/")+"/api/v1/model-api-catalog/"+url.PathEscape(productID), nil)
+	if err != nil {
+		return catalogResponse{}, errors.New("catalog request could not be created")
+	}
+	request.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	request.Header.Set("Accept", "application/json")
+	client := &http.Client{Timeout: 20 * time.Second, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	response, err := client.Do(request)
+	if err != nil {
+		return catalogResponse{}, errors.New("catalog could not be reached")
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return catalogResponse{}, fmt.Errorf("catalog returned HTTP %d", response.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, (1<<20)+1))
+	if err != nil || len(body) > 1<<20 {
+		return catalogResponse{}, errors.New("catalog returned an oversized or unreadable response")
+	}
+	var decoded catalogResponse
+	if err = json.Unmarshal(body, &decoded); err != nil {
+		return catalogResponse{}, errors.New("catalog returned an invalid response")
+	}
+	return decoded, nil
+}
+
+func acquireLock(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, errors.New("renewal lock could not be opened")
+	}
+	if err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = file.Close()
+		return nil, errors.New("another model API renewal is already running")
+	}
+	return file, nil
+}
+
+func releaseLock(file *os.File) {
+	if file == nil {
+		return
+	}
+	_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+	_ = file.Close()
+}
+
+func runCommand(ctx context.Context, name string, args ...string) error {
+	command := exec.CommandContext(ctx, name, args...)
+	command.Env = os.Environ()
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err := command.Run(); err != nil {
+		return fmt.Errorf("%s exited unsuccessfully", name)
+	}
+	return nil
+}
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, "model API renewal:", err)
+	os.Exit(1)
+}

--- a/tools/model-api-renewer/main_test.go
+++ b/tools/model-api-renewer/main_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRenewProfileSkipsWithoutSupplierTrafficOutsideWindow(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	server := catalogServer(t, now.Add(7*time.Hour))
+	defer server.Close()
+	t.Setenv("INFERCRANE_MODEL_API_DEEPSEEK_CREDENTIAL_REFERENCE", "deepseek-secret-ref")
+	cfg := testConfig(t, server.URL)
+	commands := 0
+	err := renewProfile(context.Background(), cfg, renewalProfiles[0], now, func(context.Context, string, ...string) error {
+		commands++
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if commands != 0 {
+		t.Fatalf("ran %d commands outside the renewal window", commands)
+	}
+}
+
+func TestCurrentCatalogStateDecodesProductionDetailEnvelope(t *testing.T) {
+	expiry := time.Date(2026, 9, 4, 16, 14, 25, 742732000, time.UTC)
+	server := catalogServer(t, expiry)
+	defer server.Close()
+	state, err := currentCatalogState(context.Background(), testConfig(t, server.URL), "deepseek-v4-flash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.Model.Callable || state.Model.EvidenceValidUntil == nil || !state.Model.EvidenceValidUntil.Equal(expiry) {
+		t.Fatalf("production detail envelope decoded as %+v", state.Model)
+	}
+}
+
+func TestRenewProfileUsesBoundedQualificationAndImmutableVersion(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 34, 56, 0, time.UTC)
+	server := catalogServer(t, now.Add(5*time.Hour))
+	defer server.Close()
+	t.Setenv("INFERCRANE_MODEL_API_ZAI_CREDENTIAL_REFERENCE", "zai-secret-ref")
+	cfg := testConfig(t, server.URL)
+	type invocation struct {
+		name string
+		args []string
+	}
+	var calls []invocation
+	err := renewProfile(context.Background(), cfg, renewalProfiles[1], now, func(_ context.Context, name string, args ...string) error {
+		calls = append(calls, invocation{name: name, args: append([]string(nil), args...)})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 10 {
+		t.Fatalf("ran %d commands, want qualifier + release + 8 renewal publications", len(calls))
+	}
+	if calls[0].name != "infercrane-model-api-qualifier" || !hasPair(calls[0].args, "--max-output-tokens", "512") || !hasPair(calls[0].args, "--samples-per-mode", "3") || !hasPair(calls[0].args, "--valid-for", "24h0m0s") {
+		t.Fatalf("qualification is not bounded as required: %q %q", calls[0].name, calls[0].args)
+	}
+	wantVersion := fmt.Sprint(now.Unix())
+	if !hasPair(calls[0].args, "--offer-version", wantVersion) || calls[1].name != "infercrane-model-api-mvp-release" || !hasPair(calls[1].args, "--release-version", wantVersion) {
+		t.Fatalf("qualification and release do not share immutable version %s", wantVersion)
+	}
+	wantTypes := []string{"rate", "offer", "qualification", "target-binding", "plan", "product", "publication", "entitlement"}
+	for index, want := range wantTypes {
+		call := calls[index+2]
+		if call.name != "infercrane" || len(call.args) < 4 || call.args[0] != "model-api" || call.args[1] != "publish" || call.args[2] != want {
+			t.Fatalf("publication %d = %q %q, want %s", index, call.name, call.args, want)
+		}
+	}
+	if !strings.HasPrefix(calls[0].args[slices.Index(calls[0].args, "--evidence-ref")+1], "fly-machine://machine-1/") {
+		t.Fatal("evidence is not bound to the persistent Fly Machine")
+	}
+}
+
+func TestConfigRequiresHTTPSAndFlyIdentity(t *testing.T) {
+	cfg := testConfig(t, "http://control.example")
+	if err := cfg.validate(); err == nil || !strings.Contains(err.Error(), "HTTPS") {
+		t.Fatalf("HTTP control URL error=%v", err)
+	}
+	cfg.ControlURL = "https://control.example"
+	cfg.MachineID = ""
+	if err := cfg.validate(); err == nil || !strings.Contains(err.Error(), "FLY_MACHINE_ID") {
+		t.Fatalf("missing machine identity error=%v", err)
+	}
+}
+
+func catalogServer(t *testing.T, expiry time.Time) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("Authorization") != "Bearer control-key" {
+			t.Fatalf("missing control authentication")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"model":{"id":"model","callable":true,"evidence_valid_until":%q},"access":{"authorized":true},"catalog_source":"durable_product_catalog"}`, expiry.UTC().Format(time.RFC3339Nano))
+	}))
+}
+
+func testConfig(t *testing.T, controlURL string) config {
+	t.Helper()
+	return config{
+		ControlURL: controlURL, APIKey: "control-key", OperatorWorkspace: "global", ServingPlan: "serving-plan",
+		CustomerWorkspace: "customer-workspace", MachineID: "machine-1", StateDirectory: filepath.Join(t.TempDir(), "renewals"), RenewBefore: defaultRenewBefore,
+	}
+}
+
+func hasPair(values []string, name, value string) bool {
+	index := slices.Index(values, name)
+	return index >= 0 && index+1 < len(values) && values[index+1] == value
+}


### PR DESCRIPTION
## Summary
- add a one-shot Model API renewal operator for DeepSeek V4 Flash and the three direct Z.ai GLM profiles
- keep the 24-hour evidence TTL and renew only when callable evidence has less than six hours remaining
- package the qualifier and release tools in the production image and make Z.ai releases immutable/versioned
- document an hourly, stopped-between-runs Fly Machine with persistent-rootfs evidence and no service

## Safety contract
- supplier credentials stay in Fly app secrets and never enter arguments, artifacts, or GitHub
- all four credentials/references and operator binaries are preflighted before any billable request
- profiles run sequentially with 3 buffered + 3 streaming samples, `max_tokens=512`, per-request and total deadlines
- existing product availability is not downgraded during renewal; only reviewed dependent contracts are updated
- artifacts are timestamped, mode `0600`, and opened exclusively; overlapping runs fail via a nonblocking lock
- failures do not weaken TTL or publish unqualified evidence; the process exits non-zero
- persistent rootfs is an MVP durability boundary, explicitly documented as non-replicated

## Validation
- `make verify`
- focused race tests and vet for qualifier/release/renewer tools
- Docker builder target compiled and contained all four operator binaries
- read-only production catalog check confirmed all four configured products currently callable

## Production rollout
Do not create the scheduled Machine before review/merge. After the reviewed image deploy, use the exact no-service command in `tools/model-api-renewer/README.md` with `--schedule hourly --restart no --rootfs-persist always`.
